### PR TITLE
Updates the subscription timeout value for update function to 30 mins

### DIFF
--- a/docs/resources/rediscloud_subscription.md
+++ b/docs/resources/rediscloud_subscription.md
@@ -214,7 +214,7 @@ The database `module` block supports:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 mins) Used when creating the subscription
-* `update` - (Defaults to 10 mins) Used when updating the subscrition
+* `update` - (Defaults to 30 mins) Used when updating the subscription
 * `delete` - (Defaults to 10 mins) Used when destroying the subscription
 
 ## Attribute reference

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -57,7 +57,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Read:   schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 


### PR DESCRIPTION
This small PR adjusts the default optional timeout value for the update function.  The original default value was set to 10 minutes and has now been updated to 30 mins to align with the create optional default timeout value.  

The original expectation was that most database creations would be actioned at the time of the subscription creation, but this is not completely true.  The databases are managed through the subscription life and databases can be added or removed later as required.   The following issue showed that the update default timeout value can be too short at 10 minutes: #124 

Because database creation can happen in the subscription create and update functions then it make sense to keep them aligned.

As mentioned in the following documentation by HashiCorp [Optional Timouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts) not all resource support the optional timeout configuration, but the susbcription resource does support the HCL block.  I the default of 30 minutes for either create or update is not enough then it can be adjusted through this method.  Existing documentation for the resource also shows this and the PR will update [rediscloud_subscription#timeouts](https://registry.terraform.io/providers/RedisLabs/rediscloud/latest/docs/resources/rediscloud_subscription#timeouts) to reflect the new default value.

