### PR TITLE
Use the correct cloud account name

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -159,7 +159,7 @@ jobs:
           REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_QA }}
           REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_QA }}
           REDISCLOUD_URL: https://api-cloudapi.qa.redislabs.com/v1
-          AWS_TEST_CLOUD_ACCOUNT_NAME: EXTERNAL-CA-2023
+          AWS_TEST_CLOUD_ACCOUNT_NAME: "${{ secrets.AWS_TEST_CLOUD_ACCOUNT_NAME }}"
 #          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_PROD }}
 #          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_PROD }}
 #          REDISCLOUD_URL: https://api.redislabs.com/v1/


### PR DESCRIPTION
Pick the cloud account name from secrets so that it can be corrected when needed.