### PR TITLE
Changing the network_deployment_cidr 

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -142,14 +142,14 @@ jobs:
       - run: make testacc
         if: steps.filter.outputs.code-changes == 'true'
         env:
-#          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_QA }}
-#          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_QA }}
-#          REDISCLOUD_URL: https://qa-api.redislabs.com/v1/
-#          AWS_TEST_CLOUD_ACCOUNT_NAME: oc
-          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_PROD }}
-          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_PROD }}
-          REDISCLOUD_URL: https://api.redislabs.com/v1/
-          AWS_TEST_CLOUD_ACCOUNT_NAME: PM
+          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_QA }}
+          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_QA }}
+          REDISCLOUD_URL: https://qa-api.redislabs.com/v1/
+          AWS_TEST_CLOUD_ACCOUNT_NAME: oc
+#          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_PROD }}
+#          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_PROD }}
+#          REDISCLOUD_URL: https://api.redislabs.com/v1/
+#          AWS_TEST_CLOUD_ACCOUNT_NAME: PM
           AWS_PEERING_REGION: ${{ secrets.AWS_PEERING_REGION }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_VPC_CIDR: ${{ secrets.AWS_VPC_CIDR }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ clean:
 	rm -rf ./bin
 
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m -parallel=1
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
 install_local: build
 	@echo "Installing local provider binary to plugins mirror path $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)"

--- a/docs/data-sources/rediscloud_subscription.md
+++ b/docs/data-sources/rediscloud_subscription.md
@@ -48,7 +48,13 @@ The cloud_provider `region` block supports:
 
 * `region` - Deployment region as defined by cloud provider
 * `multiple_availability_zones` - Support deployment on multiple availability zones within the selected region
-* `networking_deployment_cidr` - Deployment CIDR mask
-* `networking_subnet_id` - The subnet that the subscription deploys into
 * `networking_vpc_id` - The ID of the VPC where the Redis Cloud subscription is deployed.
 * `preferred_availability_zones` - List of availability zones used
+
+* `networks` - List of generated network configuration
+
+The `networks` block has these attributes:
+
+* `networking_subnet_id` - The subnet that the subscription deploys into
+* `networking_deployment_cidr` - Deployment CIDR mask for the generated
+* `networking_vpc_id` - VPC id for the generated network

--- a/docs/resources/rediscloud_subscription.md
+++ b/docs/resources/rediscloud_subscription.md
@@ -191,7 +191,7 @@ The cloud_provider `region` block supports:
 
 * `region` - (Required) Deployment region as defined by cloud provider
 * `multiple_availability_zones` - (Optional) Support deployment on multiple availability zones within the selected region. Default: ‘false’
-* `networking_deployment_cidr` - (Required) Deployment CIDR mask. Default: If using Redis Labs internal cloud account, 192.168.0.0/24
+* `networking_deployment_cidr` - (Required) Deployment CIDR mask.
 * `networking_vpc_id` - (Optional) Either an existing VPC Id (already exists in the specific region) or create a new VPC
 (if no VPC is specified). VPC Identifier must be in a valid format (for example: ‘vpc-0125be68a4625884ad’) and existing
 within the hosting account.
@@ -227,7 +227,13 @@ The `database` block has these attributes:
 
 The `region` block has these attributes:
 
+* `networks` - List of generated network configuration
+
+The `networks` block has these attributes:
+
 * `networking_subnet_id` - The subnet that the subscription deploys into
+* `networking_deployment_cidr` - Deployment CIDR mask for the generated
+* `networking_vpc_id` - VPC id for the generated network
 
 ## Import
 

--- a/internal/provider/datasource_rediscloud_subscription.go
+++ b/internal/provider/datasource_rediscloud_subscription.go
@@ -86,20 +86,34 @@ func dataSourceRedisCloudSubscription() *schema.Resource {
 											Type: schema.TypeString,
 										},
 									},
-									"networking_deployment_cidr": {
-										Description: "Deployment CIDR mask",
-										Type:        schema.TypeString,
-										Computed:    true,
-									},
 									"networking_vpc_id": {
 										Description: "The ID of the VPC where the Redis Cloud subscription is deployed",
 										Type:        schema.TypeString,
 										Computed:    true,
 									},
-									"networking_subnet_id": {
-										Description: "The subnet that the subscription deploys into",
-										Type:        schema.TypeString,
+									"networks": {
+										Description: "List of networks used",
+										Type:        schema.TypeList,
 										Computed:    true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"networking_subnet_id": {
+													Description: "The subnet that the subscription deploys into",
+													Type:        schema.TypeString,
+													Computed:    true,
+												},
+												"networking_deployment_cidr": {
+													Description:      "Deployment CIDR mask",
+													Type:             schema.TypeString,
+													Computed:         true,
+												},
+												"networking_vpc_id": {
+													Description: "Either an existing VPC Id (already exists in the specific region) or create a new VPC (if no VPC is specified)",
+													Type:        schema.TypeString,
+													Computed:    true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -155,7 +169,7 @@ func dataSourceRedisCloudSubscriptionRead(ctx context.Context, d *schema.Resourc
 	if err := d.Set("number_of_databases", redis.IntValue(sub.NumberOfDatabases)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("cloud_provider", flattenCloudDetails(sub.CloudDetails)); err != nil {
+	if err := d.Set("cloud_provider", flattenCloudDetails(sub.CloudDetails, false)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("status", redis.StringValue(sub.Status)); err != nil {

--- a/internal/provider/datasource_rediscloud_subscription_test.go
+++ b/internal/provider/datasource_rediscloud_subscription_test.go
@@ -40,7 +40,7 @@ func TestAccDataSourceRedisCloudSubscription_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider.0.provider", "AWS"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "cloud_provider.0.cloud_account_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider.0.region.0.region", "eu-west-1"),
-					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider.0.region.0.networking_deployment_cidr", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider.0.region.0.networks.0.networking_deployment_cidr", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
 				),
 			},

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -152,7 +152,6 @@ func resourceRedisCloudSubscription() *schema.Resource {
 								buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
 								buf.WriteString(fmt.Sprintf("%t-", m["multiple_availability_zones"].(bool)))
 								buf.WriteString(fmt.Sprintf("%s-", m["preferred_availability_zones"].([]interface{})))
-								buf.WriteString(fmt.Sprintf("%s-", m["networking_vpc_id"].(string)))
 								if v, ok := m["multiple_availability_zones"].(bool); ok && !v {
 									buf.WriteString(fmt.Sprintf("%s-", m["networking_deployment_cidr"].(string)))
 								}
@@ -1061,7 +1060,6 @@ func flattenCloudDetails(cloudDetails []*subscriptions.CloudDetail, isResource b
 				"region":                       currentRegion.Region,
 				"multiple_availability_zones":  currentRegion.MultipleAvailabilityZones,
 				"preferred_availability_zones": currentRegion.PreferredAvailabilityZones,
-				"networking_vpc_id":            currentRegion.Networking[0].VPCId,
 				"networks":                     flattenNetworks(currentRegion.Networking),
 			}
 

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -1,8 +1,14 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/cloud_accounts"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
@@ -11,10 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
-	"regexp"
-	"strconv"
-	"time"
 )
 
 func resourceRedisCloudSubscription() *schema.Resource {
@@ -144,6 +146,19 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Required:    true,
 							ForceNew:    true,
 							MinItems:    1,
+							Set: func(v interface{}) int {
+								var buf bytes.Buffer
+								m := v.(map[string]interface{})
+								buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
+								buf.WriteString(fmt.Sprintf("%t-", m["multiple_availability_zones"].(bool)))
+								buf.WriteString(fmt.Sprintf("%s-", m["preferred_availability_zones"].([]interface{})))
+								buf.WriteString(fmt.Sprintf("%s-", m["networking_vpc_id"].(string)))
+								if v, ok := m["multiple_availability_zones"].(bool); ok && !v {
+									buf.WriteString(fmt.Sprintf("%s-", m["networking_deployment_cidr"].(string)))
+								}
+
+								return schema.HashString(buf.String())
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"region": {
@@ -169,12 +184,10 @@ func resourceRedisCloudSubscription() *schema.Resource {
 										},
 									},
 									"networking_deployment_cidr": {
-										Description: "Deployment CIDR mask",
-										Type:        schema.TypeString,
-										// TODO this needs to be ForceNew as it can't be updated, but cannot also be Computed
-										// TODO need to see what the returned value is when only using redis internal account
-										Optional:         true,
-										Computed:         true,
+										Description:      "Deployment CIDR mask",
+										Type:             schema.TypeString,
+										ForceNew:         true,
+										Required:         true,
 										ValidateDiagFunc: validateDiagFunc(validation.IsCIDR),
 									},
 									"networking_vpc_id": {
@@ -184,10 +197,29 @@ func resourceRedisCloudSubscription() *schema.Resource {
 										Optional:    true,
 										Default:     "",
 									},
-									"networking_subnet_id": {
-										Description: "The subnet that the subscription deploys into",
-										Type:        schema.TypeString,
+									"networks": {
+										Description: "List of networks used",
+										Type:        schema.TypeList,
 										Computed:    true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"networking_subnet_id": {
+													Description: "The subnet that the subscription deploys into",
+													Type:        schema.TypeString,
+													Computed:    true,
+												},
+												"networking_deployment_cidr": {
+													Description: "Deployment CIDR mask",
+													Type:        schema.TypeString,
+													Computed:    true,
+												},
+												"networking_vpc_id": {
+													Description: "Either an existing VPC Id (already exists in the specific region) or create a new VPC (if no VPC is specified)",
+													Type:        schema.TypeString,
+													Computed:    true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -462,16 +494,24 @@ func resourceRedisCloudSubscriptionRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("cloud_provider", flattenCloudDetails(subscription.CloudDetails)); err != nil {
+	if err := d.Set("cloud_provider", flattenCloudDetails(subscription.CloudDetails, true)); err != nil {
 		return diag.FromErr(err)
 	}
 
-	allowlist, err := flattenSubscriptionAllowlist(ctx, subId, api)
+	providers, err := buildCreateCloudProviders(d.Get("cloud_provider"))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("allowlist", allowlist); err != nil {
-		return diag.FromErr(err)
+
+	// CIDR allowlist is not allowed for Redis Labs internal resources subscription.
+	if len(providers) > 0 && redis.IntValue(providers[0].CloudAccountID) != 1 {
+		allowlist, err := flattenSubscriptionAllowlist(ctx, subId, api)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("allowlist", allowlist); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	flatDbs, err := flattenDatabases(ctx, subId, d.Get("database").(*schema.Set).List(), api)
@@ -1009,7 +1049,7 @@ func isNil(i interface{}) bool {
 	return false
 }
 
-func flattenCloudDetails(cloudDetails []*subscriptions.CloudDetail) []map[string]interface{} {
+func flattenCloudDetails(cloudDetails []*subscriptions.CloudDetail, isResource bool) []map[string]interface{} {
 	var cdl []map[string]interface{}
 
 	for _, currentCloudDetail := range cloudDetails {
@@ -1021,9 +1061,16 @@ func flattenCloudDetails(cloudDetails []*subscriptions.CloudDetail) []map[string
 				"region":                       currentRegion.Region,
 				"multiple_availability_zones":  currentRegion.MultipleAvailabilityZones,
 				"preferred_availability_zones": currentRegion.PreferredAvailabilityZones,
-				"networking_deployment_cidr":   currentRegion.Networking[0].DeploymentCIDR,
 				"networking_vpc_id":            currentRegion.Networking[0].VPCId,
-				"networking_subnet_id":         currentRegion.Networking[0].SubnetID,
+				"networks":                     flattenNetworks(currentRegion.Networking),
+			}
+
+			if isResource {
+				regionMapString["networking_deployment_cidr"] = currentRegion.Networking[0].DeploymentCIDR
+
+				if redis.BoolValue(currentRegion.MultipleAvailabilityZones) {
+					regionMapString["networking_deployment_cidr"] = ""
+				}
 			}
 
 			regions = append(regions, regionMapString)
@@ -1035,6 +1082,23 @@ func flattenCloudDetails(cloudDetails []*subscriptions.CloudDetail) []map[string
 			"region":           regions,
 		}
 		cdl = append(cdl, cdlMapString)
+	}
+
+	return cdl
+}
+
+func flattenNetworks(networks []*subscriptions.Networking) []map[string]interface{} {
+	var cdl []map[string]interface{}
+
+	for _, currentNetwork := range networks {
+
+		networkMapString := map[string]interface{}{
+			"networking_deployment_cidr": currentNetwork.DeploymentCIDR,
+			"networking_vpc_id":          currentNetwork.VPCId,
+			"networking_subnet_id":       currentNetwork.SubnetID,
+		}
+
+		cdl = append(cdl, networkMapString)
 	}
 
 	return cdl

--- a/internal/provider/resource_rediscloud_subscription_test.go
+++ b/internal/provider/resource_rediscloud_subscription_test.go
@@ -34,7 +34,7 @@ func TestAccResourceRedisCloudSubscription_addUpdateDeleteDatabase(t *testing.T)
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networking_subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networks.0.networking_subnet_id"),
 					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
 					resource.TestCheckResourceAttrSet(resourceName, "database.0.password"),


### PR DESCRIPTION
Changing the network_deployment_cidr to work correctly with multi-availability zones and introducing networks sections with all computed values created by Redis Labs