### PR TITLE
Data source support for endpoint which lists all subscriptions for a plan

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -16,6 +16,10 @@ on:
 env:
   TERRAFORM_VERSION: "1.2.6"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go_build:
     name: go build

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.22.4
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.16.0
+	github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e // todo: replace and update this
 	github.com/bflad/tfproviderlint v0.30.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.22.4
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e // todo: replace and update this
+	github.com/RedisLabs/rediscloud-go-api v0.17.0
 	github.com/bflad/tfproviderlint v0.30.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RedisLabs/rediscloud-go-api v0.16.0 h1:vZgsXDHdPk6dyuR5syEWjc7L3v1ceQ1AmljBx2yqqZc=
 github.com/RedisLabs/rediscloud-go-api v0.16.0/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
+github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e h1:K5bqnWMNlrd3GtJD3flFFojQsJgIblOCWlAsu0WUW6M=
-github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
+github.com/RedisLabs/rediscloud-go-api v0.17.0 h1:Kg8uaZey78O6UoXXA/5CvVxk6WfKsbXbhfXkQDbC2Ek=
+github.com/RedisLabs/rediscloud-go-api v0.17.0/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,7 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/RedisLabs/rediscloud-go-api v0.16.0 h1:vZgsXDHdPk6dyuR5syEWjc7L3v1ceQ1AmljBx2yqqZc=
-github.com/RedisLabs/rediscloud-go-api v0.16.0/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
+github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e h1:K5bqnWMNlrd3GtJD3flFFojQsJgIblOCWlAsu0WUW6M=
 github.com/RedisLabs/rediscloud-go-api v0.16.1-0.20240708082244-8a5814f0b94e/go.mod h1:CMntQxo1/0plOP874rtju+vlT7SIlEwiBZbD/SRgJ7g=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/provider/datasource_rediscloud_essentials_plan.go
+++ b/provider/datasource_rediscloud_essentials_plan.go
@@ -41,9 +41,8 @@ func dataSourceRedisCloudEssentialsPlan() *schema.Resource {
 				Optional:    true,
 			},
 			"subscription_id": {
-				Description: "ID of the subscription that the database belongs to",
+				Description: "Filter plans by what is available for a given subscription",
 				Type:        schema.TypeInt,
-				Computed:    true,
 				Optional:    true,
 			},
 			"cloud_provider": {

--- a/provider/datasource_rediscloud_essentials_plan.go
+++ b/provider/datasource_rediscloud_essentials_plan.go
@@ -40,6 +40,12 @@ func dataSourceRedisCloudEssentialsPlan() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 			},
+			"subscription_id": {
+				Description: "ID of the subscription that the database belongs to",
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Optional:    true,
+			},
 			"cloud_provider": {
 				Description: "The cloud provider: 'AWS', 'GCP' or 'Azure'",
 				Type:        schema.TypeString,
@@ -296,7 +302,7 @@ func getResourceList(ctx context.Context, d *schema.ResourceData, api *apiClient
 	var list []*plans.GetPlanResponse
 	var err error
 
-	if id, ok := d.GetOk("id"); ok {
+	if id, ok := d.GetOk("subscription_id"); ok {
 		list, err = api.client.FixedPlanSubscriptions.List(ctx, id.(int))
 	} else if provider, ok := d.GetOk("cloud_provider"); ok {
 		list, err = api.client.FixedPlans.ListWithProvider(ctx, strings.ToUpper(provider.(string)))

--- a/provider/datasource_rediscloud_essentials_plan_test.go
+++ b/provider/datasource_rediscloud_essentials_plan_test.go
@@ -46,6 +46,7 @@ func TestAccDataSourceRedisCloudEssentialsPlan_basic(t *testing.T) {
 
 func TestAccDataSourceRedisCloudEssentialsPlan_azure(t *testing.T) {
 
+	const azureResource = "data.rediscloud_essentials_plan.azure"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -54,28 +55,69 @@ func TestAccDataSourceRedisCloudEssentialsPlan_azure(t *testing.T) {
 			{
 				Config: testAccDataSourceRedisCloudEssentialsPlanAzure,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "id", "35008"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "name", "Single-Zone_Persistence_1GB"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "size", "1"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "size_measurement_unit", "GB"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "cloud_provider", "Azure"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "region", "west-us"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "region_id", "17"),
-					resource.TestCheckResourceAttrSet("data.rediscloud_essentials_plan.azure", "price"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "price_currency", "USD"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "price_period", "Month"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "maximum_databases", "1"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "maximum_throughput", "2000"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "maximum_bandwidth_in_gb", "200"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "availability", "Single-zone"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "connections", "1024"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "cidr_allow_rules", "8"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "support_data_persistence", "true"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "support_instant_and_daily_backups", "true"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "support_replication", "true"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "support_clustering", "false"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "supported_alerts.#", "5"),
-					resource.TestCheckResourceAttr("data.rediscloud_essentials_plan.azure", "customer_support", "Standard"),
+					resource.TestCheckResourceAttr(azureResource, "id", "35008"),
+					resource.TestCheckResourceAttr(azureResource, "name", "Single-Zone_Persistence_1GB"),
+					resource.TestCheckResourceAttr(azureResource, "size", "1"),
+					resource.TestCheckResourceAttr(azureResource, "size_measurement_unit", "GB"),
+					resource.TestCheckResourceAttr(azureResource, "cloud_provider", "Azure"),
+					resource.TestCheckResourceAttr(azureResource, "region", "west-us"),
+					resource.TestCheckResourceAttr(azureResource, "region_id", "17"),
+					resource.TestCheckResourceAttrSet(azureResource, "price"),
+					resource.TestCheckResourceAttr(azureResource, "price_currency", "USD"),
+					resource.TestCheckResourceAttr(azureResource, "price_period", "Month"),
+					resource.TestCheckResourceAttr(azureResource, "maximum_databases", "1"),
+					resource.TestCheckResourceAttr(azureResource, "maximum_throughput", "2000"),
+					resource.TestCheckResourceAttr(azureResource, "maximum_bandwidth_in_gb", "200"),
+					resource.TestCheckResourceAttr(azureResource, "availability", "Single-zone"),
+					resource.TestCheckResourceAttr(azureResource, "connections", "1024"),
+					resource.TestCheckResourceAttr(azureResource, "cidr_allow_rules", "8"),
+					resource.TestCheckResourceAttr(azureResource, "support_data_persistence", "true"),
+					resource.TestCheckResourceAttr(azureResource, "support_instant_and_daily_backups", "true"),
+					resource.TestCheckResourceAttr(azureResource, "support_replication", "true"),
+					resource.TestCheckResourceAttr(azureResource, "support_clustering", "false"),
+					resource.TestCheckResourceAttr(azureResource, "supported_alerts.#", "5"),
+					resource.TestCheckResourceAttr(azureResource, "customer_support", "Standard"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceRedisCloudEssentialsPlan_subscriptionId(t *testing.T) {
+
+	const exampleResource = "data.rediscloud_essentials_plan.example"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      nil, // Essentials Plans aren't managed by this provider
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRedisCloudPaidEssentialsSubscriptionDataSource,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(exampleResource, "id", "34858"),
+					resource.TestCheckResourceAttr(exampleResource, "name", "250MB"),
+					resource.TestCheckResourceAttrSet(exampleResource, "subscription_id"),
+					resource.TestCheckResourceAttr(exampleResource, "size", "250"),
+					resource.TestCheckResourceAttr(exampleResource, "size_measurement_unit", "MB"),
+					resource.TestCheckResourceAttr(exampleResource, "cloud_provider", "AWS"),
+					resource.TestCheckResourceAttr(exampleResource, "region", "us-east-1"),
+					resource.TestCheckResourceAttr(exampleResource, "region_id", "1"),
+					resource.TestCheckResourceAttrSet(exampleResource, "price"),
+					resource.TestCheckResourceAttr(exampleResource, "price_currency", "USD"),
+					resource.TestCheckResourceAttr(exampleResource, "price_period", "Month"),
+					resource.TestCheckResourceAttr(exampleResource, "maximum_databases", "1"),
+					resource.TestCheckResourceAttr(exampleResource, "maximum_throughput", "1000"),
+					resource.TestCheckResourceAttr(exampleResource, "maximum_bandwidth_in_gb", "100"),
+					resource.TestCheckResourceAttr(exampleResource, "availability", "No replication"),
+					resource.TestCheckResourceAttr(exampleResource, "connections", "256"),
+					resource.TestCheckResourceAttr(exampleResource, "cidr_allow_rules", "4"),
+					resource.TestCheckResourceAttr(exampleResource, "support_data_persistence", "false"),
+					resource.TestCheckResourceAttr(exampleResource, "support_instant_and_daily_backups", "true"),
+					resource.TestCheckResourceAttr(exampleResource, "support_replication", "false"),
+					resource.TestCheckResourceAttr(exampleResource, "support_clustering", "false"),
+					resource.TestCheckResourceAttr(exampleResource, "supported_alerts.#", "5"),
+					resource.TestCheckResourceAttr(exampleResource, "customer_support", "Standard"),
 				),
 			},
 		},
@@ -134,5 +176,28 @@ data "rediscloud_essentials_plan" "ambiguous" {
 const testAccDataSourceRedisCloudEssentialsPlanImpossible = `
 data "rediscloud_essentials_plan" "impossible" {
   name = "There should never be a essentials plan with this name!"
+}
+`
+
+const testAccResourceRedisCloudPaidEssentialsSubscriptionDataSource = `
+data "rediscloud_payment_method" "card" {
+	card_type = "Visa"
+}
+
+data "rediscloud_essentials_plan" "fixed" {
+	name = "250MB"
+	cloud_provider = "AWS"
+	region = "us-east-1"
+}
+
+resource "rediscloud_essentials_subscription" "fixed" {
+	name = "fixed subscription test"
+	plan_id = data.rediscloud_essentials_plan.fixed.id
+	payment_method_id = data.rediscloud_payment_method.card.id
+}
+
+data "rediscloud_essentials_plan" "example" {
+	name = data.rediscloud_essentials_plan.fixed.name
+	subscription_id = rediscloud_essentials_subscription.fixed.id
 }
 `


### PR DESCRIPTION
- In the case that a user supplies a `subscription_id` in the `rediscloud_essentials_plan` data source, the provider will now use the new RedisCloud go API to filter by that given ID.
- Test to support this new workflow
- Bumping the API version
- Some minor refactoring around tests