### PR TITLE
Enable tls for susbcription databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ as in the following example, to configure this.
 $ TEST_PARALLELISM=2 make testacc
 ```
 
+A core set of Acceptance tests are executed through the build pipeline, (considered short tests).  
+Functionality that requires additional setup or environment variables can be executed using the following flags.
+
+| Flag      | Description                                       |
+|-----------|---------------------------------------------------|
+| `-tls`      | Allows execution of TLS based acceptance tests    |
+| `-contract` | Allows execution of contract payment method tests |
+
 Adding Dependencies
 -------------------
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.17
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.1.4
+	github.com/RedisLabs/rediscloud-go-api v0.1.5
 	github.com/bflad/tfproviderlint v0.27.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
@@ -23,7 +23,6 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
-	github.com/bflad/gopaniccheck v0.1.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
+	github.com/bflad/gopaniccheck v0.1.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.37.0 h1:GzFnhOIsrGyQ69s7VgqtrG2BG8v7X7vwB3Xpbd/DBBk=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/bflad/gopaniccheck v0.1.0 h1:tJftp+bv42ouERmUMWLoUn/5bi/iQZjHPznM00cP/bU=
 github.com/bflad/gopaniccheck v0.1.0/go.mod h1:ZCj2vSr7EqVeDaqVsWN4n2MwdROx1YL+LFo47TSWtsA=
 github.com/bflad/tfproviderlint v0.27.1 h1:sYlc6R8cQ0NtaCCA7Oh1ld8xfn0oiwn6mm4unooi2fo=
 github.com/bflad/tfproviderlint v0.27.1/go.mod h1:7Z9Pyl1Z1UWJcPBuyjN89D2NaJGpjReQb5NoaaQCthQ=

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RedisLabs/rediscloud-go-api v0.1.4 h1:0z3c5QhD4bjp9WJnGw4sHNqvbPCcilC6fpmfeqeteXw=
-github.com/RedisLabs/rediscloud-go-api v0.1.4/go.mod h1:fi/mp4UbUOH9l2jguVpyhHzFSPDqbTL5lewMN5pAW+c=
+github.com/RedisLabs/rediscloud-go-api v0.1.5 h1:bYlpDq3mJPdvzxdnDVUZKOwiSbM4of7ujE0mu8bGzbw=
+github.com/RedisLabs/rediscloud-go-api v0.1.5/go.mod h1:fi/mp4UbUOH9l2jguVpyhHzFSPDqbTL5lewMN5pAW+c=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -80,7 +80,6 @@ github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.37.0 h1:GzFnhOIsrGyQ69s7VgqtrG2BG8v7X7vwB3Xpbd/DBBk=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/bflad/gopaniccheck v0.1.0 h1:tJftp+bv42ouERmUMWLoUn/5bi/iQZjHPznM00cP/bU=
 github.com/bflad/gopaniccheck v0.1.0/go.mod h1:ZCj2vSr7EqVeDaqVsWN4n2MwdROx1YL+LFo47TSWtsA=
 github.com/bflad/tfproviderlint v0.27.1 h1:sYlc6R8cQ0NtaCCA7Oh1ld8xfn0oiwn6mm4unooi2fo=
 github.com/bflad/tfproviderlint v0.27.1/go.mod h1:7Z9Pyl1Z1UWJcPBuyjN89D2NaJGpjReQb5NoaaQCthQ=

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -391,6 +391,12 @@ func resourceRedisCloudSubscription() *schema.Resource {
 								// which isn't a valid Go regex
 							},
 						},
+						"enable_tls": {
+							Description: "Use TLS for authentication",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
 					},
 				},
 			},
@@ -863,9 +869,24 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 		create.AverageItemSizeInBytes = redis.Int(averageItemSize)
 	}
 
+	// The cert validation is done by the API (HTTP 400 is returned if it's invalid).
 	clientSSLCertificate := db["client_ssl_certificate"].(string)
-	if clientSSLCertificate != "" {
-		create.ClientSSLCertificate = redis.String(clientSSLCertificate)
+	enableTLS := db["enable_tls"].(bool)
+	if enableTLS {
+		// TLS only: enable_tls=true, client_ssl_certificate="".
+		create.EnableTls = redis.Bool(enableTLS)
+		// mTLS: enableTls=true, non-empty client_ssl_certificate.
+		if clientSSLCertificate != "" {
+			create.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		}
+	} else {
+		// mTLS (backward compatibility): enable_tls=false, non-empty client_ssl_certificate.
+		if clientSSLCertificate != "" {
+			create.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		} else {
+			// Default: enable_tls=false, client_ssl_certificate=""
+			create.EnableTls = redis.Bool(enableTLS)
+		}
 	}
 
 	backupPath := db["periodic_backup_path"].(string)
@@ -911,9 +932,24 @@ func buildUpdateDatabase(db map[string]interface{}) databases.UpdateDatabase {
 		update.ReplicaOf = make([]*string, 0)
 	}
 
+	// The cert validation is done by the API (HTTP 400 is returned if it's invalid).
 	clientSSLCertificate := db["client_ssl_certificate"].(string)
-	if clientSSLCertificate != "" {
-		update.ClientSSLCertificate = redis.String(clientSSLCertificate)
+	enableTLS := db["enable_tls"].(bool)
+	if enableTLS {
+		// TLS only: enable_tls=true, client_ssl_certificate="".
+		update.EnableTls = redis.Bool(enableTLS)
+		// mTLS: enableTls=true, non-empty client_ssl_certificate.
+		if clientSSLCertificate != "" {
+			update.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		}
+	} else {
+		// mTLS (backward compatibility): enable_tls=false, non-empty client_ssl_certificate.
+		if clientSSLCertificate != "" {
+			update.ClientSSLCertificate = redis.String(clientSSLCertificate)
+		} else {
+			// Default: enable_tls=false, client_ssl_certificate=""
+			update.EnableTls = redis.Bool(enableTLS)
+		}
 	}
 
 	regex := db["hashing_policy"].([]interface{})
@@ -1195,6 +1231,7 @@ func flattenDatabase(certificate string, externalOSSAPIEndpoint bool, backupPath
 		"password":                              password,
 		"source_ips":                            sourceIPs,
 		"hashing_policy":                        flattenRegexRules(db.Clustering.RegexRules),
+		"enable_tls":                            redis.Bool(*db.Security.EnableTls),
 	}
 
 	if db.ReplicaOf != nil {

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,8 +15,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var tlsFlag = flag.Bool("tls", false,
+	"Add this flag '-tls' to run tests for subscriptions and databases that use TLS")
+
 // enable_tls=true, client_ssl_certificate=<valid>
 func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSslCert(t *testing.T) {
+
+	if !*tlsFlag {
+		t.Skip("The '-tls' parameter wasn't provided in the test command.")
+	}
 
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	password := acctest.RandString(20)
@@ -81,9 +89,9 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSs
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"database.0.client_ssl_certificate"},
 			},
 		},
@@ -92,6 +100,10 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSs
 
 // enable_tls=true, client_ssl_certificate=""
 func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndEmptySslCert(t *testing.T) {
+
+	if !*tlsFlag {
+		t.Skip("The '-tls' parameter wasn't provided in the test command.")
+	}
 
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	password := acctest.RandString(20)
@@ -169,11 +181,15 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndEm
 // enable_tls=true, client_ssl_certificate=<invalid>
 func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndInvalidSslCert(t *testing.T) {
 
+	if !*tlsFlag {
+		t.Skip("The '-tls' parameter wasn't provided in the test command.")
+	}
+
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
@@ -181,7 +197,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndIn
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
 				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
 			},
 		},
@@ -191,11 +207,15 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndIn
 // enable_tls=false, client_ssl_certificate=<invalid>
 func TestAccResourceRedisCloudSubscription_createWithDatabaseAndDisabledTlsAndInvalidCert(t *testing.T) {
 
+	if !*tlsFlag {
+		t.Skip("The '-tls' parameter wasn't provided in the test command.")
+	}
+
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
@@ -203,7 +223,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseAndDisabledTlsAndIn
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
 				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
 			},
 		},

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -1,0 +1,353 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/RedisLabs/rediscloud-go-api/redis"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// enable_tls=true, client_ssl_certificate=<valid>
+func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSslCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	clientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+
+	var subId int
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, clientSslCertificate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networks.0.networking_subnet_id"),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttrSet(resourceName, "database.0.password"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.name", "tf-database"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.memory_limit_in_gb", "1"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						var err error
+						subId, err = strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+						sub, err := client.client.Subscription.Get(context.TODO(), subId)
+						if err != nil {
+							return err
+						}
+
+						if redis.StringValue(sub.Name) != name {
+							return fmt.Errorf("unexpected name value: %s", redis.StringValue(sub.Name))
+						}
+
+						listDb := client.client.Database.List(context.TODO(), subId)
+						if listDb.Next() != true {
+							return fmt.Errorf("no database found: %s", listDb.Err())
+						}
+
+						if listDb.Err() != nil {
+							return listDb.Err()
+						}
+
+						database := listDb.Value()
+						if *database.Security.SSLClientAuthentication != true {
+							return fmt.Errorf("database SSL Authentication is not enabled: %v", *database.Security.SSLClientAuthentication)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"database.0.client_ssl_certificate"},
+			},
+		},
+	})
+}
+
+// enable_tls=true, client_ssl_certificate=""
+func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndEmptySslCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	var subId int
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndWithoutCert, testCloudAccountName, name, 1, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider.0.region.0.networks.0.networking_subnet_id"),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "database.0.db_id", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttrSet(resourceName, "database.0.password"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.name", "tf-database"),
+					resource.TestCheckResourceAttr(resourceName, "database.0.memory_limit_in_gb", "1"),
+					func(s *terraform.State) error {
+						r := s.RootModule().Resources[resourceName]
+
+						var err error
+						subId, err = strconv.Atoi(r.Primary.ID)
+						if err != nil {
+							return err
+						}
+
+						client := testProvider.Meta().(*apiClient)
+						sub, err := client.client.Subscription.Get(context.TODO(), subId)
+						if err != nil {
+							return err
+						}
+
+						if redis.StringValue(sub.Name) != name {
+							return fmt.Errorf("unexpected name value: %s", redis.StringValue(sub.Name))
+						}
+
+						listDb := client.client.Database.List(context.TODO(), subId)
+						if listDb.Next() != true {
+							return fmt.Errorf("no database found: %s", listDb.Err())
+						}
+
+						if listDb.Err() != nil {
+							return listDb.Err()
+						}
+
+						database := listDb.Value()
+						if *database.Security.EnableTls != true {
+							return fmt.Errorf("database Tls flag is not enabled: %v", *database.Security.SSLClientAuthentication)
+						}
+						if *database.Security.SSLClientAuthentication != false {
+							return fmt.Errorf("database SSL client Authentication is enabled: %v", *database.Security.SSLClientAuthentication)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// enable_tls=true, client_ssl_certificate=<invalid>
+func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndInvalidSslCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
+				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
+			},
+		},
+	})
+}
+
+// enable_tls=false, client_ssl_certificate=<invalid>
+func TestAccResourceRedisCloudSubscription_createWithDatabaseAndDisabledTlsAndInvalidCert(t *testing.T) {
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
+				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
+			},
+		},
+	})
+}
+
+const testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS" 
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+      preferred_availability_zones = ["eu-west-1a"]
+    }
+  }
+
+  database {
+    name = "tf-database"
+    protocol = "redis"
+    memory_limit_in_gb = %d
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+	enable_tls = true
+	client_ssl_certificate = "%s"
+  }
+}
+`
+
+const testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndWithoutCert = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS" 
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+      preferred_availability_zones = ["eu-west-1a"]
+    }
+  }
+
+  database {
+    name = "tf-database"
+    protocol = "redis"
+    memory_limit_in_gb = %d
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+	enable_tls = true
+  }
+}
+`
+
+const testAccResourceRedisCloudSubscriptionOneDbWithoutEnableTlsAndWithCert = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS" 
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+      preferred_availability_zones = ["eu-west-1a"]
+    }
+  }
+
+  database {
+    name = "tf-database"
+    protocol = "redis"
+    memory_limit_in_gb = %d
+    support_oss_cluster_api = true
+    data_persistence = "none"
+    replication = false
+    throughput_measurement_by = "operations-per-second"
+    password = "%s"
+    throughput_measurement_value = 10000
+    source_ips = ["10.0.0.0/8"]
+	client_ssl_certificate = "%s"
+  }
+}
+`

--- a/internal/provider/resource_rediscloud_subscription_tls_test.go
+++ b/internal/provider/resource_rediscloud_subscription_tls_test.go
@@ -18,6 +18,14 @@ import (
 var tlsFlag = flag.Bool("tls", false,
 	"Add this flag '-tls' to run tests for subscriptions and databases that use TLS")
 
+func testAccTLSValidCertificatePreCheck(t *testing.T) {
+	requireEnvironmentVariables(t, "SSL_CERTIFICATE")
+}
+
+func testAccTLSInvalidCertificatePreCheck(t *testing.T) {
+	requireEnvironmentVariables(t, "SSL_CERTIFICATE_INVALID")
+}
+
 // enable_tls=true, client_ssl_certificate=<valid>
 func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSslCert(t *testing.T) {
 
@@ -35,7 +43,11 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSs
 	var subId int
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAwsPreExistingCloudAccountPreCheck(t)
+			testAccTLSValidCertificatePreCheck(t)
+		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -192,7 +204,11 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndIn
 	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAwsPreExistingCloudAccountPreCheck(t)
+			testAccTLSInvalidCertificatePreCheck(t)
+		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -218,12 +234,16 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseAndDisabledTlsAndIn
 	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAwsPreExistingCloudAccountPreCheck(t)
+			testAccTLSInvalidCertificatePreCheck(t)
+		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithoutEnableTlsAndWithCert, testCloudAccountName, name, 1, password, invalidClientSslCertificate),
 				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
 			},
 		},


### PR DESCRIPTION
In this PR, we allow the user to enable TLS in the database.  This PR covers the alterations from the following PR (#166 )