### PR TITLE
Pre-polling delays removed

### DIFF
--- a/provider/resource_rediscloud_pro_subscription.go
+++ b/provider/resource_rediscloud_pro_subscription.go
@@ -892,7 +892,6 @@ func createDatabase(dbName string, idx *int, modules []*subscriptions.CreateModu
 
 func waitForSubscriptionToBeActive(ctx context.Context, id int, api *apiClient) error {
 	wait := &retry.StateChangeConf{
-		Delay:        30 * time.Second,
 		Pending:      []string{subscriptions.SubscriptionStatusPending},
 		Target:       []string{subscriptions.SubscriptionStatusActive},
 		Timeout:      safetyTimeout,
@@ -918,7 +917,6 @@ func waitForSubscriptionToBeActive(ctx context.Context, id int, api *apiClient) 
 
 func waitForSubscriptionToBeDeleted(ctx context.Context, id int, api *apiClient) error {
 	wait := &retry.StateChangeConf{
-		Delay:        30 * time.Second,
 		Pending:      []string{subscriptions.SubscriptionStatusDeleting},
 		Target:       []string{"deleted"},
 		Timeout:      safetyTimeout,
@@ -947,7 +945,6 @@ func waitForSubscriptionToBeDeleted(ctx context.Context, id int, api *apiClient)
 
 func waitForDatabaseToBeActive(ctx context.Context, subId, id int, api *apiClient) error {
 	wait := &retry.StateChangeConf{
-		Delay: 30 * time.Second,
 		Pending: []string{
 			databases.StatusDraft,
 			databases.StatusPending,


### PR DESCRIPTION
these were originally introduced to slow down requests because Imperva(?) was flagging regular use as an attack. That might no longer be the case.