### PR TITLE
Fix subscription changes appearing in plan

### DIFF
--- a/docs/resources/rediscloud_subscription.md
+++ b/docs/resources/rediscloud_subscription.md
@@ -78,8 +78,8 @@ The following arguments are supported:
 
 The `allowlist` block supports:
 
+* `security_group_ids` - (Requiured) Set of security groups that are allowed to access the databases associated with this subscription
 * `cidrs` - (Optional) Set of CIDR ranges that are allowed to access the databases associated with this subscription
-* `security_group_ids` - (Optional) Set of security groups that are allowed to access the databases associated with this subscription
 
 ~> **Note:** `allowlist` is only available when you run on your own cloud account, and not one that Redis Labs provided (i.e `cloud_account_id` != 1)
 
@@ -94,9 +94,9 @@ only with Redis Labs internal cloud account
 The `creation_plan` block supports:
 
 * `memory_limit_in_gb` - (Required) Maximum memory usage for the initial databases
-* `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
-* `modules` - (Optional) a list of modules that will be used by the databases in this subscription. 
+* `modules` - (Required) a list of modules that will be used by the databases in this subscription. 
 Example: `modules = ["RedisJSON", RedisBloom"]`.
+* `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 * `replication` - (Required) Databases replication.
 * `quantity` - (Required) The planned number of databases.
 * `throughput_measurement_by` - (Required) Throughput measurement method, (either ‘number-of-shards’ or ‘operations-per-second’)

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -112,7 +112,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 						"security_group_ids": {
 							Description: "Set of security groups that are allowed to access the databases associated with this subscription",
 							Type:        schema.TypeSet,
-							Optional:    true,
+							Required:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -28,7 +28,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 		UpdateContext: resourceRedisCloudSubscriptionUpdate,
 		DeleteContext: resourceRedisCloudSubscriptionDelete,
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
-		    _, cPlanExists := diff.GetOk("creation_plan")
+			_, cPlanExists := diff.GetOk("creation_plan")
 			if cPlanExists {
 				return nil
 			}
@@ -290,7 +290,7 @@ func resourceRedisCloudSubscription() *schema.Resource {
 						"modules": {
 							Description: "Modules that will be used by the databases in this subscription.",
 							Type:        schema.TypeList,
-							Optional:    true,
+							Required:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},


### PR DESCRIPTION
This is to fix the behaviour found in the demo where the subscription resource was showing changes in the plan even if it had not been changed. This was caused because some of the list attributes (`modules` and `security_group_ids`) were set to optional but, due to limitations in the Terraform SDK , there is no way of having a default value for a list attribute. Therefore to prevent this behaviour the two fields have been made required, the user will now have to specify an empty list (i.e.' = []' ) if they don't have any values to provide. 