### PR TITLE
Change subscription database password to required

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -184,8 +184,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 						},
 						"password": {
 							Type:      schema.TypeString,
-							Optional:  true,
-							Computed:  true,
+							Required:  true,
 							Sensitive: true,
 						},
 						"public_endpoint": {
@@ -371,10 +370,7 @@ func resourceRedisCloudSubscriptionUpdate(ctx context.Context, d *schema.Resourc
 					Value: redis.Int(throughputMeasurementValue),
 				},
 				DataPersistence: redis.String(dataPersistence),
-			}
-
-			if v, ok := databaseMap["password"]; ok {
-				update.Password = redis.String(v.(string))
+				Password:        redis.String(databaseMap["password"].(string)),
 			}
 
 			err = api.client.Database.Update(ctx, subId, dbId, update)

--- a/website/docs/r/rediscloud_subscription.html.markdown
+++ b/website/docs/r/rediscloud_subscription.html.markdown
@@ -45,7 +45,7 @@ The `database` block supports:
 * `memory_limit_in_gb` - (Required) Maximum memory usage for this specific database
 * `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 * `data_persistence` - (Optional) Rate of database data persistence (in persistent storage). Default: ‘none’
-* `password` - (Optional) Password used to access the database. Defaults to a randomly generated one
+* `password` - (Required) Password used to access the database
 * `replication` - (Optional) Databases replication. Default: ‘true’
 * `throughput_measurement_by` - (Required) Throughput measurement method, (either ‘number-of-shards’ or ‘operations-per-second’)
 * `throughput_measurement_value` - (Required) Throughput value (as applies to selected measurement method)


### PR DESCRIPTION
Something within the way Terraform calculates the hash for a TypeSet element causes Terraform to see a change when the schema also has `average_item_size_in_bytes` defined. Changing `password` from `Optional` `Computed` to `Required` to avoid this problem at the moment.