### PR TITLE
Add validation for length of database name

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -241,6 +241,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Description: "A meaningful name to identify the database",
 							Type:        schema.TypeString,
 							Required:    true,
+							ValidateDiagFunc: validateDiagFunc(validation.StringLenBetween(0, 40)),
 						},
 						"protocol": {
 							Description:      "The protocol that will be used to access the database, (either ‘redis’ or 'memcached’) ",


### PR DESCRIPTION
Right now terraform provider does not have any restriction on length of the database name.
But the redislabs api limits length of the database name to max of 40 characters. This causes `terraform apply` to fail.
This commit adds validation for the same.

Error observed (only when `TF_LOG=trace` is set):
```
"additionalInfo" : "Database name is longer than 40 characters"
```

Ref issue: https://github.com/RedisLabs/terraform-provider-rediscloud/issues/99