### PR TITLE
Add validation for length of database name (#101)

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -241,6 +241,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Description: "A meaningful name to identify the database",
 							Type:        schema.TypeString,
 							Required:    true,
+							ValidateDiagFunc: validateDiagFunc(validation.StringLenBetween(0, 40)),
 						},
 						"protocol": {
 							Description:      "The protocol that will be used to access the database, (either ‘redis’ or 'memcached’) ",

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -241,7 +241,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Description: "A meaningful name to identify the database",
 							Type:        schema.TypeString,
 							Required:    true,
-							ValidateDiagFunc: validateDiagFunc(validation.StringLenBetween(0, 40)),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 40)),
 						},
 						"protocol": {
 							Description:      "The protocol that will be used to access the database, (either ‘redis’ or 'memcached’) ",


### PR DESCRIPTION
Provides validation for database names to ensure they are within 40 characters.  Fix contributed by SachinTS.
Original PR #101  