### PR TITLE
Adding payment_method to essentials subscription

### DIFF
--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -123,7 +123,8 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription"'
+      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsDatabase_CRUDI"'
+
 
   go_test_smoke_essentials_sub:
     name: go test smoke essentials sub
@@ -134,7 +135,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription_CRUDI"'
+      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription"'
 
 
   go_test_smoke_pro_db:

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -126,7 +126,7 @@ jobs:
       - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription"'
 
   go_test_smoke_essentials_sub:
-    name: go test smoke essentials db
+    name: go test smoke essentials sub
     needs: [go_build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -123,7 +123,18 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsDatabase_CRUDI"'
+      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription"'
+
+  go_test_smoke_essentials_sub:
+    name: go test smoke essentials db
+    needs: [go_build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAccResourceRedisCloudEssentialsSubscription_CRUDI"'
 
 
   go_test_smoke_pro_db:

--- a/docs/data-sources/rediscloud_essentials_subscription.md
+++ b/docs/data-sources/rediscloud_essentials_subscription.md
@@ -33,5 +33,6 @@ output "rediscloud_essentials_subscription" {
 
 * `status` - The current status of the subscription
 * `plan_id` - The plan to which this subscription belongs
+* `payment_method` - Payment method for the requested subscription. If `credit-card` is specified, the payment method id must be defined. This information is only used when creating a new subscription and any changes will be ignored after this.
 * `payment_method_id` - A valid payment method pre-defined in the current account
 * `creation_date` - When the subscription was created

--- a/go.mod
+++ b/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/RedisLabs/rediscloud-go-api v0.26.0 => ../rediscloud-go-api

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 go 1.22.4
 
 require (
-	github.com/RedisLabs/rediscloud-go-api v0.26.0
+	github.com/RedisLabs/rediscloud-go-api v0.27.0
 	github.com/bflad/tfproviderlint v0.31.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
@@ -66,5 +66,3 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/RedisLabs/rediscloud-go-api v0.26.0 => ../rediscloud-go-api

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/RedisLabs/rediscloud-go-api v0.26.0 h1:ka6CN2O+Ti6igkfH8lDT9Ua1/ksEh2H5dj1GF/pnKKQ=
-github.com/RedisLabs/rediscloud-go-api v0.26.0/go.mod h1:3/oVb71rv2OstFRYEc65QCIbfwnJTgZeQhtPCcdHook=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/RedisLabs/rediscloud-go-api v0.27.0 h1:eTaxZFl+y6z+loViUl6CDhlG+JVDokXHbkIctRD+r2g=
+github.com/RedisLabs/rediscloud-go-api v0.27.0/go.mod h1:3/oVb71rv2OstFRYEc65QCIbfwnJTgZeQhtPCcdHook=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/provider/datasource_rediscloud_essentials_subscription.go
+++ b/provider/datasource_rediscloud_essentials_subscription.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	fixedSubscriptions "github.com/RedisLabs/rediscloud-go-api/service/fixed/subscriptions"
+	fs "github.com/RedisLabs/rediscloud-go-api/service/fixed/subscriptions"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -60,16 +60,16 @@ func dataSourceRedisCloudEssentialsSubscriptionRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	var filters []func(method *fixedSubscriptions.FixedSubscription) bool
+	var filters []func(method *fs.FixedSubscriptionResponse) bool
 
 	if id, ok := d.GetOk("id"); ok {
-		filters = append(filters, func(sub *fixedSubscriptions.FixedSubscription) bool {
+		filters = append(filters, func(sub *fs.FixedSubscriptionResponse) bool {
 			return redis.IntValue(sub.ID) == id
 		})
 	}
 
 	if name, ok := d.GetOk("name"); ok {
-		filters = append(filters, func(sub *fixedSubscriptions.FixedSubscription) bool {
+		filters = append(filters, func(sub *fs.FixedSubscriptionResponse) bool {
 			return redis.StringValue(sub.Name) == name
 		})
 	}
@@ -109,8 +109,8 @@ func dataSourceRedisCloudEssentialsSubscriptionRead(ctx context.Context, d *sche
 	return diags
 }
 
-func filterFixedSubscriptions(subs []*fixedSubscriptions.FixedSubscription, filters []func(sub *fixedSubscriptions.FixedSubscription) bool) []*fixedSubscriptions.FixedSubscription {
-	var filteredSubs []*fixedSubscriptions.FixedSubscription
+func filterFixedSubscriptions(subs []*fs.FixedSubscriptionResponse, filters []func(sub *fs.FixedSubscriptionResponse) bool) []*fs.FixedSubscriptionResponse {
+	var filteredSubs []*fs.FixedSubscriptionResponse
 	for _, sub := range subs {
 		if filterFixedSub(sub, filters) {
 			filteredSubs = append(filteredSubs, sub)
@@ -120,7 +120,7 @@ func filterFixedSubscriptions(subs []*fixedSubscriptions.FixedSubscription, filt
 	return filteredSubs
 }
 
-func filterFixedSub(method *fixedSubscriptions.FixedSubscription, filters []func(method *fixedSubscriptions.FixedSubscription) bool) bool {
+func filterFixedSub(method *fs.FixedSubscriptionResponse, filters []func(method *fs.FixedSubscriptionResponse) bool) bool {
 	for _, f := range filters {
 		if !f(method) {
 			return false

--- a/provider/rediscloud_active_active_subscription_test.go
+++ b/provider/rediscloud_active_active_subscription_test.go
@@ -24,7 +24,7 @@ var activeActiveMarketplaceFlag = flag.Bool("activeActiveMarketplace", false,
 // Also checks active-active subscription regions.
 func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI(t *testing.T) {
 
-	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	name := acctest.RandomWithPrefix(testResourcePrefix)
 	const resourceName = "rediscloud_active_active_subscription.example"

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestAccResourceRedisCloudEssentialsSubscription_Free_CRUDI(t *testing.T) {
 
-	// TODO: remove comments: temp
-	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"
@@ -79,8 +78,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Free_CRUDI(t *testing.T) {
 
 func TestAccResourceRedisCloudEssentialsSubscription_Paid_CreditCard_CRUDI(t *testing.T) {
 
-	// TODO: remove comments: temp
-	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"
@@ -146,8 +144,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_CreditCard_CRUDI(t *te
 
 func TestAccResourceRedisCloudEssentialsSubscription_Paid_NoPaymentType_CRUDI(t *testing.T) {
 
-	// TODO: remove comments: temp
-	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"
@@ -213,8 +210,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_NoPaymentType_CRUDI(t 
 
 func TestAccResourceRedisCloudEssentialsSubscription_Paid_Marketplace_CRUDI(t *testing.T) {
 
-	// TODO: remove comments: temp
-	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -92,13 +92,14 @@ func TestAccResourceRedisCloudEssentialsSubscription_PaidCRUDI(t *testing.T) {
 		CheckDestroy:      testAccCheckEssentialsSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudPaidEssentialsSubscription, subscriptionName),
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidCreditCardEssentialsSubscription, subscriptionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Test the resource
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", subscriptionName),
 					resource.TestCheckResourceAttr(resourceName, "status", "active"),
 					resource.TestCheckResourceAttrSet(resourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method"),
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
 
@@ -112,7 +113,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_PaidCRUDI(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudPaidEssentialsSubscription, subscriptionNameUpdated),
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidCreditCardEssentialsSubscription, subscriptionNameUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Test the resource
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -132,7 +133,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_PaidCRUDI(t *testing.T) {
 				),
 			},
 			{
-				Config:            fmt.Sprintf(testAccResourceRedisCloudPaidEssentialsSubscription, subscriptionNameUpdated),
+				Config:            fmt.Sprintf(testAccResourceRedisCloudPaidCreditCardEssentialsSubscription, subscriptionNameUpdated),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -158,7 +159,30 @@ data "rediscloud_essentials_subscription" "example" {
 }
 `
 
-const testAccResourceRedisCloudPaidEssentialsSubscription = `
+const testAccResourceRedisCloudPaidMarketplaceEssentialsSubscription = `
+data "rediscloud_payment_method" "card" {
+	card_type = "Visa"
+}
+
+data "rediscloud_essentials_plan" "example" {
+	name = "250MB"
+	cloud_provider = "AWS"
+	region = "us-east-1"
+}
+
+resource "rediscloud_essentials_subscription" "example" {
+	name = "%s"
+	plan_id = data.rediscloud_essentials_plan.example.id
+	payment_method = "marketplace"
+	payment_method_id = data.rediscloud_payment_method.card.id
+}
+
+data "rediscloud_essentials_subscription" "example" {
+	name = rediscloud_essentials_subscription.example.name
+}
+`
+
+const testAccResourceRedisCloudPaidCreditCardEssentialsSubscription = `
 data "rediscloud_payment_method" "card" {
 	card_type = "Visa"
 }
@@ -173,6 +197,7 @@ resource "rediscloud_essentials_subscription" "example" {
 	name = "%s"
 	plan_id = data.rediscloud_essentials_plan.example.id
 	payment_method_id = data.rediscloud_payment_method.card.id
+	payment_method = "credit-card"
 }
 
 data "rediscloud_essentials_subscription" "example" {

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -210,8 +210,9 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_NoPaymentType_CRUDI(t 
 }
 
 func TestAccResourceRedisCloudEssentialsSubscription_Paid_Marketplace_CRUDI(t *testing.T) {
-
-	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	// Only the qa environment has access to the marketplace, so this test will normally fail.
+	// Leaving this in the test suite for manual runs
+	testAccRequiresEnvVar(t, "EXECUTE_QA_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 )
 
-func TestAccResourceRedisCloudEssentialsSubscription_FreeCRUDI(t *testing.T) {
+func TestAccResourceRedisCloudEssentialsSubscription_Free_CRUDI(t *testing.T) {
 
-	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	// TODO: remove comments: temp
+	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"
@@ -76,9 +77,10 @@ func TestAccResourceRedisCloudEssentialsSubscription_FreeCRUDI(t *testing.T) {
 	})
 }
 
-func TestAccResourceRedisCloudEssentialsSubscription_PaidCRUDI(t *testing.T) {
+func TestAccResourceRedisCloudEssentialsSubscription_Paid_CreditCard_CRUDI(t *testing.T) {
 
-	testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+	// TODO: remove comments: temp
+	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
 	subscriptionNameUpdated := subscriptionName + "-updated"
@@ -134,6 +136,141 @@ func TestAccResourceRedisCloudEssentialsSubscription_PaidCRUDI(t *testing.T) {
 			},
 			{
 				Config:            fmt.Sprintf(testAccResourceRedisCloudPaidCreditCardEssentialsSubscription, subscriptionNameUpdated),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceRedisCloudEssentialsSubscription_Paid_NoPaymentType_CRUDI(t *testing.T) {
+
+	// TODO: remove comments: temp
+	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+
+	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionNameUpdated := subscriptionName + "-updated"
+
+	const resourceName = "rediscloud_essentials_subscription.example"
+	const datasourceName = "data.rediscloud_essentials_subscription.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckEssentialsSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidNoPaymentTypeEssentialsSubscription, subscriptionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Test the resource
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", subscriptionName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
+
+					// Test the datasource
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "name", subscriptionName),
+					resource.TestCheckResourceAttr(datasourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(datasourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "creation_date"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidNoPaymentTypeEssentialsSubscription, subscriptionNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Test the resource
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", subscriptionNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
+
+					// Test the datasource
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "name", subscriptionNameUpdated),
+					resource.TestCheckResourceAttr(datasourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(datasourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "creation_date"),
+				),
+			},
+			{
+				Config:            fmt.Sprintf(testAccResourceRedisCloudPaidNoPaymentTypeEssentialsSubscription, subscriptionNameUpdated),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceRedisCloudEssentialsSubscription_Paid_Marketplace_CRUDI(t *testing.T) {
+
+	// TODO: remove comments: temp
+	//testAccRequiresEnvVar(t, "EXECUTE_TESTS")
+
+	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionNameUpdated := subscriptionName + "-updated"
+
+	const resourceName = "rediscloud_essentials_subscription.example"
+	const datasourceName = "data.rediscloud_essentials_subscription.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckEssentialsSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidMarketplaceEssentialsSubscription, subscriptionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Test the resource
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", subscriptionName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "plan_id"),
+					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
+
+					// Test the datasource
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "name", subscriptionName),
+					resource.TestCheckResourceAttr(datasourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(datasourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "creation_date"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccResourceRedisCloudPaidMarketplaceEssentialsSubscription, subscriptionNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Test the resource
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", subscriptionNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "plan_id"),
+					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
+					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
+
+					// Test the datasource
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "name", subscriptionNameUpdated),
+					resource.TestCheckResourceAttr(datasourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(datasourceName, "plan_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "payment_method_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "creation_date"),
+				),
+			},
+			{
+				Config:            fmt.Sprintf(testAccResourceRedisCloudPaidMarketplaceEssentialsSubscription, subscriptionNameUpdated),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -198,6 +335,29 @@ resource "rediscloud_essentials_subscription" "example" {
 	plan_id = data.rediscloud_essentials_plan.example.id
 	payment_method_id = data.rediscloud_payment_method.card.id
 	payment_method = "credit-card"
+}
+
+data "rediscloud_essentials_subscription" "example" {
+	name = rediscloud_essentials_subscription.example.name
+}
+`
+
+// doesn't contain credit-card, tests for default
+const testAccResourceRedisCloudPaidNoPaymentTypeEssentialsSubscription = `
+data "rediscloud_payment_method" "card" {
+	card_type = "Visa"
+}
+
+data "rediscloud_essentials_plan" "example" {
+	name = "250MB"
+	cloud_provider = "AWS"
+	region = "us-east-1"
+}
+
+resource "rediscloud_essentials_subscription" "example" {
+	name = "%s"
+	plan_id = data.rediscloud_essentials_plan.example.id
+	payment_method_id = data.rediscloud_payment_method.card.id
 }
 
 data "rediscloud_essentials_subscription" "example" {

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -283,6 +283,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Incorrect_PaymentIdForType(
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckEssentialsSubscriptionDestroy,
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -49,6 +51,20 @@ func resourceRedisCloudEssentialsSubscription() *schema.Resource {
 				Description: "The identifier of the plan to template the subscription",
 				Type:        schema.TypeInt,
 				Required:    true,
+			},
+			"payment_method": {
+				Description:      "Payment method for the requested subscription. If credit card is specified, the payment method id must be defined. This information is only used when creating a new subscription and any changes will be ignored after this.",
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile("^(credit-card|marketplace)$"), "must be 'credit-card' or 'marketplace'")),
+				Optional:         true,
+				Default:          "credit-card",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Id() == "" {
+						// We don't want to ignore the block if the resource is about to be created.
+						return false
+					}
+					return true
+				},
 			},
 			"payment_method_id": {
 				Description: "The identifier of the method which will be charged for this subscription. Not required for free plans",

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -91,10 +91,12 @@ func resourceRedisCloudEssentialsSubscriptionCreate(ctx context.Context, d *sche
 	}
 
 	// payment_method_id only matters if it is a credit card
-	if d.Get("payment_method").(string) != "credit-card" {
-		if d.Get("payment_method_id") != nil {
-			return diag.FromErr(errors.New("payment methods aside from credit-card cannot have a payment ID"))
-		}
+	if d.Get("payment_method").(string) != "credit-card" && d.Get("payment_method_id") != 0 {
+		return diag.FromErr(errors.New("payment methods aside from credit-card cannot have a payment ID"))
+	}
+
+	if v, ok := d.GetOk("payment_method"); ok {
+		createSubscriptionRequest.PaymentMethod = redis.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("payment_method_id"); ok {

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"regexp"
@@ -87,6 +88,13 @@ func resourceRedisCloudEssentialsSubscriptionCreate(ctx context.Context, d *sche
 	createSubscriptionRequest := fixedSubscriptions.FixedSubscriptionRequest{
 		Name:   redis.String(d.Get("name").(string)),
 		PlanId: redis.Int(d.Get("plan_id").(int)),
+	}
+
+	// payment_method_id only matters if it is a credit card
+	if d.Get("payment_method").(string) != "credit-card" {
+		if d.Get("payment_method_id") != nil {
+			return diag.FromErr(errors.New("payment methods aside from credit-card cannot have a payment ID"))
+		}
 	}
 
 	if v, ok := d.GetOk("payment_method_id"); ok {

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -84,7 +84,7 @@ func resourceRedisCloudEssentialsSubscriptionCreate(ctx context.Context, d *sche
 	var diags diag.Diagnostics
 	api := meta.(*apiClient)
 
-	createSubscriptionRequest := fixedSubscriptions.FixedSubscription{
+	createSubscriptionRequest := fixedSubscriptions.FixedSubscriptionRequest{
 		Name:   redis.String(d.Get("name").(string)),
 		PlanId: redis.Int(d.Get("plan_id").(int)),
 	}
@@ -140,6 +140,9 @@ func resourceRedisCloudEssentialsSubscriptionRead(ctx context.Context, d *schema
 	if err := d.Set("payment_method_id", redis.IntValue(subscription.PaymentMethodID)); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("payment_method", redis.StringValue(subscription.PaymentMethod)); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("creation_date", redis.TimeValue(subscription.CreationDate).String()); err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,9 +168,13 @@ func resourceRedisCloudEssentialsSubscriptionUpdate(ctx context.Context, d *sche
 		return diags
 	}
 
-	updateSubscriptionRequest := fixedSubscriptions.FixedSubscription{
+	updateSubscriptionRequest := fixedSubscriptions.FixedSubscriptionRequest{
 		Name:   redis.String(d.Get("name").(string)),
 		PlanId: redis.Int(d.Get("plan_id").(int)),
+	}
+
+	if v, ok := d.GetOk("payment_method"); ok {
+		updateSubscriptionRequest.PaymentMethod = redis.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("payment_method_id"); ok {

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -53,7 +53,7 @@ func resourceRedisCloudEssentialsSubscription() *schema.Resource {
 				Required:    true,
 			},
 			"payment_method": {
-				Description:      "Payment method for the requested subscription. If credit card is specified, the payment method id must be defined. This information is only used when creating a new subscription and any changes will be ignored after this.",
+				Description:      "Payment method for the requested subscription. If credit-card is specified, the payment method id must be defined. This information is only used when creating a new subscription and any changes will be ignored after this.",
 				Type:             schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile("^(credit-card|marketplace)$"), "must be 'credit-card' or 'marketplace'")),
 				Optional:         true,


### PR DESCRIPTION
Enables users to specify a `payment_method` in the Essentials Subscription resource. The field is optional - omitting it will default to `credit-card` to preserve backwards compatibility. 

This is to allow users to have `marketplace` as a payment method.