### PR TITLE
chore: remove go.mod `replace` for go-api and upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.17
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.1.13
+	github.com/RedisLabs/rediscloud-go-api v0.1.14
 	github.com/bflad/tfproviderlint v0.28.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
@@ -63,5 +63,3 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/RedisLabs/rediscloud-go-api => github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4 h1:ZP+mp8WDMBHg3WUMrw47MJF5PJSrNFlO2B9O7ojymbc=
-github.com/RedisLabs/rediscloud-go-api v0.1.14-0.20230125162827-9a3ae6aaa2f4/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
+github.com/RedisLabs/rediscloud-go-api v0.1.14 h1:jxv8ZXfkIuBryvoN+/sRJPsQuCr9ycSiErzdcO6e63c=
+github.com/RedisLabs/rediscloud-go-api v0.1.14/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
Forgot to update in #320 before merging 🤦🏻‍♂️

There was a temporary `replace` directive pointing to a PR in the Redis go-api. I have since merged that PR so need to remove the temporary redirect and point to the latest tag instead