### PR TITLE
Fixed parsing of log-levels by removing date/time prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,9 @@ func main() {
 
 	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
 
+	// Prevent logger from prepending date/time to logs, which breaks log-level parsing/filtering
+	log.SetFlags(0)
+
 	if debugMode {
 		err := plugin.Debug(context.Background(), "RedisLabs/rediscloud", opts)
 		if err != nil {


### PR DESCRIPTION
The following PR covers fixing the log-levels by removing a date/time prefix

The following output is before the fix
`2021-07-21T12:26:11.305+0100 [INFO]  provider.terraform-provider-rediscloud_v0.2.3: 2021/07/21 12:26:11 [DEBUG] Updating database tf-support-example-db (51152787): timestamp=2021-07-21T12:26:11.305+0100`

The following output is after the fix has been applied
`2021-07-21T12:12:51.781+0100 [DEBUG] provider.terraform-provider-rediscloud_v99.99.99: Updating database tf-support-example-db (51152785): timestamp=2021-07-21T12:12:51.780+0100`

As show the additional date/time prefix has been removed following the `provider.terraform-provider-rediscloud_vx.x.x`. value