### PR TITLE
Essentials DB version, aws_account_id, region_id, db_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ vendor
 .claude/
 CLAUDE.md
 
+# npm/node
+node_modules/
+package-lock.json
+package.json
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/


### PR DESCRIPTION
## Added
- Added support for database version for Essentials databases.
- Added `aws_account_id` attribute to Pro and Active-Active subscription resources and data sources.
- Added `region_id` to the attribute reference documentation for `rediscloud_active_active_subscription_regions` data source.
- Added `region_id` attribute to `rediscloud_regions` data source.
- Added `db_id` to the attribute reference documentation for `rediscloud_database` data source.