### PR TITLE
document enable_tls attribute added in v0.2.8

### DIFF
--- a/docs/data-sources/rediscloud_database.md
+++ b/docs/data-sources/rediscloud_database.md
@@ -55,6 +55,7 @@ database will be a replica of.
 hashing policy.
 * `public_endpoint` - Public endpoint to access the database
 * `private_endpoint` - Private endpoint to access the database
+* `enable_tls` - Enable TLS for database, default is `false`
 
 The `alert` block supports:
 


### PR DESCRIPTION
👋🏽  Redis Labs

There was a recent change in `v.0.2.8`  to Enable TLS for a database; it was merged in #167.
But the corresponding documentation was omitted; [see current live docs](https://registry.terraform.io/providers/RedisLabs/rediscloud/latest/docs/data-sources/rediscloud_database)

this PR adds the missing attribute to the existing terraform documentation.

reference PR:
#167 
