### PR TITLE
Updates to README focusing on using and developing the provider

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,23 +1,30 @@
 default: testacc
 
 plugin_version = 99.99.99
-plugins_mirror_path = ~/Library/Application\ Support/io.terraform/plugins
-plugins_provider_path = registry.redislabs.com/redislabs/rediscloud/$(plugin_version)/darwin_amd64/
+plugins_mirror_path = ~/.terraform.d/plugins
+plugins_provider_path = registry.terraform.io/RedisLabs/rediscloud/$(plugin_version)/darwin_amd64/
 
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PROVIDER_TYPE=rediscloud
 
-# Run acceptance tests
-.PHONY: testacc install_macos website website-test
+.PHONY: build clean testacc install_local website website-test
+
+build:
+	@echo "Building local provider binary"
+	@mkdir -p ./bin
+	go build -o bin/terraform-provider-rediscloud_v$(plugin_version)
+
+clean:
+	@echo "Deleting local provider binary"
+	rm -rf ./bin
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
-install_macos:
-	go build -o dist/terraform-provider-rediscloud_v$(plugin_version)
-
-	mkdir -p $(plugins_mirror_path)/$(plugins_provider_path)
-	cp dist/terraform-provider-rediscloud_v$(plugin_version) $(plugins_mirror_path)/$(plugins_provider_path)
+install_local: build
+	@echo "Installing local provider binary to plugins mirror path $(plugins_mirror_path)/$(plugins_provider_path)"
+	@mkdir -p $(plugins_mirror_path)/$(plugins_provider_path)
+	@cp ./bin/terraform-provider-rediscloud_v$(plugin_version) $(plugins_mirror_path)/$(plugins_provider_path)
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
@@ -36,10 +43,6 @@ endif
 	ln -s ../../../ext/providers/$(PROVIDER_TYPE)/website/$(PROVIDER_TYPE).erb $(GOPATH)/src/$(WEBSITE_REPO)/content/source/layouts/$(PROVIDER_TYPE).erb || true
 	ln -s ../../../../ext/providers/$(PROVIDER_TYPE)/website/docs $(GOPATH)/src/$(WEBSITE_REPO)/content/source/docs/providers/$(PROVIDER_TYPE) || true
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PROVIDER_TYPE)
-
-build_0_13: fmtcheck
-	@mkdir -p $(PROVIDER_PATH)
-	go build -o $(PROVIDER_PATH)/terraform-provider-$(PROVIDER_NAMESPACE)_v$(PROVIDER_VERSION)
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,13 @@
 default: testacc
 
-plugin_version = 99.99.99
-plugins_mirror_path = ~/.terraform.d/plugins
-plugins_provider_path = registry.terraform.io/RedisLabs/rediscloud/$(plugin_version)/darwin_amd64/
+PROVIDER_HOSTNAME=registry.terraform.io
+PROVIDER_NAMESPACE=RedisLabs
+PROVIDER_TYPE=rediscloud
+PROVIDER_TARGET=$(shell go env GOOS)_$(shell go env GOARCH)
+PROVIDER_VERSION = 99.99.99
+
+PLUGINS_PATH = ~/.terraform.d/plugins
+PLUGINS_PROVIDER_PATH=$(PROVIDER_HOSTNAME)/$(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE)/$(PROVIDER_VERSION)/$(PROVIDER_TARGET)
 
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PROVIDER_TYPE=rediscloud
@@ -12,7 +17,7 @@ PROVIDER_TYPE=rediscloud
 build:
 	@echo "Building local provider binary"
 	@mkdir -p ./bin
-	go build -o bin/terraform-provider-rediscloud_v$(plugin_version)
+	go build -o bin/terraform-provider-rediscloud_v$(PROVIDER_VERSION)
 
 clean:
 	@echo "Deleting local provider binary"
@@ -22,9 +27,9 @@ testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
 install_local: build
-	@echo "Installing local provider binary to plugins mirror path $(plugins_mirror_path)/$(plugins_provider_path)"
-	@mkdir -p $(plugins_mirror_path)/$(plugins_provider_path)
-	@cp ./bin/terraform-provider-rediscloud_v$(plugin_version) $(plugins_mirror_path)/$(plugins_provider_path)
+	@echo "Installing local provider binary to plugins mirror path $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)"
+	@mkdir -p $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)
+	@cp ./bin/terraform-provider-rediscloud_v$(PROVIDER_VERSION) $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Terraform Provider RedisCloud
 ==================
 
+- Website: [terraform.io](https://www.terraform.io)
+- Tutorials: [learn.hashicorp.com](https://learn.hashicorp.com/terraform?track=getting-started#getting-started)
+- Redis Cloud:  [redislabs.com/redis-enterprise-cloud](https://redislabs.com/redis-enterprise-cloud)
+- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+
 The RedisCloud Terraform provider is a plugin for Terraform that allows Redis Cloud Enterprise customers to manage the full 
 lifecyle of their enterprise subscriptions and related redis databases.
 
@@ -10,18 +15,99 @@ Requirements
 -	[Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
 -	[Go](https://golang.org/doc/install) >= 1.12
 
-Building The Provider
+Quick Starts
+------------
+
+- [Using the provider](https://www.terraform.io/docs/providers/RedisLabs/rediscloud/index.html)
+
+To use the RedisCloud Terraform provider you will need to set the following environment variables, 
+and these are created through the Redis Cloud console under the settings menu.
+
+- REDISCLOUD_ACCESS_KEY - Account Cloud API Access Key
+- REDISCLOUD_SECRET_KEY - Individual user Cloud API Secret Key
+
+
+Developing the Provider
+-----------------------
+
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
+You will also need to create or have access to a [Redis Cloud Enterprise](https://redislabs.com/redis-enterprise-cloud/overview) account.
+
+Building the Provider
 ---------------------
 
 1. Clone the repository
 1. Enter the repository directory
-1. Build the provider using the Go `make install_macos` command: 
+1. Build the provider using the `make build` command: 
 ```sh
-$ make install_macos
+$ make build
+```
+
+The `make build` command will build a local provider binary into a `bin` directory at the root of the repository.
+
+Installing the Provider
+------------------------------------
+
+After the provider has been built locally it most be placed the user plugins directory so it can be discovered by the 
+Terraform CLI.  The default user plugins directory root is `~/.terraform.d/plugins`.  
+
+Use the following make command to install the provider locally.
+```sh
+$ make install_local
+```
+
+The provider will now be installed that the following location ready to be used by Terraform
+```
+~/.terraform.d/plugins
+└── registry.terraform.io
+    └── RedisLabs
+        └── rediscloud
+            └── 99.99.99
+                └── <OS>_<ARCH>
+                    └── terraform-provider-rediscloud_v99.99.99
+```
+
+The provider binary is built using a version number of `99.99.99` and this will allow terraform to use the locally 
+built provider over a released version.
+
+The terraform provider is now installed and now can be discovered by Terraform through the following HCL block.
+
+```hcl-terraform
+terraform {
+  required_providers {
+    rediscloud = {
+      source = "RedisLabs/rediscloud"
+    }
+  }
+  required_version = ">= 0.13"
+}
+``` 
+
+The following is an example of using the rediscloud_regions data-source to discover a list of supported regions.  It can be 
+used to verify that the provider is setup and installed correctly without incurring the cost of subscriptions and databases.
+
+```hcl-terraform
+data "rediscloud_regions" "example" {
+}
+
+output "all_regions" {
+  value = data.rediscloud_regions.example.regions
+}
+```
+
+Testing the Provider
+--------------------
+
+In order to run the full suite of Acceptance tests, run `make testacc`.
+
+*Note:* Acceptance tests create real resources, and often cost money to run.
+
+```sh
+$ make testacc
 ```
 
 Adding Dependencies
----------------------
+-------------------
 
 This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
 Please see the Go documentation for the most up to date information about using Go modules.
@@ -34,65 +120,3 @@ go mod tidy
 ```
 
 Then commit the changes to `go.mod` and `go.sum`.
-
-
-Using the provider
-----------------------
-
-The RedisCloud Terraform provider is distributed through the HashiCorp managed [Terraform Registry](https://registry.terraform.io) 
-and is discovered through the use of a `required_providers`hcl block as shown in the following example.
-
-```hcl-terraform
-terraform {
-  required_providers {
-    rediscloud = {
-      source = "registry.redislabs.com/redislabs/rediscloud"
-    }
-  }
-  required_version = ">= 0.13"
-}
-```
-
-After the `required_providers` block has been configured Terraform will download the latest version of the RedisCloud provider.  
-An optional and recommended `version` parameter can be applied to use a specific version of the provider.
-
-To use the RedisCloud Terraform provider you will need to set the following environment variables 
-and these are created through the Redis Cloud console under the settings menu.
-
-* REDISCLOUD_ACCESS_KEY - Account Cloud API Access Key
-* REDISCLOUD_SECRET_KEY - Individual user Cloud API Secret Key
-
-After this initial setup the provider can be used against your account.  The following example can be used to validate 
-your account access through the provider and will return a list of regions without incurring a cost.  
-
-```hcl-terraform
-data "rediscloud_regions" "example" {
-}
-
-output "all_regions" {
-  value = data.rediscloud_regions.example.regions
-}
-```
-
-Developing the Provider
----------------------------
-
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
-You will also need to create or have access to a [Redis Cloud Enterprise](https://redislabs.com/redis-enterprise-cloud/overview) account.
-
-To compile the provider, run `make install_macos`. This will build the provider and place the binary 
-in the `~/Library/Application\ Support/io.terraform/plugins` directory.
-
-The provider binary is installed with a version number of `99.99.99` and this will allow terraform to use the locally 
-built provider over a released version.
-
-Next configure a `required_versions` hcl block to reference the provider, (see [Using the provider](#using-the-provider)) and set the appropriate 
-access and secret keys linked to your RedisCloud Enterprise account.  The provider can now be used through the Terraform CLI.
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```sh
-$ make testacc
-```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ make build
 The `make build` command will build a local provider binary into a `bin` directory at the root of the repository.
 
 Installing the Provider
-------------------------------------
+-----------------------
 
 After the provider has been built locally it most be placed the user plugins directory so it can be discovered by the 
 Terraform CLI.  The default user plugins directory root is `~/.terraform.d/plugins`.  

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Terraform Provider RedisCloud
 ==================
 
-TODO - Fill this in for provider
+The RedisCloud Terraform provider is a plugin for Terraform that allows Redis Cloud Enterprise customers to manage the full 
+lifecyle of their enterprise subscriptions and related redis databases.
 
 Requirements
 ------------
@@ -14,9 +15,9 @@ Building The Provider
 
 1. Clone the repository
 1. Enter the repository directory
-1. Build the provider using the Go `install` command: 
+1. Build the provider using the Go `make install_macos` command: 
 ```sh
-$ go install
+$ make install_macos
 ```
 
 Adding Dependencies
@@ -38,14 +39,55 @@ Then commit the changes to `go.mod` and `go.sum`.
 Using the provider
 ----------------------
 
-TODO - Fill this in for provider
+The RedisCloud Terraform provider is distributed through the HashiCorp managed [Terraform Registry](https://registry.terraform.io) 
+and is discovered through the use of a `required_providers`hcl block as shown in the following example.
+
+```hcl-terraform
+terraform {
+  required_providers {
+    rediscloud = {
+      source = "registry.redislabs.com/redislabs/rediscloud"
+    }
+  }
+  required_version = ">= 0.13"
+}
+```
+
+After the `required_providers` block has been configured Terraform will download the latest version of the RedisCloud provider.  
+An optional and recommended `version` parameter can be applied to use a specific version of the provider.
+
+To use the RedisCloud Terraform provider you will need to set the following environment variables 
+and these are created through the Redis Cloud console under the settings menu.
+
+* REDISCLOUD_ACCESS_KEY - Account Cloud API Access Key
+* REDISCLOUD_SECRET_KEY - Individual user Cloud API Secret Key
+
+After this initial setup the provider can be used against your account.  The following example can be used to validate 
+your account access through the provider and will return a list of regions without incurring a cost.  
+
+```hcl-terraform
+data "rediscloud_regions" "example" {
+}
+
+output "all_regions" {
+  value = data.rediscloud_regions.example.regions
+}
+```
 
 Developing the Provider
 ---------------------------
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
+You will also need to create or have access to a [Redis Cloud Enterprise](https://redislabs.com/redis-enterprise-cloud/overview) account.
 
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+To compile the provider, run `make install_macos`. This will build the provider and place the binary 
+in the `~/Library/Application\ Support/io.terraform/plugins` directory.
+
+The provider binary is installed with a version number of `99.99.99` and this will allow terraform to use the locally 
+built provider over a released version.
+
+Next configure a `required_versions` hcl block to reference the provider, (see [Using the provider](#using-the-provider)) and set the appropriate 
+access and secret keys linked to your RedisCloud Enterprise account.  The provider can now be used through the Terraform CLI.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 


### PR DESCRIPTION
The PR updates the GNUMakefile and the README.md with a focus towards onboarding a potential new developer.  Where appropriate best guess placeholders for registry documentation and naming have been used.

The local deployment has been reworked to the home `~/.terraform.d/plugins` and this should remove a need for a macos specific command. 