### PR TITLE
Add `support_oss_cluster_api` and others optional

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -150,7 +150,7 @@ jobs:
             code-changes:
               - 'go.mod'
               - 'go.sum'
-              - 'internal/**'
+              - 'provider/**'
               - '*.go'
               - '.github/workflows/**'
       - run: make testacc

--- a/docs/resources/rediscloud_active_active_subscription.md
+++ b/docs/resources/rediscloud_active_active_subscription.md
@@ -62,6 +62,7 @@ The `creation_plan` block supports:
 
 * `memory_limit_in_gb` - (Required) Maximum memory usage that will be used for your largest planned database, including replication and other overhead
 * `quantity` - (Required) The planned number of databases in the subscription.
+* `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 
 The creation_plan `region` block supports:
 

--- a/docs/resources/rediscloud_subscription.md
+++ b/docs/resources/rediscloud_subscription.md
@@ -47,7 +47,6 @@ resource "rediscloud_subscription" "subscription-resource" {
     memory_limit_in_gb = 2
     quantity = 1
     replication= false
-    support_oss_cluster_api= false
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 10000
     modules = ["RediSearch", "RedisBloom"]
@@ -85,7 +84,7 @@ only with Redis Labs internal cloud account
 The `creation_plan` block supports:
 
 * `memory_limit_in_gb` - (Required) Maximum memory usage that will be used for your largest planned database.
-* `modules` - (Required) a list of modules that will be used by the databases in this subscription. Not currently compatible with ‘ram-and-flash’ memory storage.
+* `modules` - (Optional) a list of modules that will be used by the databases in this subscription. Not currently compatible with ‘ram-and-flash’ memory storage.
 Example: `modules = ["RedisJSON", RedisBloom"]`
 * `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 * `replication` - (Required) Databases replication. Set to `true` if any of your databases will use replication
@@ -108,7 +107,7 @@ The cloud_provider `region` block supports:
 * `networking_vpc_id` - (Optional) Either an existing VPC Id (already exists in the specific region) or create a new VPC
 (if no VPC is specified). VPC Identifier must be in a valid format (for example: ‘vpc-0125be68a4986384ad’) and existing
 within the hosting account.
-* `preferred_availability_zones` - (Required) Availability zones deployment preferences (for the selected provider & region). If multiple_availability_zones is set to 'true', select three availability zones from the list. If you don't want to specify preferred avaialbility zones, set this attribute to an empty list ('[]').
+* `preferred_availability_zones` - (Optional) Availability zones deployment preferences (for the selected provider & region). If multiple_availability_zones is set to 'true', select three availability zones from the list. If you don't want to specify preferred availability zones, set this attribute to an empty list ('[]').
 
 ~> **Note:** The preferred_availability_zones parameter is required for Terraform, but is optional within the Redis Enterprise Cloud UI. 
 This difference in behaviour is to guarantee that a plan after an apply does not generate differences. In AWS Redis internal cloud account, please set the zone IDs (for example: `["use-az2", "use-az3", "use-az5"]`).

--- a/provider/resource_rediscloud_active_active_subscription_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_test.go
@@ -165,6 +165,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
@@ -225,6 +226,7 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 		memory_limit_in_gb = 1
 		quantity = 1
+		support_oss_cluster_api = true
 		region {
 			region = "us-east-1"
 			networking_deployment_cidr = "192.168.0.0/24"

--- a/provider/resource_rediscloud_subscription.go
+++ b/provider/resource_rediscloud_subscription.go
@@ -167,8 +167,9 @@ func resourceRedisCloudSubscription() *schema.Resource {
 									"preferred_availability_zones": {
 										Description: "List of availability zones used",
 										Type:        schema.TypeList,
-										Required:    true,
+										Optional:    true,
 										ForceNew:    true,
+										Computed:    true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
@@ -278,7 +279,8 @@ func resourceRedisCloudSubscription() *schema.Resource {
 						"modules": {
 							Description: "Modules that will be used by the databases in this subscription.",
 							Type:        schema.TypeList,
-							Required:    true,
+							Optional:    true,
+							Computed:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -930,19 +932,6 @@ func flattenRegexRules(rules []*databases.RegexRule) []string {
 	}
 
 	return ret
-}
-
-func getDatabaseNameIdMap(ctx context.Context, subId int, client *apiClient) (map[string]int, error) {
-	ret := map[string]int{}
-	list := client.client.Database.List(ctx, subId)
-	for list.Next() {
-		db := list.Value()
-		ret[redis.StringValue(db.Name)] = redis.IntValue(db.ID)
-	}
-	if list.Err() != nil {
-		return nil, list.Err()
-	}
-	return ret, nil
 }
 
 func readPaymentMethodID(d *schema.ResourceData) (*int, error) {

--- a/provider/resource_rediscloud_subscription_database_test.go
+++ b/provider/resource_rediscloud_subscription_database_test.go
@@ -133,6 +133,27 @@ func TestAccResourceRedisCloudSubscriptionDatabase_CRUDI(t *testing.T) {
 	})
 }
 
+func TestAccResourceRedisCloudSubscriptionDatabase_optionalAttributes(t *testing.T) {
+	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	resourceName := "rediscloud_subscription_database.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionDatabaseOptionalAttributes, testCloudAccountName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
+				),
+			},
+		},
+	})
+}
+
 // Tests the multi-modules feature in a database resource.
 func TestAccResourceRedisCloudSubscriptionDatabase_MultiModules(t *testing.T) {
 	name := acctest.RandomWithPrefix(testResourcePrefix)
@@ -182,7 +203,7 @@ resource "rediscloud_subscription" "example" {
 
   allowlist {
     cidrs = ["192.168.0.0/16"]
-	security_group_ids = []
+    security_group_ids = []
   }
 
   cloud_provider {
@@ -203,7 +224,7 @@ resource "rediscloud_subscription" "example" {
     quantity = 1
     replication=false
     support_oss_cluster_api=false
-	modules = []
+    modules = []
   }
 }
 `
@@ -217,27 +238,38 @@ resource "rediscloud_subscription_database" "example" {
     protocol = "redis"
     memory_limit_in_gb = 3
     data_persistence = "none"
-	data_eviction = "allkeys-random"
+    data_eviction = "allkeys-random"
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 1000
-	password = "%s"
-	support_oss_cluster_api = false 
-	external_endpoint_for_oss_cluster_api = false
-	replication = false
-	average_item_size_in_bytes = 0
-	client_ssl_certificate = "" 
-	periodic_backup_path = ""
+    password = "%s"
+    support_oss_cluster_api = false 
+    external_endpoint_for_oss_cluster_api = false
+    replication = false
+    average_item_size_in_bytes = 0
+    client_ssl_certificate = "" 
+    periodic_backup_path = ""
 
-	alert {
-		name = "dataset-size"
-		value = 40
-	}
-	
-	modules = [
+    alert {
+        name = "dataset-size"
+        value = 40
+    }
+
+    modules = [
         {
           name = "RedisBloom"
         }
     ]
+} 
+`
+
+const testAccResourceRedisCloudSubscriptionDatabaseOptionalAttributes = subscriptionBoilerplate + `
+resource "rediscloud_subscription_database" "example" {
+    subscription_id = rediscloud_subscription.example.id
+    name = "example-no-protocol"
+    memory_limit_in_gb = 1
+    data_persistence = "none"
+    throughput_measurement_by = "operations-per-second"
+    throughput_measurement_value = 1000   
 } 
 `
 
@@ -338,7 +370,7 @@ resource "rediscloud_subscription" "example" {
 const testAccResourceRedisCloudSubscriptionDatabaseMultiModules = multiModulesSubscriptionBoilerplate + `
 resource "rediscloud_subscription_database" "example" {
     subscription_id              = rediscloud_subscription.example.id
-	name                         = "%s"
+    name                         = "%s"
     protocol                     = "redis"
     memory_limit_in_gb           = 1
     data_persistence             = "none"

--- a/provider/resource_rediscloud_subscription_test.go
+++ b/provider/resource_rediscloud_subscription_test.go
@@ -112,6 +112,27 @@ func TestAccResourceRedisCloudSubscription_CRUDI(t *testing.T) {
 	})
 }
 
+func TestAccResourceRedisCloudSubscription_preferredAZsModulesOptional(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	resourceName := "rediscloud_subscription.example"
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionPreferredAZsModulesOptional, testCloudAccountName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceRedisCloudSubscription_createUpdateContractPayment(t *testing.T) {
 
 	if !*contractFlag {
@@ -450,7 +471,7 @@ resource "rediscloud_subscription" "example" {
 
   allowlist {
     cidrs = ["192.168.0.0/16"]
-	security_group_ids = []
+    security_group_ids = []
   }
 
   cloud_provider {
@@ -471,7 +492,50 @@ resource "rediscloud_subscription" "example" {
     support_oss_cluster_api=false
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 10000
-	modules = ["RedisJSON", "RedisBloom"]
+    modules = ["RedisJSON", "RedisBloom"]
+  }
+}
+`
+
+const testAccResourceRedisCloudSubscriptionPreferredAZsModulesOptional = `
+data "rediscloud_payment_method" "card" {
+  card_type = "Visa"
+}
+
+data "rediscloud_cloud_account" "account" {
+  exclude_internal_account = true
+  provider_type = "AWS" 
+  name = "%s"
+}
+
+resource "rediscloud_subscription" "example" {
+
+  name = "%s"
+  payment_method_id = data.rediscloud_payment_method.card.id
+  memory_storage = "ram"
+
+  allowlist {
+    cidrs = ["192.168.0.0/16"]
+    security_group_ids = []
+  }
+
+  cloud_provider {
+    provider = data.rediscloud_cloud_account.account.provider_type
+    cloud_account_id = data.rediscloud_cloud_account.account.id
+    region {
+      region = "eu-west-1"
+      networking_deployment_cidr = "10.0.0.0/24"
+    }
+  }
+
+  creation_plan {
+    average_item_size_in_bytes = 1
+    memory_limit_in_gb = 1
+    quantity = 1
+    replication=false
+    support_oss_cluster_api=false
+    throughput_measurement_by = "operations-per-second"
+    throughput_measurement_value = 10000
   }
 }
 `
@@ -496,7 +560,7 @@ resource "rediscloud_subscription" "example" {
 
   allowlist {
     cidrs = ["192.168.0.0/16"]
-	security_group_ids = []
+    security_group_ids = []
   }
 
   cloud_provider {
@@ -526,7 +590,7 @@ resource "rediscloud_subscription" "example" {
 
   allowlist {
     cidrs = ["192.168.0.0/16"]
-	security_group_ids = []
+    security_group_ids = []
   }
 
   cloud_provider {
@@ -547,7 +611,7 @@ resource "rediscloud_subscription" "example" {
     support_oss_cluster_api=false
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 10000
-	modules = []
+    modules = []
   }
 }
 `
@@ -568,7 +632,7 @@ resource "rediscloud_subscription" "example" {
 
   allowlist {
     cidrs = ["192.168.0.0/16"]
-	security_group_ids = []
+    security_group_ids = []
   }
 
   cloud_provider {
@@ -589,7 +653,7 @@ resource "rediscloud_subscription" "example" {
     support_oss_cluster_api=false
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 10000
-	modules = []
+    modules = []
   }
 }
 `


### PR DESCRIPTION
This adds the `support_oss_cluster_api` attribute to the `rediscloud_active_active_subscription` resource, as well as making a number of other attributes optional:
* `rediscloud_subscription.preferred_availability_zones`
* `rediscloud_subscription.modules`
* `rediscloud_subscription_database.protocol`
* Remove `support_oss_cluster_api` from `rediscloud_subscription` example as it is optional.