### PR TITLE
fix: regions inactive subscription error and memory limit hardcoding

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -159,7 +159,7 @@ jobs:
           REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_QA }}
           REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_QA }}
           REDISCLOUD_URL: https://api-cloudapi.qa.redislabs.com/v1
-          AWS_TEST_CLOUD_ACCOUNT_NAME: 2024
+          AWS_TEST_CLOUD_ACCOUNT_NAME: EXTERNAL-CA-2023
 #          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_PROD }}
 #          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_PROD }}
 #          REDISCLOUD_URL: https://api.redislabs.com/v1/

--- a/docs/resources/rediscloud_active_active_regions.md
+++ b/docs/resources/rediscloud_active_active_regions.md
@@ -88,8 +88,8 @@ The `database` block supports:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 mins) Used when creating the subscription
-* `update` - (Defaults to 30 mins) Used when updating the subscription
+* `create` - (Defaults to 60 mins) Used when creating the subscription
+* `update` - (Defaults to 60 mins) Used when updating the subscription
 * `delete` - (Defaults to 10 mins) Used when destroying the subscription
 
 ## Import

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.1.13
 	github.com/bflad/tfproviderlint v0.28.1
-	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.8.1
@@ -20,6 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -63,3 +63,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/RedisLabs/rediscloud-go-api => github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RedisLabs/rediscloud-go-api v0.1.13 h1:j+mukOiAoE/NGMLSsJKA/J4AcBhe3E8Zy6ItcWhzxfU=
-github.com/RedisLabs/rediscloud-go-api v0.1.13/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
+github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4 h1:ZP+mp8WDMBHg3WUMrw47MJF5PJSrNFlO2B9O7ojymbc=
+github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/internal/provider/resource_rediscloud_active_active_region.go
+++ b/internal/provider/resource_rediscloud_active_active_region.go
@@ -29,9 +29,9 @@ func resourceRedisCloudActiveActiveRegion() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 

--- a/internal/provider/resource_rediscloud_active_active_region.go
+++ b/internal/provider/resource_rediscloud_active_active_region.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"reflect"
 	"regexp"
 	"strconv"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
 	"github.com/RedisLabs/rediscloud-go-api/service/regions"
 	"github.com/RedisLabs/rediscloud-go-api/service/subscriptions"
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -120,15 +120,25 @@ func resourceRedisCloudActiveActiveRegion() *schema.Resource {
 }
 
 func resourceRedisCloudActiveActiveRegionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*apiClient)
-	var diags diag.Diagnostics
-
 	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	d.SetId(strconv.Itoa(subId))
 
-	// Get existing regions so we can do a manual diff
+	return resourceRedisCloudActiveActiveRegionUpdate(ctx, d, meta)
+}
+
+func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*apiClient)
+
+	subId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	deleteRegionsFlag := d.Get("delete_regions").(bool)
+
+	// Get existing regions, so we can do a manual diff
 	// Query API for existing Regions for a given Subscription
 	existingRegions, err := api.client.Regions.List(ctx, subId)
 	if err != nil {
@@ -141,34 +151,115 @@ func resourceRedisCloudActiveActiveRegionCreate(ctx context.Context, d *schema.R
 		existingRegionMap[*existingRegion.Region] = existingRegion
 	}
 
-	regionsFromResourceData := buildCreateActiveActiveRegions(d.Get("region").(*schema.Set))
+	desiredRegions := buildRegionsFromResourceData(d.Get("region").(*schema.Set))
 
-	// Filter non-existing regions
-	createRegions := make([]*regions.Region, 0)
-	for _, currentRegion := range regionsFromResourceData {
-		if _, ok := existingRegionMap[*currentRegion.Region]; !ok {
-			createRegions = append(createRegions, currentRegion)
+	// Determine which regions currently exist but aren't in the config
+	// These will need to be deleted
+	regionsToDelete := make([]*regions.Region, 0)
+	for _, r := range existingRegions.Regions {
+		if _, ok := desiredRegions[*r.Region]; !ok {
+			regionsToDelete = append(regionsToDelete, r)
 		}
 	}
 
-	err = regionCreate(ctx, subId, createRegions, api)
+	// Of the regions that are in the config, determine which are brand new and should be created, which already exist
+	// but have changed and require recreating (if update not supported), and which have changed and require updates
+	// (updating a region's DBs is supported)
+	regionsToCreate := make([]*regions.Region, 0)
+	regionsToRecreate := make([]*regions.Region, 0)
+	regionsToUpdateDatabases := make([]*regions.Region, 0)
+	for _, r := range desiredRegions {
+		existingRegion, ok := existingRegionMap[*r.Region]
+		if !ok {
+			regionsToCreate = append(regionsToCreate, r)
+		} else {
+			if shouldRecreateRegion(r, existingRegion) {
+				if !*r.RecreateRegion || !deleteRegionsFlag {
+					return diag.Errorf("Region %s needs to be recreated but recreate_region flag was not set!", *r.Region)
+				}
+				regionsToRecreate = append(regionsToRecreate, r)
+			} else if shouldUpdateRegionDatabases(r, existingRegion) {
+				regionsToUpdateDatabases = append(regionsToUpdateDatabases, r)
+			}
+		}
+	}
+
+	if len(regionsToCreate) > 0 {
+		err := regionsCreate(ctx, subId, regionsToCreate, api)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(regionsToRecreate) > 0 {
+		err := regionsDelete(ctx, subId, regionsToRecreate, api)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		err = regionsCreate(ctx, subId, regionsToRecreate, api)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(regionsToUpdateDatabases) > 0 {
+		err = regionsUpdateDatabases(ctx, subId, api, regionsToUpdateDatabases, existingRegionMap)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(regionsToDelete) > 0 {
+		if !deleteRegionsFlag {
+			return diag.Errorf("Region has been removed, but delete_regions flag was not set!")
+		}
+
+		err := regionsDelete(ctx, subId, regionsToDelete, api)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceRedisCloudActiveActiveRegionRead(ctx, d, meta)
+}
+
+func resourceRedisCloudActiveActiveRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*apiClient)
+
+	subId, err := strconv.Atoi(d.Id())
+	existingRegions, err := api.client.Regions.List(ctx, subId)
 	if err != nil {
+		if _, ok := err.(*subscriptions.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
-	d.SetId(strconv.Itoa(subId))
+	if err := d.Set("subscription_id", strconv.Itoa(*existingRegions.SubscriptionId)); err != nil {
+		return diag.FromErr(err)
+	}
 
-	return diags
+	if err := d.Set("region", buildResourceDataFromAPIRegions(existingRegions.Regions, d.Get("region").(*schema.Set))); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
 }
 
-func regionCreate(ctx context.Context, subId int, createRegions []*regions.Region, api *apiClient) error {
+// Does nothing
+func resourceRedisCloudActiveActiveRegionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudActiveActiveRegionRead(ctx, d, meta)
+}
+
+func regionsCreate(ctx context.Context, subId int, regionsToCreate []*regions.Region, api *apiClient) error {
 	// If no new regions were defined return
-	if len(createRegions) == 0 {
+	if len(regionsToCreate) == 0 {
 		return nil
 	}
 
 	// Call GO API createRegion for all non-existing regions
-	for _, currentRegion := range createRegions {
+	for _, currentRegion := range regionsToCreate {
 		createDatabases := make([]*regions.CreateDatabase, 0)
 		for _, database := range currentRegion.Databases {
 			localThroughputMeasurement := regions.CreateLocalThroughput{
@@ -194,168 +285,65 @@ func regionCreate(ctx context.Context, subId int, createRegions []*regions.Regio
 		if err != nil {
 			return err
 		}
-	}
 
-	subscriptionMutex.Lock(subId)
-	defer subscriptionMutex.Unlock(subId)
+		subscriptionMutex.Lock(subId)
 
-	// Wait for the subscription to be active before deleting it.
-	if err := waitForSubscriptionToBeActive(ctx, subId, api); err != nil {
-		return err
-	}
+		// Wait for the subscription to be active before deleting it.
+		if err := waitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+			return err
+		}
 
-	// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
-	// This additional wait ensures that the databases are deleted before the subscription is deleted.
-	time.Sleep(10 * time.Second) //lintignore:R018
-	if err := waitForSubscriptionToBeActive(ctx, subId, api); err != nil {
-		return err
+		// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
+		// This additional wait ensures that the databases are deleted before the subscription is deleted.
+		time.Sleep(10 * time.Second) //lintignore:R018
+		if err := waitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+			return err
+		}
+
+		subscriptionMutex.Unlock(subId)
 	}
 
 	return nil
 }
 
-func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*apiClient)
-	var diags diag.Diagnostics
-
-	subId, err := strconv.Atoi(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Get existing regions so we can do a manual diff
-	// Query API for existing Regions for a given Subscription
-	existingRegions, err := api.client.Regions.List(ctx, subId)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Create an existingRegionMap<regionName, region>
-	existingRegionMap := make(map[string]*regions.Region)
-	for _, existingRegion := range existingRegions.Regions {
-		existingRegionMap[*existingRegion.Region] = existingRegion
-	}
-
-	regionsFromResourceData := buildCreateActiveActiveRegions(d.Get("region").(*schema.Set))
-
-	// Handling Delete Regions
-	deleteRegions := make([]*regions.Region, 0)
-	regionsToKeepMap := make(map[string]*regions.Region)
-	for _, regionToKeep := range regionsFromResourceData {
-		regionsToKeepMap[*regionToKeep.Region] = regionToKeep
-	}
-
-	for _, currentRegion := range existingRegions.Regions {
-		if _, ok := regionsToKeepMap[*currentRegion.Region]; !ok {
-			deleteRegions = append(deleteRegions, currentRegion)
-		}
-	}
-
-	deleteRegionsFlag := d.Get("delete_regions").(bool)
-	// Validations
-	if len(deleteRegions) > 0 && !deleteRegionsFlag {
-		return diag.Errorf("Region has been removed, but delete_regions flag was not set!")
-	}
-
-	if deleteRegionsFlag && len(deleteRegions) > 0 {
-		regionDelete(ctx, subId, deleteRegions, meta)
-		// Updating existing region map
-		for _, removedRegion := range deleteRegions {
-			delete(existingRegionMap, *removedRegion.Region)
-		}
-	}
-
-	// Handling region create
-	// Filter non-existing regions
-	createRegions := make([]*regions.Region, 0)
-	for _, currentRegion := range regionsFromResourceData {
-		if _, ok := existingRegionMap[*currentRegion.Region]; !ok {
-			createRegions = append(createRegions, currentRegion)
-		}
-	}
-	if len(createRegions) > 0 {
-		err := regionCreate(ctx, subId, createRegions, api)
-		if err != nil {
-			return diag.FromErr(err)
+func regionsUpdateDatabases(ctx context.Context, subId int, api *apiClient, regionsToUpdateDatabases []*regions.Region, existingRegionMap map[string]*regions.Region) error {
+	databaseUpdates := make(map[int][]*databases.LocalRegionProperties)
+	for _, desiredRegion := range regionsToUpdateDatabases {
+		// Collect existing databases to a map <dbId, db>
+		existingDBMap := make(map[int]*regions.Database)
+		for _, db := range existingRegionMap[*desiredRegion.Region].Databases {
+			existingDBMap[*db.DatabaseId] = db
 		}
 
-		// Updating existing region map
-		for _, newRegion := range createRegions {
-			existingRegionMap[*newRegion.Region] = newRegion
-		}
-	}
-
-	for _, currentRegion := range regionsFromResourceData {
-		if !*currentRegion.RecreateRegion && *existingRegionMap[*currentRegion.Region].DeploymentCIDR != *currentRegion.DeploymentCIDR {
-			return diag.Errorf("Region %s needs to be recreated but recreate_region flag was not set!", *currentRegion.Region)
-		}
-	}
-
-	// Handling region re-create
-	reCreateRegions := make([]*regions.Region, 0)
-	for _, currentRegion := range regionsFromResourceData {
-		existingRegion := existingRegionMap[*currentRegion.Region]
-		if !cmp.Equal(existingRegion, currentRegion) {
-			if shouldRecreateRegion(existingRegion, currentRegion, deleteRegionsFlag) {
-				reCreateRegions = append(reCreateRegions, currentRegion)
-			}
-		}
-	}
-
-	if len(reCreateRegions) > 0 {
-		regionDelete(ctx, subId, reCreateRegions, meta)
-		resourceRedisCloudActiveActiveRegionCreate(ctx, d, meta)
-	}
-
-	// Handling DB updates
-	err = performDbUpdates(ctx, api, subId, regionsFromResourceData, existingRegionMap)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return diags
-}
-
-func performDbUpdates(ctx context.Context, api *apiClient, subId int, regionsFromResourceData []*regions.Region, existingRegionMap map[string]*regions.Region) error {
-	updateDBMap := make(map[int][]*databases.LocalRegionProperties)
-	for _, currentRegion := range regionsFromResourceData {
-		existingRegion := existingRegionMap[*currentRegion.Region]
-		if shouldUpdateDatabaseOnly(existingRegion, currentRegion) {
-			// Collect databases to a map <dbId, db>
-			existingDBMap := make(map[int]*regions.Database)
-			for _, db := range existingRegion.Databases {
-				existingDBMap[*db.DatabaseId] = db
-			}
-
-			for _, db := range currentRegion.Databases {
-				if !cmp.Equal(db, existingDBMap[*db.DatabaseId]) {
-					localThroughput := databases.LocalThroughput{
-						Region:                   currentRegion.Region,
-						WriteOperationsPerSecond: db.WriteOperationsPerSecond,
-						ReadOperationsPerSecond:  db.ReadOperationsPerSecond,
-					}
-					localRegionProperty := databases.LocalRegionProperties{
-						Region:                     currentRegion.Region,
-						LocalThroughputMeasurement: &localThroughput,
-					}
-					updateDBMap[*db.DatabaseId] = append(updateDBMap[*db.DatabaseId], &localRegionProperty)
+		for _, db := range desiredRegion.Databases {
+			if !reflect.DeepEqual(db, existingDBMap[*db.DatabaseId]) {
+				localThroughput := databases.LocalThroughput{
+					Region:                   desiredRegion.Region,
+					WriteOperationsPerSecond: db.WriteOperationsPerSecond,
+					ReadOperationsPerSecond:  db.ReadOperationsPerSecond,
 				}
+				localRegionProperty := databases.LocalRegionProperties{
+					Region:                     desiredRegion.Region,
+					LocalThroughputMeasurement: &localThroughput,
+				}
+				databaseUpdates[*db.DatabaseId] = append(databaseUpdates[*db.DatabaseId], &localRegionProperty)
 			}
 		}
 	}
 
-	if len(updateDBMap) > 0 {
-		for dbId, localRegionProperties := range updateDBMap {
-			updateActiveActiveDb := databases.UpdateActiveActiveDatabase{
+	if len(databaseUpdates) > 0 {
+		for dbId, localRegionProperties := range databaseUpdates {
+			dbUpdate := databases.UpdateActiveActiveDatabase{
 				Regions: localRegionProperties,
 			}
-			err := api.client.Database.ActiveActiveUpdate(ctx, subId, dbId, updateActiveActiveDb)
+			err := api.client.Database.ActiveActiveUpdate(ctx, subId, dbId, dbUpdate)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
+	// TODO: check mutex is locked early enough
 	subscriptionMutex.Lock(subId)
 	defer subscriptionMutex.Unlock(subId)
 
@@ -374,51 +362,13 @@ func performDbUpdates(ctx context.Context, api *apiClient, subId int, regionsFro
 	return nil
 }
 
-func resourceRedisCloudActiveActiveRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*apiClient)
-
-	var diags diag.Diagnostics
-
-	subId, err := strconv.Atoi(d.Id())
-	regions, err := api.client.Regions.List(ctx, subId)
-	if err != nil {
-		if _, ok := err.(*subscriptions.NotFound); ok {
-			d.SetId("")
-			return diags
-		}
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("subscription_id", strconv.Itoa(*regions.SubscriptionId)); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("region", buildActiveActiveRegionsResourceData(regions.Regions, d)); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return diags
-}
-
-// Does nothing
-func resourceRedisCloudActiveActiveRegionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceRedisCloudActiveActiveRegionRead(ctx, d, meta)
-}
-
-func regionDelete(ctx context.Context, subId int, regionsToDelete []*regions.Region, meta interface{}) error {
-	// use the meta value to retrieve your client from the provider configure method
-	api := meta.(*apiClient)
-
-	var deleteRegionArray []*regions.DeleteRegion
+func regionsDelete(ctx context.Context, subId int, regionsToDelete []*regions.Region, api *apiClient) error {
+	deleteRegions := regions.DeleteRegions{}
 	for _, region := range regionsToDelete {
 		deleteRegion := regions.DeleteRegion{
 			Region: region.Region,
 		}
-		deleteRegionArray = append(deleteRegionArray, &deleteRegion)
-	}
-
-	deleteRegions := regions.DeleteRegions{
-		Regions: deleteRegionArray,
+		deleteRegions.Regions = append(deleteRegions.Regions, &deleteRegion)
 	}
 
 	err := api.client.Regions.DeleteWithQuery(ctx, subId, deleteRegions)
@@ -444,80 +394,77 @@ func regionDelete(ctx context.Context, subId int, regionsToDelete []*regions.Reg
 	return nil
 }
 
-func buildActiveActiveRegionsResourceData(regions []*regions.Region, d *schema.ResourceData) []map[string]interface{} {
-	var resourceDataMap []map[string]interface{}
+func buildResourceDataFromAPIRegions(regionsFromAPI []*regions.Region, regionsFromConfig *schema.Set) []map[string]interface{} {
+	var result []map[string]interface{}
 
-	resDataRegionsMap := d.Get("region").(*schema.Set)
-	regionByRegionIdMap := make(map[string]bool)
-	for _, resDataRegion := range resDataRegionsMap.List() {
-		resDataRegionMap := resDataRegion.(map[string]interface{})
-		regionByRegionIdMap[resDataRegionMap["region"].(string)] = resDataRegionMap["recreate_region"].(bool)
+	recreateRegions := make(map[string]bool)
+	for _, element := range regionsFromConfig.List() {
+		r := element.(map[string]interface{})
+		recreateRegions[r["region"].(string)] = r["recreate_region"].(bool)
 	}
 
-	for _, currentRegion := range regions {
-		var databases []interface{}
-		for _, database := range currentRegion.Databases {
-			datbaseMapString := map[string]interface{}{
+	for _, region := range regionsFromAPI {
+		var dbs []interface{}
+		for _, database := range region.Databases {
+			databaseMapString := map[string]interface{}{
 				"id":                                database.DatabaseId,
 				"database_name":                     database.DatabaseName,
 				"local_read_operations_per_second":  database.ReadOperationsPerSecond,
 				"local_write_operations_per_second": database.WriteOperationsPerSecond,
 			}
-			databases = append(databases, datbaseMapString)
+			dbs = append(dbs, databaseMapString)
 		}
 
 		regionMapString := map[string]interface{}{
-			"region_id":                  currentRegion.RegionId,
-			"region":                     currentRegion.Region,
-			"recreate_region":            regionByRegionIdMap[*currentRegion.Region],
-			"networking_deployment_cidr": currentRegion.DeploymentCIDR,
-			"vpc_id":                     currentRegion.VpcId,
-			"database":                   databases,
+			"region_id":                  region.RegionId,
+			"region":                     region.Region,
+			"recreate_region":            recreateRegions[*region.Region],
+			"networking_deployment_cidr": region.DeploymentCIDR,
+			"vpc_id":                     region.VpcId,
+			"database":                   dbs,
 		}
-		resourceDataMap = append(resourceDataMap, regionMapString)
+		result = append(result, regionMapString)
 	}
 
-	return resourceDataMap
+	return result
 }
 
-func buildCreateActiveActiveRegions(r *schema.Set) []*regions.Region {
-	createRegions := make([]*regions.Region, 0)
-	for _, region := range r.List() {
-		regionMap := region.(map[string]interface{})
+func buildRegionsFromResourceData(rd *schema.Set) map[string]*regions.Region {
+	result := make(map[string]*regions.Region)
+	for _, r := range rd.List() {
+		regionMap := r.(map[string]interface{})
 
-		// CreateDatabases
-		createDatabases := make([]*regions.Database, 0)
-		if databases := regionMap["database"].(*schema.Set).List(); len(databases) != 0 {
-			for _, database := range databases {
-				databaseMap := database.(map[string]interface{})
-				createDatabase := regions.Database{
-					DatabaseId:               redis.Int(databaseMap["id"].(int)),
-					DatabaseName:             redis.String(databaseMap["database_name"].(string)),
-					ReadOperationsPerSecond:  redis.Int(databaseMap["local_read_operations_per_second"].(int)),
-					WriteOperationsPerSecond: redis.Int(databaseMap["local_write_operations_per_second"].(int)),
-				}
-				createDatabases = append(createDatabases, &createDatabase)
+		dbs := make([]*regions.Database, 0)
+		for _, database := range regionMap["database"].(*schema.Set).List() {
+			databaseMap := database.(map[string]interface{})
+			db := regions.Database{
+				DatabaseId:               redis.Int(databaseMap["id"].(int)),
+				DatabaseName:             redis.String(databaseMap["database_name"].(string)),
+				ReadOperationsPerSecond:  redis.Int(databaseMap["local_read_operations_per_second"].(int)),
+				WriteOperationsPerSecond: redis.Int(databaseMap["local_write_operations_per_second"].(int)),
 			}
+			dbs = append(dbs, &db)
 		}
 
-		createRegion := regions.Region{
+		region := regions.Region{
 			Region:         redis.String(regionMap["region"].(string)),
 			RecreateRegion: redis.Bool(regionMap["recreate_region"].(bool)),
 			DeploymentCIDR: redis.String(regionMap["networking_deployment_cidr"].(string)),
 			VpcId:          redis.String(regionMap["vpc_id"].(string)),
-			Databases:      createDatabases,
+			Databases:      dbs,
 		}
 
-		createRegions = append(createRegions, &createRegion)
+		result[*region.Region] = &region
 	}
 
-	return createRegions
+	return result
 }
 
-func shouldRecreateRegion(existingRegion *regions.Region, resourceDataRegion *regions.Region, deleteRegionsFlag bool) bool {
-	return (*existingRegion.DeploymentCIDR != *resourceDataRegion.DeploymentCIDR) && *resourceDataRegion.RecreateRegion && deleteRegionsFlag
+func shouldRecreateRegion(existingRegion *regions.Region, desiredRegion *regions.Region) bool {
+	return *existingRegion.DeploymentCIDR != *desiredRegion.DeploymentCIDR
 }
 
-func shouldUpdateDatabaseOnly(existingRegion *regions.Region, resourceDataRegion *regions.Region) bool {
-	return *existingRegion.DeploymentCIDR == *resourceDataRegion.DeploymentCIDR && !cmp.Equal(existingRegion.Databases, resourceDataRegion.Databases) && !*resourceDataRegion.RecreateRegion
+func shouldUpdateRegionDatabases(existingRegion *regions.Region, desiredRegion *regions.Region) bool {
+	return !shouldRecreateRegion(existingRegion,
+		desiredRegion) && !reflect.DeepEqual(existingRegion.Databases, desiredRegion.Databases)
 }

--- a/internal/provider/resource_rediscloud_active_active_region_test.go
+++ b/internal/provider/resource_rediscloud_active_active_region_test.go
@@ -101,7 +101,7 @@ func TestAccResourceRedisCloudActiveActiveRegion_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region.0.region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "region.0.networking_deployment_cidr", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(resourceName, "region.1.region", "eu-west-1"),
-					resource.TestCheckResourceAttr(resourceName, "region.1.networking_deployment_cidr", "10.1.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "region.1.networking_deployment_cidr", "10.2.0.0/24"),
 				),
 			},
 			{
@@ -341,7 +341,7 @@ resource "rediscloud_active_active_subscription_regions" "example" {
 	}
 	region {
 	  region = "eu-west-1"
-	  networking_deployment_cidr = "10.1.0.0/24"
+	  networking_deployment_cidr = "10.2.0.0/24"
 	  recreate_region = false
 	  database {
 		id = rediscloud_active_active_subscription_database.example.db_id

--- a/internal/provider/resource_rediscloud_active_active_subscription.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription.go
@@ -71,8 +71,9 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 			"cloud_provider": {
 				Description:      "A cloud provider string either GCP or AWS",
 				Type:             schema.TypeString,
-				Required:         true,
 				ForceNew:         true,
+				Optional:         true,
+				Default:          "AWS",
 				ValidateDiagFunc: validateDiagFunc(validation.StringMatch(regexp.MustCompile("^(GCP|AWS)$"), "must be 'GCP' or 'AWS'")),
 			},
 			"creation_plan": {


### PR DESCRIPTION
This PR fixes two issues:
1. The memory limit in the subscription creation plan was harcoded to 1000GB
2. The regions resource was producing a "subscription not active" error when modifying a few regions

I have also done some refactoring to simplify the regions resource, hopefully making the execution flows easier to follow, in order to allow me to fix the second issue. The create and update functions are now the same code, and I've tweaked some of the function signatures to make the different phases of the update more explicit in the code. The main behavioural change, other than fixing the error, is that the `delete_regions` protection flags now also apply in the create phase, as well as the update phase. However this seems to make sense to me intuitively I think? If you've disabled region deletion, to avoid accidentally deleting anything, then this should apply whether you're running Terraform for the first time, or a subsequent update in my opinion.

I have left a TODO in, for which I would love some clarification. The subscription mutex seems to be used in different ways, and I'd like to make sure it's correct before merging this. It seems to be mainly used before the "wait for subscription to be active" operation. However, in my mind, it seems like it should also encompass the actual modification operation? For example, in the `regionCreate` function, it seems like it should obtain the lock before creating the region, and release it once the subscription is active instead of only obtaining it after the region creation has succeeded.