### PR TITLE
Add port, remote backup & CIDRs support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,8 +9,8 @@ PROVIDER_VERSION = 99.99.99
 PLUGINS_PATH = ~/.terraform.d/plugins
 PLUGINS_PROVIDER_PATH=$(PROVIDER_HOSTNAME)/$(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE)/$(PROVIDER_VERSION)/$(PROVIDER_TARGET)
 
-# Use a parallelism of 3 by default for tests, overriding whatever GOMAXPROCS is set to.
-TEST_PARALLELISM?=3
+# Use a parallelism of 2 by default for tests, overriding whatever GOMAXPROCS is set to.
+TEST_PARALLELISM?=2
 TESTARGS?=-short
 
 BIN=$(CURDIR)/bin

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,8 +30,9 @@ clean:
 	@echo "Deleting local provider binary"
 	rm -rf $(BIN)
 
+# `-p=1` added to avoid testing packages in parallel which causes `go test` to not stream logs as they are written
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 360m -parallel=$(TEST_PARALLELISM)
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 360m -p=1 -parallel=$(TEST_PARALLELISM)
 
 install_local: build
 	@echo "Installing local provider binary to plugins mirror path $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,14 +36,14 @@ testacc:
 install_local: build
 	@echo "Installing local provider binary to plugins mirror path $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)"
 	@mkdir -p $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)
-	@cp ./$(BIN)/terraform-provider-rediscloud_v$(PROVIDER_VERSION) $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)
+	@cp $(BIN)/terraform-provider-rediscloud_v$(PROVIDER_VERSION) $(PLUGINS_PATH)/$(PLUGINS_PROVIDER_PATH)
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test ./provider -v -sweep=ALL $(SWEEPARGS) -timeout 30m
 
-tfproviderlintx: $(BIN)/tfproviderlint
+tfproviderlintx: $(BIN)/tfproviderlintx
 	$(BIN)/tfproviderlintx $(TFPROVIDERLINT_ARGS) ./...
 
-tfproviderlint: $(BIN)/tfproviderlintx
+tfproviderlint: $(BIN)/tfproviderlint
 	$(BIN)/tfproviderlint $(TFPROVIDERLINT_ARGS) ./...

--- a/docs/resources/rediscloud_active_active_subscription_database.md
+++ b/docs/resources/rediscloud_active_active_subscription_database.md
@@ -13,7 +13,7 @@ Creates a Database within a specified Active-Active Subscription in your Redis E
 
 ```hcl
 data "rediscloud_payment_method" "card" {
-	card_type = "Visa"
+  card_type = "Visa"
 }
 
 resource "rediscloud_active_active_subscription" "subscription-resource" {
@@ -24,18 +24,18 @@ resource "rediscloud_active_active_subscription" "subscription-resource" {
   creation_plan {
     memory_limit_in_gb = 1
     quantity = 1
-	region {
-		region = "us-east-1"
-		networking_deployment_cidr = "192.168.0.0/24"
-		write_operations_per_second = 1000
-		read_operations_per_second = 1000
-	}
-	region {
-		region = "us-east-2"
-		networking_deployment_cidr = "10.0.1.0/24"
-		write_operations_per_second = 1000
-		read_operations_per_second = 2000
-	}
+    region {
+      region = "us-east-1"
+      networking_deployment_cidr = "192.168.0.0/24"
+      write_operations_per_second = 1000
+      read_operations_per_second = 1000
+    }
+    region {
+      region = "us-east-2"
+      networking_deployment_cidr = "10.0.1.0/24"
+      write_operations_per_second = 1000
+      read_operations_per_second = 2000
+    }
   }
 }
 
@@ -47,23 +47,23 @@ resource "rediscloud_active_active_subscription_database" "database-resource" {
     global_password = "some-random-pass-2" 
     global_source_ips = ["192.168.0.0/16"]
     global_alert {
-	name = "dataset-size"
-	value = 40
+      name = "dataset-size"
+      value = 40
     }
 
     override_region {
-    	name = "us-east-2"
-        override_global_source_ips = ["192.10.0.0/16"]
+      name = "us-east-2"
+      override_global_source_ips = ["192.10.0.0/16"]
     }
 
     override_region {
-    	name = "us-east-1"
-    	override_global_data_persistence = "none"
-    	override_global_password = "region-specific-password"
-    	override_global_alert {
-        	name = "dataset-size"
-        	value = 60
-    	}
+      name = "us-east-1"
+      override_global_data_persistence = "none"
+      override_global_password = "region-specific-password"
+      override_global_alert {
+        name = "dataset-size"
+        value = 60
+      }
    }
 }
 
@@ -89,9 +89,10 @@ The following arguments are supported:
 * `client_ssl_certificate` - (Optional) SSL certificate to authenticate user connections.
 * `data_eviction` - (Optional) The data items eviction policy (either: 'allkeys-lru', 'allkeys-lfu', 'allkeys-random', 'volatile-lru', 'volatile-lfu', 'volatile-random', 'volatile-ttl' or 'noeviction'. Default: 'volatile-lru')
 * `global_data_persistence` - (Optional) Global rate of database data persistence (in persistent storage) of regions that dont override global settings. Default: 'none'
-* `global_password` - (Optional) Password to access the database of regions that dont override global settings. If left empty, the password will be generated automatically
-* `global_alert` - (Optional) A block defining Redis database alert of regions that dont override global settings, documented below, can be specified multiple times
-* `global_source_ips` - (Optional)  List of source IP addresses or subnet masks of regions that dont override global settings. If specified, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges (example: ['192.168.10.0/32', '192.168.12.0/24'])
+* `global_password` - (Optional) Password to access the database of regions that don't override global settings. If left empty, the password will be generated automatically
+* `global_alert` - (Optional) A block defining Redis database alert of regions that don't override global settings, documented below, can be specified multiple times
+* `global_source_ips` - (Optional)  List of source IP addresses or subnet masks of regions that don't override global settings. If specified, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges (example: ['192.168.10.0/32', '192.168.12.0/24'])
+* `port` - (Optional) TCP port on which the database is available - must be between 10000 and 19999.
 * `override_region` - (Optional) Override region specific configuration, documented below
 
 
@@ -102,11 +103,19 @@ The `override_region` block supports:
 * `override_global_password` - (Optional) If specified, this regional instance of an Active-Active database password will be used to access the database
 * `override_global_source_ips` - (Optional)  List of regional instance of an Active-Active database source IP addresses or subnet masks. If specified, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges (example: ['192.168.10.0/32', '192.168.12.0/24'] )
 * `override_global_data_persistence` - (Optional) Regional instance of an Active-Active database data persistence rate (in persistent storage)
+* `remote_backup` - (Optional) Specifies the backup options for the database in this region, documented below
 
 The `override_global_alert` block supports:
 
 * `name` - (Required) Alert name
 * `value` - (Required) Alert value
+
+The `remote_backup` block supports:
+
+* `interval` (Required) - Defines the frequency of the automatic backup
+* `time_utc` (Optional) - Defines the hour automatic backups are made - only applicable when interval is `every-12-hours` or `every-24-hours`
+* `storage_type` (Required) - Defines the provider of the storage location
+* `storage_path` (Required) - Defines a URI representing the backup storage location
 
 ### Timeouts
 
@@ -129,5 +138,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 $ terraform import rediscloud_active_active_subscription_database.database-resource 123456/12345678
 ```
 
-Note: Due to constraints in the Redis Cloud API, the import process will not import global attributes or override region attributes. If you wish to use these attributes in your Terraform configuraton, you will need to manually add them to your Terraform configuration and run `terraform apply` to update the database.
+Note: Due to constraints in the Redis Cloud API, the import process will not import global attributes or override region attributes. If you wish to use these attributes in your Terraform configuration, you will need to manually add them to your Terraform configuration and run `terraform apply` to update the database.
 

--- a/docs/resources/rediscloud_active_active_subscription_peering.md
+++ b/docs/resources/rediscloud_active_active_subscription_peering.md
@@ -77,7 +77,8 @@ The following arguments are supported:
 * `source_region` -	(Required) Name of the region to create the VPC peering from
 * `destination_region` - (Required) Name of the region to create the VPC peering to
 * `vpc_id` - (Required) Identifier of the VPC to be peered
-* `vpc_cidr` - (Required) CIDR range of the VPC to be peered 
+* `vpc_cidr` - (Optional) CIDR range of the VPC to be peered. Either this or `vpc_cidrs` must be specified
+* `vpc_cidrs` - (Optional) CIDR ranges of the VPC to be peered. Either this or `vpc_cidr` must be specified
 
 **GCP ONLY:**
 * `gcp_project_id` - (Required) GCP project ID that the VPC to be peered lives in

--- a/docs/resources/rediscloud_subscription_database.md
+++ b/docs/resources/rediscloud_subscription_database.md
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `throughput_measurement_by` - (Required) Throughput measurement method, (either ‘number-of-shards’ or ‘operations-per-second’)
 * `throughput_measurement_value` - (Required) Throughput value (as applies to selected measurement method)
 * `memory_limit_in_gb` - (Required) Maximum memory usage for this specific database
-* `protocol` - (Optional) The protocol that will be used to access the database, (either ‘redis’ or 'memcached’) Default: ‘redis’
+* `protocol` - (Optional) The protocol that will be used to access the database, (either ‘redis’ or ‘memcached’) Default: ‘redis’
 * `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 * `external_endpoint_for_oss_cluster_api` - (Optional) Should use the external endpoint for open-source (OSS) Cluster API.
   Can only be enabled if OSS Cluster API support is enabled. Default: 'false'
@@ -122,6 +122,8 @@ The following arguments are supported:
   [the documentation on clustering](https://docs.redislabs.com/latest/rc/concepts/clustering/) for more information on the
   hashing policy. This cannot be set when `support_oss_cluster_api` is set to true.
 * `enable_tls` - (Optional) Use TLS for authentication. Default: ‘false’
+* `port` - (Optional) TCP port on which the database is available - must be between 10000 and 19999.
+* `remote_backup` (Optional) Specifies the backup options for the database, documented below
 
 The `alert` block supports:
 
@@ -144,6 +146,13 @@ The `modules` list supports:
         }
     ]
   ```
+
+The `remote_backup` block supports:
+
+* `interval` (Required) - Defines the frequency of the automatic backup
+* `time_utc` (Optional) - Defines the hour automatic backups are made - only applicable when interval is `every-12-hours` or `every-24-hours`
+* `storage_type` (Required) - Defines the provider of the storage location
+* `storage_path` (Required) - Defines a URI representing the backup storage location
 
 ### Timeouts
 

--- a/docs/resources/rediscloud_subscription_peering.md
+++ b/docs/resources/rediscloud_subscription_peering.md
@@ -75,7 +75,8 @@ The following arguments are supported:
 * `aws_account_id` - (Required AWS) AWS account ID that the VPC to be peered lives in
 * `region` - (Required AWS) AWS Region that the VPC to be peered lives in
 * `vpc_id` - (Required AWS) Identifier of the VPC to be peered
-* `vpc_cidr` - (Required AWS) CIDR range of the VPC to be peered 
+* `vpc_cidr` - (Optional) CIDR range of the VPC to be peered. Either this or `vpc_cidrs` must be specified
+* `vpc_cidrs` - (Optional) CIDR ranges of the VPC to be peered. Either this or `vpc_cidr` must be specified
 
 **GCP ONLY:**
 * `gcp_project_id` - (Required GCP) GCP project ID that the VPC to be peered lives in

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.17
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.2.0
+	github.com/RedisLabs/rediscloud-go-api v0.3.0
 	github.com/bflad/tfproviderlint v0.28.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RedisLabs/rediscloud-go-api v0.2.0 h1:tkS2AIMLLlI3yeW22dT5DP2BvaYO+K7xvytJvFo8z04=
-github.com/RedisLabs/rediscloud-go-api v0.2.0/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
+github.com/RedisLabs/rediscloud-go-api v0.3.0 h1:IiQZ8uFoyZVWIRytFMykiD0ohRijmQcAI3YeAT1kEgg=
+github.com/RedisLabs/rediscloud-go-api v0.3.0/go.mod h1:EJXWMnC2ZSM5m7k2TCnmxenYv57o6yGlZXo0ZVnMgIs=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/provider/datasource_rediscloud_subscription_peerings_test.go
+++ b/provider/datasource_rediscloud_subscription_peerings_test.go
@@ -33,7 +33,7 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 	)
 	dataSourceName := "data.rediscloud_subscription_peerings.example"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPeeringPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,

--- a/provider/datasource_rediscloud_subscription_test.go
+++ b/provider/datasource_rediscloud_subscription_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceRedisCloudSubscription_basic(t *testing.T) {
 	dataSourceName := "data.rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -69,7 +69,7 @@ func New(version string) func() *schema.Provider {
 }
 
 // Lock that must be acquired when modifying something related to a subscription as only one _thing_ can modify a subscription and all sub-resources at any time
-var subscriptionMutex = NewPerIdLock()
+var subscriptionMutex = newPerIdLock()
 
 type apiClient struct {
 	client *rediscloud_api.Client

--- a/provider/resource_rediscloud_active_active_subscription_database_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_database_test.go
@@ -25,7 +25,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_CRUDI(t *testing.
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
@@ -152,7 +152,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_optionalAttribute
 	resourceName := "rediscloud_active_active_subscription_database.example"
 	portNumber := 10101
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
@@ -172,7 +172,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_timeUtcRequiresVa
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	password := acctest.RandString(20)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,

--- a/provider/resource_rediscloud_active_active_subscription_database_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_database_test.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -142,33 +144,74 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_CRUDI(t *testing.
 	})
 }
 
+func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_optionalAttributes(t *testing.T) {
+	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
+	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-subscription"
+	name := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	password := acctest.RandString(20)
+	resourceName := "rediscloud_active_active_subscription_database.example"
+	portNumber := 10101
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudActiveActiveSubscriptionDatabaseOptionalAttributes, subscriptionName, name, password, portNumber),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "port", strconv.Itoa(portNumber)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceRedisCloudActiveActiveSubscriptionDatabase_timeUtcRequiresValidInterval(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	password := acctest.RandString(20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccResourceRedisCloudActiveActiveSubscriptionDatabaseInvalidTimeUtc, testCloudAccountName, name, password),
+				ExpectError: regexp.MustCompile("unexpected value at override_region\\.\\d*\\.remote_backup\\.0\\.time_utc - time_utc can only be set when interval is either every-24-hours or every-12-hours"),
+			},
+		},
+	})
+}
+
 const activeActiveSubscriptionBoilerplate = `
 	data "rediscloud_payment_method" "card" {
 		card_type = "Visa"
 	}
-  
-  resource "rediscloud_active_active_subscription" "example" {
-	name = "%s"
-	payment_method_id = data.rediscloud_payment_method.card.id
-	cloud_provider = "AWS"
-   
-	creation_plan {
-	  memory_limit_in_gb = 1
-	  quantity = 1
-	  region {
-		  region = "us-east-1"
-		  networking_deployment_cidr = "192.168.0.0/24"
-		  write_operations_per_second = 1000
-		  read_operations_per_second = 1000
-	  }
-	  region {
-		  region = "us-east-2"
-		  networking_deployment_cidr = "10.0.1.0/24"
-		  write_operations_per_second = 1000
-		  read_operations_per_second = 1000
-	  }
+
+	resource "rediscloud_active_active_subscription" "example" {
+		name = "%s"
+		payment_method_id = data.rediscloud_payment_method.card.id
+		cloud_provider = "AWS"
+
+		creation_plan {
+			memory_limit_in_gb = 1
+			quantity = 1
+			region {
+				region = "us-east-1"
+				networking_deployment_cidr = "192.168.0.0/24"
+				write_operations_per_second = 1000
+				read_operations_per_second = 1000
+			}
+			region {
+				region = "us-east-2"
+				networking_deployment_cidr = "10.0.1.0/24"
+				write_operations_per_second = 1000
+				read_operations_per_second = 1000
+			}
+		}
 	}
-  }
 `
 
 // Create and Read tests
@@ -239,3 +282,74 @@ resource "rediscloud_active_active_subscription_database" "example" {
     memory_limit_in_gb = 1
 	} 
 	`
+
+const testAccResourceRedisCloudActiveActiveSubscriptionDatabaseOptionalAttributes = activeActiveSubscriptionBoilerplate + `
+resource "rediscloud_active_active_subscription_database" "example" {
+	subscription_id = rediscloud_active_active_subscription.example.id
+	name = "%s"
+	memory_limit_in_gb = 3
+	support_oss_cluster_api = false 
+	external_endpoint_for_oss_cluster_api = false
+	enable_tls = false
+
+	global_data_persistence = "none"
+	global_password = "%s" 
+	global_source_ips = ["192.168.0.0/16", "192.170.0.0/16"]
+	global_alert {
+		name = "dataset-size"
+		value = 40
+	}
+	override_region {
+		name = "us-east-1"
+		override_global_data_persistence = "aof-every-write"
+		override_global_source_ips = ["192.175.0.0/16"]
+		override_global_password = "region-specific-password"
+		override_global_alert {
+			name = "dataset-size"
+			value = 42
+		}
+	}
+	override_region {
+		name = "us-east-2"
+	}
+	port = %d
+} 
+`
+
+const testAccResourceRedisCloudActiveActiveSubscriptionDatabaseInvalidTimeUtc = activeActiveSubscriptionBoilerplate + `
+resource "rediscloud_active_active_subscription_database" "example" {
+	subscription_id = rediscloud_active_active_subscription.example.id
+	name = "%s"
+	memory_limit_in_gb = 3
+	support_oss_cluster_api = false 
+	external_endpoint_for_oss_cluster_api = false
+	enable_tls = false
+
+	global_data_persistence = "none"
+	global_password = "%s" 
+	global_source_ips = ["192.168.0.0/16", "192.170.0.0/16"]
+	global_alert {
+		name = "dataset-size"
+		value = 40
+	}
+	override_region {
+		name = "us-east-1"
+		override_global_data_persistence = "aof-every-write"
+		override_global_source_ips = ["192.175.0.0/16"]
+		override_global_password = "region-specific-password"
+		override_global_alert {
+			name = "dataset-size"
+			value = 42
+		}
+		remote_backup {
+			interval = "every-6-hours"
+			time_utc = "16:00"
+			storage_type = "aws-s3"
+			storage_path = "uri://interval.not.12.or.24.hours.test"
+		}
+	}
+	override_region {
+		name = "us-east-2"
+	}
+} 
+`

--- a/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -59,6 +59,8 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_aws(t *testing.T) 
 					resource.TestCheckResourceAttrSet(resourceName, "aws_account_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", cidrRange),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.0", cidrRange),
 					resource.TestCheckResourceAttrSet(resourceName, "source_region"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_region"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_peering_id"),

--- a/provider/resource_rediscloud_active_active_subscription_regions_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_regions_test.go
@@ -20,7 +20,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionRegions_CRUDI(t *testing.T
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,

--- a/provider/resource_rediscloud_active_active_subscription_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_test.go
@@ -28,7 +28,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
@@ -117,7 +117,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateContractPayme
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	resourceName := "rediscloud_active_active_subscription.example"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,
@@ -155,7 +155,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	resourceName := "rediscloud_active_active_subscription.example"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckActiveActiveSubscriptionDestroy,

--- a/provider/resource_rediscloud_subscription_database_test.go
+++ b/provider/resource_rediscloud_subscription_database_test.go
@@ -26,7 +26,7 @@ func TestAccResourceRedisCloudSubscriptionDatabase_CRUDI(t *testing.T) {
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -141,7 +141,7 @@ func TestAccResourceRedisCloudSubscriptionDatabase_optionalAttributes(t *testing
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	portNumber := 10101
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -161,7 +161,7 @@ func TestAccResourceRedisCloudSubscriptionDatabase_timeUtcRequiresValidInterval(
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,

--- a/provider/resource_rediscloud_subscription_database_test.go
+++ b/provider/resource_rediscloud_subscription_database_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -138,6 +139,7 @@ func TestAccResourceRedisCloudSubscriptionDatabase_optionalAttributes(t *testing
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	resourceName := "rediscloud_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	portNumber := 10101
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
@@ -145,10 +147,28 @@ func TestAccResourceRedisCloudSubscriptionDatabase_optionalAttributes(t *testing
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionDatabaseOptionalAttributes, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionDatabaseOptionalAttributes, testCloudAccountName, name, portNumber),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "port", strconv.Itoa(portNumber)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceRedisCloudSubscriptionDatabase_timeUtcRequiresValidInterval(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionDatabaseInvalidTimeUtc, testCloudAccountName, name),
+				ExpectError: regexp.MustCompile("unexpected value at remote_backup\\.0\\.time_utc - time_utc can only be set when interval is either every-24-hours or every-12-hours"),
 			},
 		},
 	})
@@ -269,7 +289,25 @@ resource "rediscloud_subscription_database" "example" {
     memory_limit_in_gb = 1
     data_persistence = "none"
     throughput_measurement_by = "operations-per-second"
-    throughput_measurement_value = 1000   
+    throughput_measurement_value = 1000
+    port = %d
+} 
+`
+
+const testAccResourceRedisCloudSubscriptionDatabaseInvalidTimeUtc = subscriptionBoilerplate + `
+resource "rediscloud_subscription_database" "example" {
+    subscription_id = rediscloud_subscription.example.id
+    name = "example-no-protocol"
+    memory_limit_in_gb = 1
+    data_persistence = "none"
+    throughput_measurement_by = "operations-per-second"
+    throughput_measurement_value = 1000
+    remote_backup {
+        interval = "every-6-hours"
+        time_utc = "16:00"
+        storage_type = "aws-s3"
+        storage_path = "uri://interval.not.12.or.24.hours.test"
+    }
 } 
 `
 

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -62,7 +62,9 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_account_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", cidrRange),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.0", cidrRange),
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_peering_id"),
 				),
@@ -168,7 +170,6 @@ resource "rediscloud_subscription" "example" {
     support_oss_cluster_api=false
     throughput_measurement_by = "operations-per-second"
     throughput_measurement_value = 10000
-	modules = []
   }
 }
 
@@ -178,7 +179,7 @@ resource "rediscloud_subscription_peering" "test" {
   region = "%s"
   aws_account_id = "%s"
   vpc_id = "%s"
-  vpc_cidr = "%s"
+  vpc_cidrs = ["%s"]
 }
 `
 

--- a/provider/resource_rediscloud_subscription_test.go
+++ b/provider/resource_rediscloud_subscription_test.go
@@ -31,7 +31,7 @@ func TestAccResourceRedisCloudSubscription_CRUDI(t *testing.T) {
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -117,7 +117,7 @@ func TestAccResourceRedisCloudSubscription_preferredAZsModulesOptional(t *testin
 	resourceName := "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -144,7 +144,7 @@ func TestAccResourceRedisCloudSubscription_createUpdateContractPayment(t *testin
 	resourceName := "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -181,7 +181,7 @@ func TestAccResourceRedisCloudSubscription_createUpdateMarketplacePayment(t *tes
 	resourceName := "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,

--- a/provider/resource_rediscloud_subscription_tls_test.go
+++ b/provider/resource_rediscloud_subscription_tls_test.go
@@ -42,7 +42,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndSs
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAwsPreExistingCloudAccountPreCheck(t)
@@ -124,7 +124,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndEm
 
 	var subId int
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckSubscriptionDestroy,
@@ -203,7 +203,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseWithEnabledTlsAndIn
 
 	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAwsPreExistingCloudAccountPreCheck(t)
@@ -233,7 +233,7 @@ func TestAccResourceRedisCloudSubscription_createWithDatabaseAndDisabledTlsAndIn
 
 	invalidClientSslCertificate := os.Getenv("SSL_CERTIFICATE_INVALID")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAwsPreExistingCloudAccountPreCheck(t)

--- a/provider/utils_test.go
+++ b/provider/utils_test.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsTime(t *testing.T) {
+	tests := []struct {
+		input  string
+		errors bool
+	}{
+		{"0:00", false},
+		{"09:00", false},
+		{"12:00", false},
+		{"24:00", true},    // '24' isn't a valid hour
+		{"12:00:00", true}, // seconds are invalid
+		{"blah", true},     // Not a valid time
+		{"", true},         // Nothing
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actual := isTime()(test.input, nil)
+			assert.Equal(t, test.errors, actual.HasError(), "%+v", actual)
+		})
+	}
+}


### PR DESCRIPTION
Add support for:
* Specifying the port number on a normal or active/active database
* Configuring backups for normal or active/active databases
* Specifying multiple CIDR ranges when peering a normal or active/active database