### PR TITLE
docs: fix `rediscloud_active_active_subscription_regions` naming issue

### DIFF
--- a/docs/resources/rediscloud_active_active_subscription_regions.md
+++ b/docs/resources/rediscloud_active_active_subscription_regions.md
@@ -1,14 +1,15 @@
 ---
 layout: "rediscloud"
-page_title: "Redis Cloud: rediscloud_active_active_regions"
+page_title: "Redis Cloud: rediscloud_active_active_subscription_regions"
 description: |-
   Regions resource in the Terraform provider Redis Cloud.
 ---
 
-# Resource: rediscloud_active_active_regions
+# Resource: rediscloud_active_active_subscription_regions
 
-Creates an Active Active Regions within your Redis Enterprise Cloud subscription.
-This resource is responsible for creating and managing regions within that subscription. This allows Redis Enterprise Cloud to efficiently provision your cluster within each defined region in a separate block.
+Manages regions within your Redis Enterprise Cloud Active-Active subscription.
+This resource is responsible for creating and managing regions within that subscription.
+This allows Redis Enterprise Cloud to efficiently provision your cluster within each defined region in a separate block.
 
 ## Example Usage
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -57,7 +57,7 @@ func New(version string) func() *schema.Provider {
 				"rediscloud_subscription_peering":                resourceRedisCloudSubscriptionPeering(),
 				"rediscloud_active_active_subscription_database": resourceRedisCloudActiveActiveSubscriptionDatabase(),
 				"rediscloud_active_active_subscription":          resourceRedisCloudActiveActiveSubscription(),
-				"rediscloud_active_active_subscription_regions":  resourceRedisCloudActiveActiveRegion(),
+				"rediscloud_active_active_subscription_regions":  resourceRedisCloudActiveActiveSubscriptionRegions(),
 				"rediscloud_active_active_subscription_peering":  resourceRedisCloudActiveActiveSubscriptionPeering(),
 			},
 		}

--- a/internal/provider/resource_rediscloud_active_active_subscription_regions.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_regions.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func resourceRedisCloudActiveActiveRegion() *schema.Resource {
+func resourceRedisCloudActiveActiveSubscriptionRegions() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Creates an Active Active Region and within your Redis Enterprise Cloud Account.",
 		CreateContext: resourceRedisCloudActiveActiveRegionCreate,

--- a/internal/provider/resource_rediscloud_active_active_subscription_regions_test.go
+++ b/internal/provider/resource_rediscloud_active_active_subscription_regions_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccResourceRedisCloudActiveActiveRegion_CRUDI(t *testing.T) {
+func TestAccResourceRedisCloudActiveActiveSubscriptionRegions_CRUDI(t *testing.T) {
 	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-regions-test"
 	dbName := acctest.RandomWithPrefix(testResourcePrefix) + "-regions" + "-db"
 	dbPass := acctest.RandString(20)


### PR DESCRIPTION
The `rediscloud_active_active_subscription_regions` resource was incorrectly named in the documentation. I have corrected this, and also aligned some of the naming in the code to match.