### PR TITLE
Enable TLS for database

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -391,6 +391,12 @@ func resourceRedisCloudSubscription() *schema.Resource {
 								// which isn't a valid Go regex
 							},
 						},
+						"enable_tls": {
+							Description: "Use TLS for authentication",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -871,21 +871,20 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 
 	clientSSLCertificate := db["client_ssl_certificate"].(string)
 	enableTLS := db["enable_tls"].(bool)
-	if !enableTLS {
-		if clientSSLCertificate != "" {
-			// 5 & 6 & 8
-			create.ClientSSLCertificate = redis.String(clientSSLCertificate)
-		} else {
-			// 2
-			create.EnableTls = redis.Bool(enableTLS)
-		}
-	}
 	if enableTLS {
 		// 3
 		create.EnableTls = redis.Bool(enableTLS)
 		// 4 & 7
 		if clientSSLCertificate != "" {
 			create.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		}
+	} else {
+		if clientSSLCertificate != "" {
+			// 5 & 6 & 8
+			create.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		} else {
+			// 2
+			create.EnableTls = redis.Bool(enableTLS)
 		}
 	}
 
@@ -934,21 +933,20 @@ func buildUpdateDatabase(db map[string]interface{}) databases.UpdateDatabase {
 
 	clientSSLCertificate := db["client_ssl_certificate"].(string)
 	enableTLS := db["enable_tls"].(bool)
-	if !enableTLS {
-		if clientSSLCertificate != "" {
-			// 5 & 6 & 8
-			update.ClientSSLCertificate = redis.String(clientSSLCertificate)
-		} else {
-			// 2
-			update.EnableTls = redis.Bool(enableTLS)
-		}
-	}
 	if enableTLS {
 		// 3
 		update.EnableTls = redis.Bool(enableTLS)
 		// 4 & 7
 		if clientSSLCertificate != "" {
 			update.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		}
+	} else {
+		if clientSSLCertificate != "" {
+			// 5 & 6 & 8
+			update.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		} else {
+			// 2
+			update.EnableTls = redis.Bool(enableTLS)
 		}
 	}
 

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -869,8 +869,10 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 		create.AverageItemSizeInBytes = redis.Int(averageItemSize)
 	}
 
-	clientSSLCertificate := db["client_ssl_certificate"].(string)
-	if clientSSLCertificate != "" {
+	enableTls := db["enable_tls"].(bool)
+	if enableTls == true {
+		create.EnableTls = redis.Bool(enableTls)
+		clientSSLCertificate := db["client_ssl_certificate"].(string)
 		create.ClientSSLCertificate = redis.String(clientSSLCertificate)
 	}
 
@@ -917,8 +919,10 @@ func buildUpdateDatabase(db map[string]interface{}) databases.UpdateDatabase {
 		update.ReplicaOf = make([]*string, 0)
 	}
 
-	clientSSLCertificate := db["client_ssl_certificate"].(string)
-	if clientSSLCertificate != "" {
+	enableTls := db["enable_tls"].(bool)
+	if enableTls == true {
+		update.EnableTls = redis.Bool(enableTls)
+		clientSSLCertificate := db["client_ssl_certificate"].(string)
 		update.ClientSSLCertificate = redis.String(clientSSLCertificate)
 	}
 
@@ -1201,6 +1205,7 @@ func flattenDatabase(certificate string, externalOSSAPIEndpoint bool, backupPath
 		"password":                              password,
 		"source_ips":                            sourceIPs,
 		"hashing_policy":                        flattenRegexRules(db.Clustering.RegexRules),
+		"enable_tls":                            redis.Bool(*db.Security.EnableTls),
 	}
 
 	if db.ReplicaOf != nil {

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -1,0 +1,206 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/RedisLabs/rediscloud-go-api/redis"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceRedisCloudSubscription_createWithDatabaseAndSslCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	clientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+	
+	var subId int
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithCert, testCloudAccountName, name, 1, password, clientSslCertificate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networks.0.networking_subnet_id"),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttrSet(resourceName, "database.0.password"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.name", "tf-database"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.memory_limit_in_gb", "1"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						var err error
+						subId, err = strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+						sub, err := client.client.Subscription.Get(context.TODO(), subId)
+						if err != nil {
+							return err
+						}
+
+						if redis.StringValue(sub.Name) != name {
+							return fmt.Errorf("unexpected name value: %s", redis.StringValue(sub.Name))
+						}
+
+						listDb := client.client.Database.List(context.TODO(), subId)
+						if listDb.Next() != true {
+							return fmt.Errorf("no database found: %s", listDb.Err())
+						}
+
+						if listDb.Err() != nil {
+							return listDb.Err()
+						}
+
+						database := listDb.Value()
+						if *database.Security.SSLClientAuthentication != true {
+							return fmt.Errorf("database SSL Authentication is not enabled: %v", *database.Security.SSLClientAuthentication)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceRedisCloudSubscription_createWithDatabaseAndInvalidSslCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	clientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+
+	var subId int
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithCert, testCloudAccountName, name, 1, password, clientSslCertificate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networks.0.networking_subnet_id"),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttrSet(resourceName, "database.0.password"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.name", "tf-database"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.memory_limit_in_gb", "1"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						var err error
+						subId, err = strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+						sub, err := client.client.Subscription.Get(context.TODO(), subId)
+						if err != nil {
+							return err
+						}
+
+						if redis.StringValue(sub.Name) != name {
+							return fmt.Errorf("unexpected name value: %s", redis.StringValue(sub.Name))
+						}
+
+						listDb := client.client.Database.List(context.TODO(), subId)
+						if listDb.Next() != true {
+							return fmt.Errorf("no database found: %s", listDb.Err())
+						}
+
+						if listDb.Err() != nil {
+							return listDb.Err()
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const testAccResourceRedisCloudSubscriptionOneDbWithCert = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS" 
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+      preferred_availability_zones = ["eu-west-1a"]
+    }
+  }
+
+  database {
+    name = "tf-database"
+    protocol = "redis"
+    memory_limit_in_gb = %d
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+	enable_tls = true
+	client_ssl_certificate = "%s"
+  }
+}
+`

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -83,6 +83,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseAndSslCert(t *testi
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"database.0.client_ssl_certificate"},
 			},
 		},
 	})

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -145,7 +145,13 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndEm
 							return listDb.Err()
 						}
 
-						//database := listDb.Value()
+						database := listDb.Value()
+						if *database.Security.EnableTls != true {
+							return fmt.Errorf("database Tls flag is not enabled: %v", *database.Security.SSLClientAuthentication)
+						}
+						if *database.Security.SSLClientAuthentication != false {
+							return fmt.Errorf("database SSL client Authentication is enabled: %v", *database.Security.SSLClientAuthentication)
+						}
 
 						return nil
 					},


### PR DESCRIPTION
BLOCKED by: https://github.com/opencredo/rediscloud-go-api/pull/1

Changes:
- Enable TLS for databases
- Implemented logic for various scenarios

TODO before merging:
- delete the comments referencing the scenarios

 