### PR TITLE
Remove path-ignore on build workflow

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -5,14 +5,10 @@ on:
     branches:
       - main
       - develop
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - main
       - develop
-    paths-ignore:
-      - '**.md'
 env:
   TERRAFORM_VERSION: "1.2.6"
 


### PR DESCRIPTION
This fixes the issue of checks not being triggered on pull requests with only markdown changes.

The acc tests are only run if there are code changes, so removing the path-ignore will not cause them to run on documentation changes.
