### PR TITLE
remove ForceNew from the module attribute

### DIFF
--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -585,6 +585,7 @@ func resourceRedisCloudSubscriptionUpdate(ctx context.Context, d *schema.Resourc
 		} else {
 			// this is not a new resource, so these databases really do new to be created
 			for _, db := range addition {
+			// This loop with addition is triggered when another database is added to the subscription.
 				request := buildCreateDatabase(db)
 				id, err := api.client.Database.Create(ctx, subId, request)
 				if err != nil {
@@ -819,8 +820,8 @@ func buildCreateDatabase(db map[string]interface{}) databases.CreateDatabase {
 	}
 
 	createModules := make([]*databases.CreateModule, 0)
-	module := db["module"]
-	for _, module := range module.([]interface{}) {
+	module := db["module"].(*schema.Set)
+	for _, module := range module.List() {
 		moduleMap := module.(map[string]interface{})
 
 		modName := moduleMap["name"].(string)

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -352,7 +352,6 @@ func resourceRedisCloudSubscription() *schema.Resource {
 							Description: "A module object",
 							Type:        schema.TypeSet,
 							Optional:    true,
-							ForceNew:    true,
 							MinItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_rediscloud_subscription_test.go
+++ b/internal/provider/resource_rediscloud_subscription_test.go
@@ -634,7 +634,7 @@ resource "rediscloud_subscription" "example" {
   }
 
   database {
-    name = "tf-database-2"
+    name = "tf-database-0"
 	protocol = "redis"
     memory_limit_in_gb = 1
     support_oss_cluster_api = true
@@ -687,7 +687,7 @@ resource "rediscloud_subscription" "example" {
   }
 
   database {
-    name = "tf-database-2"
+    name = "tf-database-0"
 	protocol = "redis"
     memory_limit_in_gb = 1
     support_oss_cluster_api = true
@@ -707,7 +707,7 @@ resource "rediscloud_subscription" "example" {
   }
   
   database {
-    name = "tf-database-3"
+    name = "tf-database-1"
 	protocol = "redis"
     memory_limit_in_gb = 1
     support_oss_cluster_api = true


### PR DESCRIPTION
The db block is treated as TypeSet and making changes inside the module block would cause the hash of the whole block to be recalculated. That is why we need to **remove this property `ForceNew`**.
We initially, thought that it would provide enough warning for the client to prevent them from modifying the module block.
After removing the `ForceNew` property the client would detect the change if the `module` block was modified. The output would look like the following:
```
rediscloud_subscription.example: Refreshing state... [id=140473]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # rediscloud_subscription.example will be updated in-place
  ~ resource "rediscloud_subscription" "example" {
        id                = "140473"
        name              = "hieu-example-test"
        # (2 unchanged attributes hidden)


      - database {
          - average_item_size_in_bytes            = 0 -> null
          - data_persistence                      = "none" -> null
          - db_id                                 = 51254863 -> null
          - enable_tls                            = false -> null
          - external_endpoint_for_oss_cluster_api = false -> null
          - hashing_policy                        = [] -> null
          - memory_limit_in_gb                    = 0.1 -> null
          - name                                  = "tf-example-database" -> null
          - password                              = (sensitive value)
          - private_endpoint                      = "redis-18999.internal.c357182.eu-west-1-1.ec2.qa-cloud.rlrcp.com:18999" -> null
          - protocol                              = "redis" -> null
          - public_endpoint                       = "redis-18999.c357182.eu-west-1-1.ec2.qa-cloud.rlrcp.com:18999" -> null
          - replica_of                            = [] -> null
          - replication                           = false -> null
          - source_ips                            = [] -> null
          - support_oss_cluster_api               = false -> null
          - throughput_measurement_by             = "operations-per-second" -> null
          - throughput_measurement_value          = 1000 -> null

          - alert {
              - name  = "dataset-size" -> null
              - value = 40 -> null
            }

          - module {
              - name = "RedisBloom" -> null
            }
          - module {
              - name = "RedisJSON" -> null
            }
        }
      + database {
          + average_item_size_in_bytes            = 0
          + data_persistence                      = "none"
          + db_id                                 = (known after apply)
          + enable_tls                            = false
          + external_endpoint_for_oss_cluster_api = false
          + hashing_policy                        = []
          + memory_limit_in_gb                    = 0.1
          + name                                  = "tf-example-database"
          + password                              = (sensitive value)
          + private_endpoint                      = (known after apply)
          + protocol                              = "redis"
          + public_endpoint                       = (known after apply)
          + replica_of                            = []
          + replication                           = false
          + source_ips                            = []
          + support_oss_cluster_api               = false
          + throughput_measurement_by             = "operations-per-second"
          + throughput_measurement_value          = 1000

          + alert {
              + name  = "dataset-size"
              + value = 40
            }
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

To correct the mismatch above, the client needs to revert back the module block to the initial configuration when the database was initially created.