### PR TITLE
fix: AA regions bug and some assorted documentation things

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,8 +22,8 @@ $(BIN)/%:
 
 build:
 	@echo "Building local provider binary"
-	@mkdir -p ./$(BIN)
-	go build -o ./$(BIN)/terraform-provider-rediscloud_v$(PROVIDER_VERSION)
+	@mkdir -p $(BIN)
+	go build -o $(BIN)/terraform-provider-rediscloud_v$(PROVIDER_VERSION)
 	@sh -c "'$(CURDIR)/scripts/generate-dev-overrides.sh'"
 
 clean:

--- a/docs/resources/rediscloud_active_active_subscription_peering.md
+++ b/docs/resources/rediscloud_active_active_subscription_peering.md
@@ -17,12 +17,12 @@ For GCP, the opposite peering request should be submitted.
 The following example shows how a subscription can be peered with a AWS VPC using the rediscloud and google providers.
 
 ```hcl
-resource "rediscloud_subscription" "example" {
+resource "rediscloud_active_active_subscription" "example" {
   // ...
 }
 
 resource "rediscloud_active_active_subscription_peering" "example" {
-   subscription_id = rediscloud_subscription.example.id
+   subscription_id = rediscloud_active_active_subscription.example.id
    source_region = "us-east-1"
    destination_region = "eu-west-2"
    aws_account_id = "123456789012"
@@ -44,7 +44,7 @@ The following example shows how a subscription can be peered with a GCP project 
 The example HCL locates the network details and creates/accepts the vpc peering connection through the Google provider.   
 
 ```hcl
-resource "rediscloud_subscription" "example" {
+resource "rediscloud_active_active_subscription" "example" {
   // ...
 }
 
@@ -54,7 +54,7 @@ data "google_compute_network" "network" {
 }
 
 resource "rediscloud_active_active_subscription_peering" "example-peering" {
-  subscription_id = rediscloud_subscription.example.id
+  subscription_id = rediscloud_active_active_subscription.example.id
   provider_name = "GCP"
   gcp_project_id = data.google_compute_network.network.project
   gcp_network_name = data.google_compute_network.network.name

--- a/internal/provider/resource_rediscloud_active_active_subscription.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription.go
@@ -106,7 +106,8 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 						"support_oss_cluster_api": {
 							Description: "Support Redis open-source (OSS) Cluster API",
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
+							Default:     false,
 						},
 						"region": {
 							Description: "Cloud networking details, per region (multiple regions for Active-Active cluster)",

--- a/internal/provider/resource_rediscloud_subscription.go
+++ b/internal/provider/resource_rediscloud_subscription.go
@@ -267,7 +267,8 @@ func resourceRedisCloudSubscription() *schema.Resource {
 						"support_oss_cluster_api": {
 							Description: "Support Redis open-source (OSS) Cluster API",
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
+							Default:     false,
 						},
 						"replication": {
 							Description: "Databases replication",


### PR DESCRIPTION
Had a bug when creating a `rediscloud_active_active_region` resource with no new regions (all regions already created in subscription's `creation_plan`). In this case, the `d.SetId()` would never be called and there would be an error sort of like below:

```
Error: Provider produced inconsistent result after apply
When applying changes to
 
 rediscloud_active_active_regions.demo
 
provider "rediscloud"
 
produced an unexpected new value: Root resource was present, but now absent.
```

There are a couple of other changes to bring the provider and the documentation closer together