### PR TITLE
Wrong syntax in example.

### DIFF
--- a/docs/resources/rediscloud_subscription_peering.md
+++ b/docs/resources/rediscloud_subscription_peering.md
@@ -47,7 +47,7 @@ resource "rediscloud_subscription" "example" {
 
 resource "rediscloud_subscription_peering" "example" {
    subscription_id = rediscloud_subscription.example.id
-   provider = "GCP"
+   provider_name = "GCP"
    gcp_project_id = "cloud-api-123456"
    gcp_network_name = "cloud-api-vpc-peering-example"
 }


### PR DESCRIPTION
That results in this error:

```bash
Warning: Quoted references are deprecated

  on redis.tf line 47, in resource "rediscloud_subscription_peering" "dapper-eth-staging-us-west1":
  47:   provider         = "gcp"

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.


Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/gcp:
provider registry registry.terraform.io does not have a provider named
registry.terraform.io/hashicorp/gcp
```

This fixes it.