### PR TITLE
fix: active-active subscription acceptance test attribute check bug 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,7 @@ clean:
 	rm -rf $(BIN)
 
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m -parallel=$(TEST_PARALLELISM)
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 360m -parallel=$(TEST_PARALLELISM)
 
 install_local: build
 	@echo "Installing local provider binary to plugins mirror path $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)"

--- a/internal/provider/resource_rediscloud_active_active_subscription_test.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_test.go
@@ -42,11 +42,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.memory_limit_in_gb", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.quantity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "false"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.read_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.read_operations_per_second", "1000"),
 
 					func(s *terraform.State) error {
 						r := s.RootModule().Resources[resourceName]
@@ -80,11 +80,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.memory_limit_in_gb", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.quantity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "false"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.read_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.read_operations_per_second", "1000"),
 				),
 			},
 			{
@@ -92,8 +92,8 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 				ResourceName: resourceName,
 				ImportState:  true,
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					creationPlan := states[0].Attributes["creation_plan.#"]
-					if creationPlan != "0" {
+					creationPlan, ok := states[0].Attributes["creation_plan.#"]
+					if ok && creationPlan != "0" {
 						return fmt.Errorf("Unexpected creation_plan block. Should be 0, instead of  %s", creationPlan)
 					}
 					return nil
@@ -129,11 +129,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateContractPayme
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.read_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.read_operations_per_second", "1000"),
 				),
 			},
 			{
@@ -168,11 +168,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.0.read_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.write_operations_per_second", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.region.1.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.write_operations_per_second", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.1.read_operations_per_second", "1000"),
 				),
 			},
 			{

--- a/internal/provider/resource_rediscloud_subscription_test.go
+++ b/internal/provider/resource_rediscloud_subscription_test.go
@@ -95,8 +95,8 @@ func TestAccResourceRedisCloudSubscription_CRUDI(t *testing.T) {
 				ResourceName: resourceName,
 				ImportState:  true,
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					creationPlan := states[0].Attributes["creation_plan.#"]
-					if creationPlan != "0" {
+					creationPlan, ok := states[0].Attributes["creation_plan.#"]
+					if ok && creationPlan != "0" {
 						return fmt.Errorf("Unexpected creation_plan block. Should be 0, instead of  %s", creationPlan)
 					}
 					return nil


### PR DESCRIPTION
The acceptance test for the active-active subscription resource fails with the following error:

```
TF_ACC=1 go test ./... -v -run=TestAccResourceRedisCloudActiveActiveSubscription_CRUDI -timeout 120m -parallel=3
?       github.com/RedisLabs/terraform-provider-rediscloud      [no test files]
=== RUN   TestAccResourceRedisCloudActiveActiveSubscription_CRUDI
    resource_rediscloud_active_active_subscription_test.go:31: Step 1/4 error: Check failed: Check 7/12 error: rediscloud_active_active_subscription.example: Attribute 'creation_plan.region.#' not found
--- FAIL: TestAccResourceRedisCloudActiveActiveSubscription_CRUDI (863.16s)
FAIL
FAIL    github.com/RedisLabs/terraform-provider-rediscloud/internal/provider    863.422s
FAIL
```

This is caused by the attribute check incorrectly referencing the resource's `creation_plan` attribute, which is a `TypeSet`. It therefore needs to be accessed with an index when accessing its nested attributes.