### PR TITLE
Datasource rediscloud database crashes for aa dbs

### DIFF
--- a/docs/resources/rediscloud_active_active_subscription.md
+++ b/docs/resources/rediscloud_active_active_subscription.md
@@ -55,7 +55,7 @@ resource "rediscloud_active_active_subscription" "subscription-resource" {
 The following arguments are supported:
 
 * `name` - (Required) A meaningful name to identify the subscription
-* `payment_method` (Optional) The payment method for the requested subscription, (either `credit-card` or `marketplace`). If `credit-card` is specified, `payment_method_id` must be defined. Default: 'credit-card'. **Modifying this attribute will force creation of a new resource.**
+* `payment_method` (Optional) The payment method for the requested subscription, (either `credit-card` or `marketplace`). If `credit-card` is specified, `payment_method_id` must be defined. Default: 'credit-card'. **(Changes to) this attribute are ignored after creation.**
 * `payment_method_id` - (Optional) A valid payment method pre-defined in the current account. This value is __Optional__ for AWS/GCP Marketplace accounts, but __Required__ for all other account types 
 * `cloud_provider` - (Optional) The cloud provider to use with the subscription, (either `AWS` or `GCP`). Default: ‘AWS’. **Modifying this attribute will force creation of a new resource.**
 * `redis_version` - (Optional) Either 'default' or 'latest'. If specified, the Redis Version defines the cluster version. Default: 'default'. **Modifying this attribute will force creation of a new resource.**
@@ -73,7 +73,7 @@ The creation_plan `region` block supports:
 * `write_operations_per_second` - (Required) Throughput measurement for an active-active subscription
 * `read_operations_per_second` - (Required) Throughput measurement for an active-active subscription
 
-> **Note:** If changes are made to attributes in the subscription which require the subscription to be recreated (such as `cloud_provider` or `payment_method`), the creation_plan will need to be defined in order to change these attributes. This is because the creation_plan is always required when a subscription is created.
+> **Note:** If changes are made to attributes in the subscription which require the subscription to be recreated (such as `cloud_provider`), the creation_plan will need to be defined in order to change these attributes. This is because the creation_plan is always required when a subscription is created.
 
 
 ### Timeouts

--- a/docs/resources/rediscloud_subscription.md
+++ b/docs/resources/rediscloud_subscription.md
@@ -62,7 +62,7 @@ resource "rediscloud_subscription" "subscription-resource" {
 The following arguments are supported:
 
 * `name` - (Required) A meaningful name to identify the subscription
-* `payment_method` (Optional) The payment method for the requested subscription, (either `credit-card` or `marketplace`). If `credit-card` is specified, `payment_method_id` must be defined. Default: 'credit-card'. **Modifying this attribute will force creation of a new resource.**
+* `payment_method` (Optional) The payment method for the requested subscription, (either `credit-card` or `marketplace`). If `credit-card` is specified, `payment_method_id` must be defined. Default: 'credit-card'. **(Changes to) this attribute are ignored after creation.**
 * `payment_method_id` - (Optional) A valid payment method pre-defined in the current account. This value is __Optional__ for AWS/GCP Marketplace accounts, but __Required__ for all other account types
 * `memory_storage` - (Optional) Memory storage preference: either ‘ram’ or a combination of ‘ram-and-flash’. Default: ‘ram’. **Modifying this attribute will force creation of a new resource.**
 * `redis_version` - (Optional) Either 'default' or 'latest'. If specified, the Redis Version defines the cluster version. Default: 'default'. **Modifying this attribute will force creation of a new resource.**
@@ -101,7 +101,7 @@ be the maximum average item size defined in one of your databases.  Default: 100
 
 > **Note:** If the number of modules exceeds the `quantity` then additional creation-plan databases will be created with the modules defined in the `modules` block.
 
-> **Note:** If changes are made to attributes in the subscription which require the subscription to be recreated (such as `memory_storage`, `cloud_provider` or `payment_method`), the creation_plan will need to be defined in order to change these attributes. This is because the creation_plan is always required when a subscription is created.
+> **Note:** If changes are made to attributes in the subscription which require the subscription to be recreated (such as `memory_storage` or `cloud_provider`), the creation_plan will need to be defined in order to change these attributes. This is because the creation_plan is always required when a subscription is created.
 
 The cloud_provider `region` block supports:
 

--- a/provider/datasource_rediscloud_database.go
+++ b/provider/datasource_rediscloud_database.go
@@ -231,15 +231,21 @@ func dataSourceRedisCloudDatabaseRead(ctx context.Context, d *schema.ResourceDat
 	if err := d.Set("replication", redis.BoolValue(db.Replication)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("throughput_measurement_by", redis.StringValue(db.ThroughputMeasurement.By)); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("throughput_measurement_value", redis.IntValue(db.ThroughputMeasurement.Value)); err != nil {
-		return diag.FromErr(err)
-	}
-	if v := redis.StringValue(db.Security.Password); v != "" {
-		if err := d.Set("password", v); err != nil {
+
+	if db.ThroughputMeasurement != nil {
+		if err := d.Set("throughput_measurement_by", redis.StringValue(db.ThroughputMeasurement.By)); err != nil {
 			return diag.FromErr(err)
+		}
+		if err := d.Set("throughput_measurement_value", redis.IntValue(db.ThroughputMeasurement.Value)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if db.Security != nil {
+		if v := redis.StringValue(db.Security.Password); v != "" {
+			if err := d.Set("password", v); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 	if err := d.Set("public_endpoint", redis.StringValue(db.PublicEndpoint)); err != nil {
@@ -259,11 +265,16 @@ func dataSourceRedisCloudDatabaseRead(ctx context.Context, d *schema.ResourceDat
 	if err := d.Set("module", flattenModules(db.Modules)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("hashing_policy", flattenRegexRules(db.Clustering.RegexRules)); err != nil {
-		return diag.FromErr(err)
+
+	if db.Clustering != nil {
+		if err := d.Set("hashing_policy", flattenRegexRules(db.Clustering.RegexRules)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
-	if err := d.Set("enable_default_user", redis.BoolValue(db.Security.EnableDefaultUser)); err != nil {
-		return diag.FromErr(err)
+	if db.Security != nil {
+		if err := d.Set("enable_default_user", redis.BoolValue(db.Security.EnableDefaultUser)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return diags

--- a/provider/datasource_rediscloud_database_test.go
+++ b/provider/datasource_rediscloud_database_test.go
@@ -45,6 +45,30 @@ func TestAccDataSourceRedisCloudDatabase_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceRedisCloudDatabase_filterAADatabases(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	password := acctest.RandString(20)
+
+	dataSourceName := "data.rediscloud_database.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccDatasourceRedisCloudAADatabase, name+"-subscription", name+"-database", password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", name+"-database"),
+					resource.TestCheckResourceAttr(dataSourceName, "protocol", "redis"),
+					resource.TestCheckResourceAttr(dataSourceName, "support_oss_cluster_api", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "data_eviction", "volatile-lru"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDatasourceRedisCloudDatabase = `
 data "rediscloud_payment_method" "card" {
   card_type = "Visa"
@@ -100,5 +124,69 @@ resource "rediscloud_subscription_database" "example" {
 data "rediscloud_database" "example" {
   subscription_id = rediscloud_subscription.example.id
   name = rediscloud_subscription_database.example.name
+}
+`
+
+const testAccDatasourceRedisCloudAADatabase = `
+data "rediscloud_payment_method" "card" {
+	card_type = "Visa"
+}
+
+resource "rediscloud_active_active_subscription" "example" {
+	name = "%s"
+	payment_method_id = data.rediscloud_payment_method.card.id
+	cloud_provider = "AWS"
+
+	creation_plan {
+		memory_limit_in_gb = 1
+		quantity = 1
+		region {
+			region = "us-east-1"
+			networking_deployment_cidr = "192.168.0.0/24"
+			write_operations_per_second = 1000
+			read_operations_per_second = 1000
+		}
+		region {
+			region = "us-east-2"
+			networking_deployment_cidr = "10.0.1.0/24"
+			write_operations_per_second = 1000
+			read_operations_per_second = 1000
+		}
+	}
+}
+
+resource "rediscloud_active_active_subscription_database" "example" {
+    subscription_id = rediscloud_active_active_subscription.example.id
+    name = "%s"
+    memory_limit_in_gb = 3
+    support_oss_cluster_api = false 
+    external_endpoint_for_oss_cluster_api = false
+	enable_tls = false
+    
+    global_data_persistence = "none"
+    global_password = "%s" 
+    global_source_ips = ["192.168.0.0/16", "192.170.0.0/16"]
+    global_alert {
+		name = "dataset-size"
+		value = 40
+	}
+	override_region {
+		name = "us-east-1"
+		override_global_data_persistence = "aof-every-write"
+		override_global_source_ips = ["192.175.0.0/16"]
+		override_global_password = "region-specific-password"
+		override_global_alert {
+			name = "dataset-size"
+			value = 42
+		}
+	}
+	override_region {
+		name = "us-east-2"
+	}
+}
+
+data "rediscloud_database" "example" {
+  subscription_id = rediscloud_active_active_subscription.example.id
+  name = rediscloud_active_active_subscription_database.example.name
 }
 `


### PR DESCRIPTION
The `rediscloud_database` no longer causes a crash when used to identify an active_active database, but it yields minimal information. An upcoming change will introduce more comprehensive data sources for specific database types. Also includes so documentation updates.