### PR TITLE
fix: importing active-active regions failing due to incorrect ID

### DIFF
--- a/internal/provider/resource_rediscloud_active_active_region.go
+++ b/internal/provider/resource_rediscloud_active_active_region.go
@@ -218,7 +218,7 @@ func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.R
 	api := meta.(*apiClient)
 	var diags diag.Diagnostics
 
-	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
+	subId, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -379,7 +379,7 @@ func resourceRedisCloudActiveActiveRegionRead(ctx context.Context, d *schema.Res
 
 	var diags diag.Diagnostics
 
-	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
+	subId, err := strconv.Atoi(d.Id())
 	regions, err := api.client.Regions.List(ctx, subId)
 	if err != nil {
 		if _, ok := err.(*subscriptions.NotFound); ok {

--- a/internal/provider/resource_rediscloud_active_active_region_test.go
+++ b/internal/provider/resource_rediscloud_active_active_region_test.go
@@ -26,7 +26,7 @@ func TestAccResourceRedisCloudActiveActiveRegion_CRUDI(t *testing.T) {
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudCrateActiveActiveRegion, subName, dbName, dbPass),
+				Config: fmt.Sprintf(testAccResourceRedisCloudCreateActiveActiveRegion, subName, dbName, dbPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "region.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "region.2.region", "eu-west-2"),
@@ -104,6 +104,12 @@ func TestAccResourceRedisCloudActiveActiveRegion_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region.1.networking_deployment_cidr", "10.1.0.0/24"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_regions"},
+			},
 		},
 	})
 }
@@ -156,7 +162,7 @@ resource "rediscloud_active_active_subscription_database" "example" {
 `
 
 // TF config for provisioning a new region.
-const testAccResourceRedisCloudCrateActiveActiveRegion = testAARegionsBoilerplate + `
+const testAccResourceRedisCloudCreateActiveActiveRegion = testAARegionsBoilerplate + `
 
 resource "rediscloud_active_active_subscription_regions" "example" {
 	subscription_id = rediscloud_active_active_subscription.example.id


### PR DESCRIPTION
I've added importing to the regions resource, and fixed a bug where `d.Id()` wasn't being read by the Read function, and therefore wouldn't work with the `ImportStatePassthrough` importer. Changing to read from `d.Id()` instead of `d.Get("subscription_id")` solved the issue. I also updated the test to ensure the import operation is tested