### PR TITLE
refactor: remove support_oss_cluster_api from subscription creation plan

### DIFF
--- a/docs/resources/rediscloud_active_active_subscription.md
+++ b/docs/resources/rediscloud_active_active_subscription.md
@@ -34,7 +34,6 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 	  memory_limit_in_gb = 1
 	  quantity = 1
-	  support_oss_cluster_api=false
 	  region {
 		  region = "us-east-1"
 		  networking_deployment_cidr = "192.168.0.0/24"
@@ -72,7 +71,6 @@ only with Redis Labs internal cloud account
 The `creation_plan` block supports:
 
 * `memory_limit_in_gb` - (Required) Maximum memory usage that will be used for your largest planned database.
-* `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 * `quantity` - (Required) The planned number of databases in the subscription.
 
 

--- a/internal/provider/resource_rediscloud_active_active_region_test.go
+++ b/internal/provider/resource_rediscloud_active_active_region_test.go
@@ -127,7 +127,6 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 		memory_limit_in_gb = 1
 		quantity = 1
-		support_oss_cluster_api=false
 		region {
 			region = "us-east-1"
 			networking_deployment_cidr = "10.0.0.0/24"

--- a/internal/provider/resource_rediscloud_active_active_subscription_database_test.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_database_test.go
@@ -155,7 +155,6 @@ const activeActiveSubscriptionBoilerplate = `
 	creation_plan {
 	  memory_limit_in_gb = 1
 	  quantity = 1
-	  support_oss_cluster_api=false
 	  region {
 		  region = "us-east-1"
 		  networking_deployment_cidr = "192.168.0.0/24"

--- a/internal/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -123,7 +123,6 @@ resource "rediscloud_active_active_subscription" "example" {
     creation_plan {
         memory_limit_in_gb = 1
         quantity = 1
-        support_oss_cluster_api = false
         region {
             region = "us-east-1"
             networking_deployment_cidr = "192.168.0.0/24"
@@ -162,7 +161,6 @@ resource "rediscloud_subscription" "example" {
   creation_plan {
 	  memory_limit_in_gb = 1
 	  quantity = 1
-	  support_oss_cluster_api=false
 	  region {
 		  region = "us-east-1"
 		  networking_deployment_cidr = "192.168.0.0/24"

--- a/internal/provider/resource_rediscloud_active_active_subscription_test.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_test.go
@@ -41,7 +41,6 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.memory_limit_in_gb", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.quantity", "1"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "false"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
@@ -79,7 +78,6 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.memory_limit_in_gb", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.quantity", "1"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "false"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.read_operations_per_second", "1000"),
@@ -227,7 +225,6 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 		memory_limit_in_gb = 1
 		quantity = 1
-		support_oss_cluster_api=false
 		region {
 			region = "us-east-1"
 			networking_deployment_cidr = "192.168.0.0/24"
@@ -267,7 +264,6 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 	  	memory_limit_in_gb = 2
 	  	quantity = 1
-	  	support_oss_cluster_api=false
 	  	region {
 			region = "us-east-1"
 			networking_deployment_cidr = "192.168.0.0/24"
@@ -294,7 +290,6 @@ resource "rediscloud_active_active_subscription" "example" {
   creation_plan {
     memory_limit_in_gb = 2
     quantity = 1
-    support_oss_cluster_api=false
     region {
 		region = "us-east-1"
 		networking_deployment_cidr = "192.168.0.0/24"


### PR DESCRIPTION
Attribute is also on the database resource itself, and isn't copied from creation plan dbs to new dbs if they don't specify it, so should be removed from creation plan to avoid confusion