### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -40,10 +40,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      # See also: https://github.com/actions/setup-go/issues/54
       - if: steps.cache-terraform-plugin-dir.outputs.cache-hit != 'true' || steps.cache-terraform-plugin-dir.outcome == 'failure'
         name: go env
         run: |
-          echo "::set-env name=GOCACHE::$(go env GOCACHE)"
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
       - if: steps.cache-terraform-plugin-dir.outputs.cache-hit != 'true' || steps.cache-terraform-plugin-dir.outcome == 'failure'
         uses: actions/cache@v2
         with:
@@ -103,9 +104,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      # See also: https://github.com/actions/setup-go/issues/54
       - name: go env
         run: |
-          echo "::set-env name=GOCACHE::$(go env GOCACHE)"
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
       - uses: actions/cache@v2
         continue-on-error: true
         timeout-minutes: 2


### PR DESCRIPTION
Fix the CI workflow by removing uses of `::set-env` which is no longer supported by GitHub due to security issues.