### PR TITLE
Fix: Revert removal subscription version

### DIFF
--- a/provider/resource_rediscloud_pro_subscription.go
+++ b/provider/resource_rediscloud_pro_subscription.go
@@ -606,6 +606,11 @@ func resourceRedisCloudProSubscriptionCreate(ctx context.Context, d *schema.Reso
 		Databases:       dbs,
 	}
 
+	redisVersion := d.Get("redis_version").(string)
+	if d.Get("redis_version").(string) != "" {
+		createSubscriptionRequest.RedisVersion = redis.String(redisVersion)
+	}
+
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
 
 	if cmkEnabled {


### PR DESCRIPTION
Some miscommunication over whether the functionality should be actually removed or not. The functionality is deprecated but still active.