### PR TITLE
chore: update rediscloud-go-api and add AA test sweepers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.17
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.1.13-0.20230109190658-f23d278d2f07
+	github.com/RedisLabs/rediscloud-go-api v0.1.13
 	github.com/bflad/tfproviderlint v0.28.1
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RedisLabs/rediscloud-go-api v0.1.13-0.20230109190658-f23d278d2f07 h1:FNeb7D66InroDIXxvPdlt4OoE8GfsIFOO4wI+LwbE8k=
-github.com/RedisLabs/rediscloud-go-api v0.1.13-0.20230109190658-f23d278d2f07/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
+github.com/RedisLabs/rediscloud-go-api v0.1.13 h1:j+mukOiAoE/NGMLSsJKA/J4AcBhe3E8Zy6ItcWhzxfU=
+github.com/RedisLabs/rediscloud-go-api v0.1.13/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -77,7 +77,6 @@ func (m *perIdLock) get(id int) *sync.Mutex {
 	return mutex
 }
 
-
 // IDs of any resources dependent on a subscription need to be divided by a slash. In this format: <sub id>/<resource id>.
 func buildResourceId(subId int, id int) string {
 	return fmt.Sprintf("%d/%d", subId, id)


### PR DESCRIPTION
Updated the rediscloud-go-api to the latest tag (on the head of the `develop` branch).

Also added sweepers for active-active subscriptions to allow cleaning up of any leaked resources during acceptance tests: https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/sweepers