### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## 0.2.9 (unreleased)
 
+### Changed
+
 - Updates additional dependencies contributing to build, (goreleaser-action 2.8.1)
 - Updates Terraform Plugin SDK to v2.10.1
+- Updates rediscloud-go-api dependency to v0.1.6 use correct content-type with API
 
 ## 0.2.8 (December 14 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
-## 0.2.9 (unreleased)
+## 0.2.9 (March 28 2022)
 
 ### Changed
 


### PR DESCRIPTION
This PR represents v0.2.9 of the RedisCloud Terraform Provider.