### PR TITLE
Remove `support_oss_cluster_api` from a/a sub

### DIFF
--- a/docs/resources/rediscloud_active_active_subscription.md
+++ b/docs/resources/rediscloud_active_active_subscription.md
@@ -62,7 +62,6 @@ The `creation_plan` block supports:
 
 * `memory_limit_in_gb` - (Required) Maximum memory usage that will be used for your largest planned database, including replication and other overhead
 * `quantity` - (Required) The planned number of databases in the subscription.
-* `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
 
 The creation_plan `region` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bflad/tfproviderlint v0.29.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
-	github.com/stretchr/testify v1.8.3
+	github.com/stretchr/testify v1.8.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -104,12 +104,6 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
-						"support_oss_cluster_api": {
-							Description: "Support Redis open-source (OSS) Cluster API",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-						},
 						"region": {
 							Description: "Cloud networking details, per region (multiple regions for Active-Active cluster)",
 							Type:        schema.TypeSet,
@@ -416,7 +410,6 @@ func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*s
 	numDatabases := planMap["quantity"].(int)
 	memoryLimitInGB := planMap["memory_limit_in_gb"].(float64)
 	regions := planMap["region"]
-	supportOSSClusterAPI := planMap["support_oss_cluster_api"].(bool)
 	var localThroughputs []*subscriptions.CreateLocalThroughput
 	for _, v := range regions.(*schema.Set).List() {
 		region := v.(map[string]interface{})
@@ -427,13 +420,13 @@ func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*s
 		})
 	}
 	// create the remaining DBs with all other modules
-	createDatabases = append(createDatabases, createAADatabase(dbName, &idx, localThroughputs, numDatabases, memoryLimitInGB, supportOSSClusterAPI)...)
+	createDatabases = append(createDatabases, createAADatabase(dbName, &idx, localThroughputs, numDatabases, memoryLimitInGB)...)
 
 	return createDatabases
 }
 
 // createDatabase returns a CreateDatabase struct with the given parameters
-func createAADatabase(dbName string, idx *int, localThroughputs []*subscriptions.CreateLocalThroughput, numDatabases int, memoryLimitInGB float64, supportOSSClusterAPI bool) []*subscriptions.CreateDatabase {
+func createAADatabase(dbName string, idx *int, localThroughputs []*subscriptions.CreateLocalThroughput, numDatabases int, memoryLimitInGB float64) []*subscriptions.CreateDatabase {
 	var databases []*subscriptions.CreateDatabase
 	for i := 0; i < numDatabases; i++ {
 		createDatabase := subscriptions.CreateDatabase{
@@ -442,7 +435,6 @@ func createAADatabase(dbName string, idx *int, localThroughputs []*subscriptions
 			MemoryLimitInGB:            redis.Float64(memoryLimitInGB),
 			LocalThroughputMeasurement: localThroughputs,
 			Quantity:                   redis.Int(1),
-			SupportOSSClusterAPI:       redis.Bool(supportOSSClusterAPI),
 		}
 		*idx++
 		databases = append(databases, &createDatabase)

--- a/provider/resource_rediscloud_active_active_subscription_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_test.go
@@ -165,7 +165,6 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
-					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.support_oss_cluster_api", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.region.0.write_operations_per_second", "1000"),
@@ -226,7 +225,6 @@ resource "rediscloud_active_active_subscription" "example" {
 	creation_plan {
 		memory_limit_in_gb = 1
 		quantity = 1
-		support_oss_cluster_api = true
 		region {
 			region = "us-east-1"
 			networking_deployment_cidr = "192.168.0.0/24"


### PR DESCRIPTION
The `support_oss_cluster_api` flag isn't supported on the creation of active/active subscription, so it should be removed.