### PR TITLE
Initial commit to allow modules to be set with additional databases

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -823,6 +823,20 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 		})
 	}
 
+	createModules := make([]*databases.CreateModule, 0)
+	module := db["module"]
+	for _, module := range module.([]interface{}) {
+		moduleMap := module.(map[string]interface{})
+
+		modName := moduleMap["name"].(string)
+
+		createModule := &databases.CreateModule{
+			Name: redis.String(modName),
+		}
+
+		createModules = append(createModules, createModule)
+	}
+
 	create := databases.CreateDatabase{
 		DryRun:               redis.Bool(false),
 		Name:                 redis.String(db["name"].(string)),
@@ -839,6 +853,7 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 		ReplicaOf: setToStringSlice(db["replica_of"].(*schema.Set)),
 		Password:  redis.String(db["password"].(string)),
 		SourceIP:  setToStringSlice(db["source_ips"].(*schema.Set)),
+		Modules: createModules,
 	}
 
 	averageItemSize := db["average_item_size_in_bytes"].(int)
@@ -888,6 +903,7 @@ func buildUpdateDatabase(db map[string]interface{}) databases.UpdateDatabase {
 		SourceIP:        setToStringSlice(db["source_ips"].(*schema.Set)),
 		Alerts:          alerts,
 		ReplicaOf:       setToStringSlice(db["replica_of"].(*schema.Set)),
+
 	}
 
 	clientSSLCertificate := db["client_ssl_certificate"].(string)

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -238,9 +238,9 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Computed:    true,
 						},
 						"name": {
-							Description: "A meaningful name to identify the database",
-							Type:        schema.TypeString,
-							Required:    true,
+							Description:      "A meaningful name to identify the database",
+							Type:             schema.TypeString,
+							Required:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 40)),
 						},
 						"protocol": {
@@ -854,7 +854,7 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 		ReplicaOf: setToStringSlice(db["replica_of"].(*schema.Set)),
 		Password:  redis.String(db["password"].(string)),
 		SourceIP:  setToStringSlice(db["source_ips"].(*schema.Set)),
-		Modules: createModules,
+		Modules:   createModules,
 	}
 
 	averageItemSize := db["average_item_size_in_bytes"].(int)
@@ -904,7 +904,6 @@ func buildUpdateDatabase(db map[string]interface{}) databases.UpdateDatabase {
 		SourceIP:        setToStringSlice(db["source_ips"].(*schema.Set)),
 		Alerts:          alerts,
 		ReplicaOf:       setToStringSlice(db["replica_of"].(*schema.Set)),
-
 	}
 
 	clientSSLCertificate := db["client_ssl_certificate"].(string)

--- a/internal/provider/resource_rediscloud_subscription_test.go
+++ b/internal/provider/resource_rediscloud_subscription_test.go
@@ -160,6 +160,95 @@ func TestAccResourceRedisCloudSubscription_addUpdateDeleteDatabase(t *testing.T)
 	})
 }
 
+func TestAccResourceRedisCloudSubscription_AddAdditionalDatabaseWithModule(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	password2 := acctest.RandString(20)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	var subId int
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDb, testCloudAccountName, name, 1, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttr(resourceName, "database.0.name", "tf-database"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						var err error
+						subId, err = strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+						sub, err := client.client.Subscription.Get(context.TODO(), subId)
+						if err != nil {
+							return err
+						}
+
+						if redis.StringValue(sub.Name) != name {
+							return fmt.Errorf("unexpected name value: %s", redis.StringValue(sub.Name))
+						}
+
+						listDb := client.client.Database.List(context.TODO(), subId)
+						if listDb.Next() != true {
+							return fmt.Errorf("no database found: %s", listDb.Err())
+						}
+						if listDb.Err() != nil {
+							return listDb.Err()
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionTwoDbWithModule, testCloudAccountName, name, 2, password, password2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "database.1.module.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "database.1.module.0.name", "RediSearch"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						subId, err := strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+
+						nameId, err := getDatabaseNameIdMap(context.TODO(), subId, client)
+						if err != nil {
+							return err
+						}
+
+						if _, ok := nameId["tf-database"]; !ok {
+							return fmt.Errorf("first database doesn't exist")
+						}
+						if _, ok := nameId["tf-database-2"]; !ok {
+							return fmt.Errorf("second database doesn't exist")
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSubscriptionDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*apiClient)
 
@@ -287,6 +376,69 @@ resource "rediscloud_subscription" "example" {
     throughput_measurement_by = "number-of-shards"
     throughput_measurement_value = 2
     password = "%s"
+  }
+}
+`
+
+const testAccResourceRedisCloudSubscriptionTwoDbWithModule = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS"
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+      preferred_availability_zones = ["eu-west-1a"]
+    }
+  }
+
+  database {
+    name = "tf-database"
+    protocol = "redis"
+    memory_limit_in_gb = %d
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+  }
+
+  database {
+    name = "tf-database-2"
+     protocol = "redis"
+    memory_limit_in_gb = 1
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+
+	module {
+		name = "RediSearch"
+	}
   }
 }
 `


### PR DESCRIPTION
Issue #98 reports that when creating additional databases with modules, (under a GCP subscription) the database is created, but the module is not applied.  After wider investigation the same issue is found against both GCP and AWS subscription databases.  If two databases are created when the subscription is created then the module is applied to both, but later created databases still will not be created with a module.

This PR updates the subscription resources to apply the module attribute to a database that is being created during a subscription update.  A test has also be created to represent this update.