### PR TITLE
Updates subscription peering to not replace after import.

### DIFF
--- a/internal/provider/resource_rediscloud_subscription_peering.go
+++ b/internal/provider/resource_rediscloud_subscription_peering.go
@@ -210,6 +210,10 @@ func resourceRedisCloudSubscriptionPeeringRead(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("subscription_id", strconv.Itoa(subId)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	peerings, err := api.client.Subscription.ListVPCPeering(ctx, subId)
 	if err != nil {
 		if _, ok := err.(*subscriptions.NotFound); ok {
@@ -229,7 +233,15 @@ func resourceRedisCloudSubscriptionPeeringRead(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
-	providerName := d.Get("provider_name").(string)
+	providerName := "AWS"
+
+	if redis.StringValue(peering.GCPProjectUID) != "" {
+		providerName = "GCP"
+	}
+
+	if err := d.Set("provider_name", providerName); err != nil {
+		return diag.FromErr(err)
+	}
 
 	if providerName == "AWS" {
 		if err := d.Set("aws_account_id", redis.StringValue(peering.AWSAccountID)); err != nil {

--- a/internal/provider/resource_rediscloud_subscription_peering_test.go
+++ b/internal/provider/resource_rediscloud_subscription_peering_test.go
@@ -68,11 +68,6 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "aws_peering_id"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/internal/provider/resource_rediscloud_subscription_peering_test.go
+++ b/internal/provider/resource_rediscloud_subscription_peering_test.go
@@ -68,6 +68,11 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "aws_peering_id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -103,6 +108,11 @@ func TestAccResourceRedisCloudSubscriptionPeering_gcp(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "gcp_redis_network_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "gcp_peering_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
This PR focuses on correcting the provider to not try a replace against Subscription peering for the GCP cloud provider.
The peering request details returned for the GCP cloud provider allow the read to be completed and the schema for the resource is populated correctly.

If the GCP project ID is populated then the resource read function populates the rest of the GCP values and sets the provider to GCP.  The subscription ID is also set.  This should allow the import to match the HCL config.  The import test step has been added to the GCP test.

NOTE:  A Subscription peering for the AWS cloud provider will still try to replace the resource after it has been imported.  This is because the region cannot be determined at read time during the import and so this value is different.  The AWS test at this point does not have the import test step because it would lead to test failures.