### PR TITLE
OPCR-139: Setup CI to clean up cancelled test runs

### DIFF
--- a/.github/actions/run-sweep/action.yml
+++ b/.github/actions/run-sweep/action.yml
@@ -1,0 +1,27 @@
+name: 'Run Resource Sweep'
+description: 'Sweep orphaned test resources from Redis Cloud'
+inputs:
+  sweep_prefix:
+    description: 'Resource name prefix to target (e.g. tf-ci or tf-ci-pr42-12345678)'
+    required: true
+    default: 'tf-ci'
+  age_threshold:
+    description: 'Minimum age before a resource is swept (Go duration, e.g. 2h, 0s). Default: 2h'
+    required: false
+    default: '2h'
+runs:
+  using: 'composite'
+  steps:
+    - name: Sweep resources
+      shell: bash
+      env:
+        TEST_RESOURCE_PREFIX: ${{ inputs.sweep_prefix }}
+        SWEEP_AGE_THRESHOLD: ${{ inputs.age_threshold }}
+      run: |
+        echo "Sweeping resources with prefix: $TEST_RESOURCE_PREFIX (age threshold: $SWEEP_AGE_THRESHOLD)"
+        # Sweep errors are intentionally non-fatal: a sweep failure should not
+        # block the test pipeline. The warning annotation ensures failures are
+        # visible in the GitHub Actions summary.
+        if ! go test ./provider -v -sweep=ALL -timeout 30m 2>&1; then
+          echo "::warning::Sweep completed with errors - some resources may not have been cleaned up"
+        fi

--- a/.github/actions/run-sweep/action.yml
+++ b/.github/actions/run-sweep/action.yml
@@ -23,5 +23,5 @@ runs:
         # block the test pipeline. The warning annotation ensures failures are
         # visible in the GitHub Actions summary.
         if ! go test ./provider -v -sweep=ALL -timeout 30m 2>&1; then
-          echo "::warning::Sweep completed with errors - some resources may not have been cleaned up"
+          echo "::warning::Sweep of prefix '$TEST_RESOURCE_PREFIX' completed with errors - some resources may not have been cleaned up"
         fi

--- a/.github/workflows/terraform_provider_cleanup.yml
+++ b/.github/workflows/terraform_provider_cleanup.yml
@@ -1,0 +1,56 @@
+name: Cleanup cancelled CI runs
+
+# Triggers after the PR or main workflow finishes. Runs as an independent
+# workflow, so it is NOT killed by cancel-in-progress on the original run.
+on:
+  workflow_run:
+    workflows:
+      - "Terraform Provider Checks - PR workflow"
+      - "Terraform Provider Checks - main branch"
+    types: [completed]
+
+env:
+  REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_STAGING }}
+  REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_STAGING }}
+  REDISCLOUD_URL: ${{ secrets.REDISCLOUD_URL_STAGING }}
+
+jobs:
+  sweep:
+    name: sweep cancelled run
+    if: ${{ github.event.workflow_run.conclusion == 'cancelled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - name: Determine sweep prefix
+        id: prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_NUMBER="${{ github.event.workflow_run.run_number }}"
+
+          if [ "${{ github.event.workflow_run.event }}" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+
+            # Fallback: look up PR number from the head branch if not available
+            if [ -z "$PR_NUMBER" ]; then
+              PR_NUMBER=$(gh pr list --head "${{ github.event.workflow_run.head_branch }}" --json number -q '.[0].number')
+            fi
+
+            if [ -z "$PR_NUMBER" ]; then
+              echo "::warning::Could not determine PR number — skipping cleanup"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "value=tf-ci-pr${PR_NUMBER}-${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "value=tf-ci-main-${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Sweep resources
+        if: ${{ steps.prefix.outputs.skip != 'true' }}
+        uses: ./.github/actions/run-sweep
+        with:
+          sweep_prefix: ${{ steps.prefix.outputs.value }}
+          age_threshold: '0s'

--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -27,12 +27,25 @@ env:
   GCP_VPC_ID: ${{ secrets.GCP_VPC_ID }}
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+  TEST_RESOURCE_PREFIX: "tf-ci-main-${{ github.run_number }}"
 
 concurrency:
   group: <span class="math-inline">\{\{ github\.workflow \}\}\-</span>{{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  pre_sweep:
+    name: pre-test sweep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - uses: ./.github/actions/run-sweep
+        with:
+          sweep_prefix: 'tf-ci'
+
   go_build:
     name: go build
     runs-on: ubuntu-latest
@@ -104,7 +117,7 @@ jobs:
 
   go_test_databases:
     name: go test Databases
-    needs: [go_build]
+    needs: [go_build, pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -200,3 +213,22 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make tfproviderlint
+
+  post_sweep:
+    name: post-test sweep
+    if: always()
+    # go_test_transit_payment is the terminal node of a strictly linear chain
+    # (databases -> subscriptions -> ... -> transit_payment). If the chain gains
+    # parallel branches in future, list all terminal jobs here explicitly
+    # (see terraform_provider_pr.yml for an example).
+    needs: [go_test_transit_payment]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - uses: ./.github/actions/run-sweep
+        with:
+          sweep_prefix: "tf-ci-main-${{ github.run_number }}"
+          age_threshold: '0s'

--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -216,7 +216,7 @@ jobs:
 
   post_sweep:
     name: post-test sweep
-    if: always()
+    if: ${{ always() && !cancelled() }}
     # go_test_transit_payment is the terminal node of a strictly linear chain
     # (databases -> subscriptions -> ... -> transit_payment). If the chain gains
     # parallel branches in future, list all terminal jobs here explicitly

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -35,6 +35,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check for code changes
+        id: filter
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | \
+             grep -qE '\.go$|^go\.(mod|sum)$|^GNUmakefile$|provider/.*/testdata/|^\.github/|^scripts/'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
@@ -178,8 +197,8 @@ jobs:
 
   pre_sweep:
     name: pre-test sweep
-    needs: [lint-complete]
-    if: github.event.pull_request.draft == false
+    needs: [lint-complete, detect-changes]
+    if: github.event.pull_request.draft == false && needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -366,8 +385,9 @@ jobs:
 
   post_sweep:
     name: post-test sweep
-    if: ${{ always() && github.event.pull_request.draft == false }}
+    if: ${{ always() && github.event.pull_request.draft == false && needs.detect-changes.outputs.code == 'true' }}
     needs:
+      - detect-changes
       - go_test_smoke_aa_db
       - go_test_smoke_aa_regions
       - go_test_smoke_aa_enable_default_user

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -28,6 +28,7 @@ env:
   GCP_VPC_ID: ${{ secrets.GCP_VPC_ID }}
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+  TEST_RESOURCE_PREFIX: "tf-ci-pr${{ github.event.pull_request.number }}-${{ github.run_number }}"
 
 concurrency:
   group: <span class="math-inline">\{\{ github\.workflow \}\}\-</span>{{ github.ref }}
@@ -175,9 +176,23 @@ jobs:
     steps:
       - run: echo "All linting and validation checks passed"
 
+  pre_sweep:
+    name: pre-test sweep
+    needs: [lint-complete]
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - uses: ./.github/actions/run-sweep
+        with:
+          sweep_prefix: 'tf-ci'
+
   go_test_smoke_aa_sub:
     name: go test smoke aa sub
-    needs: [lint-complete]
+    needs: [pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -229,7 +244,7 @@ jobs:
 
   go_test_smoke_pro_sub:
     name: go test smoke pro sub
-    needs: [lint-complete]
+    needs: [pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -255,7 +270,7 @@ jobs:
 
   go_test_smoke_essentials_sub:
     name: go test smoke essentials sub
-    needs: [lint-complete]
+    needs: [pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -282,7 +297,7 @@ jobs:
 
   go_test_smoke_misc:
     name: go test smoke misc
-    needs: [lint-complete]
+    needs: [pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -308,7 +323,7 @@ jobs:
 
   go_test_block_public_endpoints:
     name: go test smoke public endpoints
-    needs: [lint-complete]
+    needs: [pre_sweep]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -348,3 +363,26 @@ jobs:
             echo "::error::Documentation validation failed. Run 'tfplugindocs generate' and commit the changes."
             exit 1
           fi
+
+  post_sweep:
+    name: post-test sweep
+    if: ${{ always() && github.event.pull_request.draft == false }}
+    needs:
+      - go_test_smoke_aa_db
+      - go_test_smoke_aa_regions
+      - go_test_smoke_aa_enable_default_user
+      - go_test_smoke_pro_db
+      - go_test_smoke_essentials_db
+      - go_test_smoke_misc
+      - go_test_pro_db_upgrade
+      - go_test_block_public_endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - uses: ./.github/actions/run-sweep
+        with:
+          sweep_prefix: "tf-ci-pr${{ github.event.pull_request.number }}-${{ github.run_number }}"
+          age_threshold: '0s'

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -47,7 +47,15 @@ jobs:
       - name: Check for code changes
         id: filter
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | \
+          set -euo pipefail
+          BASE="origin/${{ github.base_ref }}"
+          if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+            echo "::error::Could not resolve $BASE - defaulting to code=true"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BASE...HEAD")
+          if echo "$CHANGED" | \
              grep -qE '\.go$|^go\.(mod|sum)$|^GNUmakefile$|provider/.*/testdata/|^\.github/|^scripts/'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
+# Unreleased
+
+
+## Changed
+
+- CI: Isolated test resources per workflow run and added automatic cleanup sweeps to prevent orphaned cloud resources.
+
 # 2.11.0 (16th February 2026)
 
 ## Added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ $(BIN)/%:
 	@echo "Installing tools from tools/tools.go"
 	@cat tools/tools.go | grep _ | awk -F '"' '{print $$2}' | GOBIN=$(BIN) xargs -tI {} go install {}
 
-.PHONY: build clean fmt fmtcheck lint testacc testacc-essentials generate_coverage install_local sweep tfproviderlint tfproviderlintx
+.PHONY: build clean fmt fmtcheck lint testacc testacc-essentials generate_coverage install_local sweep sweep-prefix tfproviderlint tfproviderlintx
 
 build: bin fmtcheck
 	@echo "Building local provider binary"
@@ -69,6 +69,13 @@ install_local: build
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test ./provider -v -sweep=ALL $(SWEEPARGS) -timeout 30m
+
+sweep-prefix:
+ifndef TEST_RESOURCE_PREFIX
+	$(error TEST_RESOURCE_PREFIX is not set. Usage: TEST_RESOURCE_PREFIX=tf-ci-12345 make sweep-prefix)
+endif
+	@echo "WARNING: This will destroy infrastructure matching prefix '$(TEST_RESOURCE_PREFIX)'. Use only in development accounts."
+	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) SWEEP_AGE_THRESHOLD=0s go test ./provider -v -sweep=ALL $(SWEEPARGS) -timeout 30m
 
 tfproviderlintx: $(BIN)/tfproviderlintx
 	$(BIN)/tfproviderlintx $(TFPROVIDERLINT_ARGS) ./...

--- a/provider/datasource_rediscloud_pro_database_test.go
+++ b/provider/datasource_rediscloud_pro_database_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceRedisCloudProDatabase_basic(t *testing.T) {
 	password := acctest.RandString(20)
 
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	content := utils.GetTestConfig(t, "./pro/testdata/pro_database_data_source.tf")
 	config := fmt.Sprintf(content, testCloudAccountName, subscriptionName, password)

--- a/provider/datasource_rediscloud_pro_subscription_test.go
+++ b/provider/datasource_rediscloud_pro_subscription_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceRedisCloudProSubscription_basic(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix("tf-test")
+	name := testRandomWithPrefix()
 
 	const resourceName = "rediscloud_subscription.example"
 	const dataSourceName = "data.rediscloud_subscription.example"
@@ -82,7 +82,7 @@ func TestAccDataSourceRedisCloudProSubscription_ignoresAA(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 
 	config := utils.GetTestConfig(t, AADatabaseProDatasourceConfigPath)

--- a/provider/datasource_rediscloud_subscription_peerings_test.go
+++ b/provider/datasource_rediscloud_subscription_peerings_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -16,7 +15,7 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/rediscloud_acl_role_test.go
+++ b/provider/rediscloud_acl_role_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -20,7 +19,7 @@ func TestAccResourceRedisCloudAclRole_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	prefix := acctest.RandomWithPrefix(testResourcePrefix)
+	prefix := testRandomWithPrefix()
 	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	exampleSubscriptionName := prefix + "-subscription"
 	exampleDatabasePassword := prefix + "aA.1"

--- a/provider/rediscloud_acl_user_test.go
+++ b/provider/rediscloud_acl_user_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -20,7 +19,7 @@ func TestAccResourceRedisCloudAclUser_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	prefix := acctest.RandomWithPrefix(testResourcePrefix)
+	prefix := testRandomWithPrefix()
 	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	exampleSubscriptionName := prefix + "-subscription"
 	exampleDatabasePassword := prefix + "aA.1"

--- a/provider/rediscloud_active_active_database_block_public_endpoints_test.go
+++ b/provider/rediscloud_active_active_database_block_public_endpoints_test.go
@@ -24,7 +24,7 @@ func TestAccActiveActiveSubscriptionDatabase_DefaultSourceIPs_PrivateAccess(t *t
 	const databaseResource = "rediscloud_active_active_subscription_database.example"
 	const datasourceName = "data.rediscloud_active_active_subscription_database.example"
 	password := acctest.RandString(20)
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	contentDisabled := utils.GetTestConfig(t, "./activeactive/testdata/public_endpoint_disabled_default_source_ips.tf")
 	configDisabled := fmt.Sprintf(contentDisabled, subscriptionName, password)
@@ -70,7 +70,7 @@ func TestAccActiveActiveSubscriptionDatabase_DefaultSourceIPs_PublicAccess(t *te
 	const databaseResource = "rediscloud_active_active_subscription_database.example"
 	const datasourceName = "data.rediscloud_active_active_subscription_database.example"
 	password := acctest.RandString(20)
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	contentEnabled := utils.GetTestConfig(t, "./activeactive/testdata/public_endpoint_enabled_default_source_ips.tf")
 	configEnabled := fmt.Sprintf(contentEnabled, subscriptionName, password)
@@ -110,7 +110,7 @@ func TestAccActiveActiveSubscriptionDatabase_BlockPublicEndpoints(t *testing.T) 
 	const databaseResource = "rediscloud_active_active_subscription_database.example"
 	const datasourceName = "data.rediscloud_active_active_subscription_database.example"
 	password := acctest.RandString(20)
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	contentDisabled := utils.GetTestConfig(t, "./activeactive/testdata/public_endpoint_disabled.tf")
 	configDisabled := fmt.Sprintf(contentDisabled, subscriptionName, password)

--- a/provider/rediscloud_active_active_database_enable_default_user_test.go
+++ b/provider/rediscloud_active_active_database_enable_default_user_test.go
@@ -26,8 +26,8 @@ import (
 // Bug behaviour: us-east-1 incorrectly got enable_default_user = true
 // Fixed behaviour: us-east-1 should inherit false from global
 func TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUserInheritance(t *testing.T) {
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-inherit-test"
-	databaseName := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	subscriptionName := testRandomWithPrefix() + "-inherit-test"
+	databaseName := testRandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 
 	const resourceName = "rediscloud_active_active_subscription_database.test"
@@ -63,8 +63,8 @@ func TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUserInheritance(
 }
 
 func TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUser(t *testing.T) {
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-enable-default-user"
-	databaseName := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	subscriptionName := testRandomWithPrefix() + "-enable-default-user"
+	databaseName := testRandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 
 	const resourceName = "rediscloud_active_active_subscription_database.test"

--- a/provider/rediscloud_active_active_database_test.go
+++ b/provider/rediscloud_active_active_database_test.go
@@ -18,8 +18,8 @@ import (
 
 // Checks CRUDI (CREATE, READ, UPDATE, IMPORT) operations on the database resource.
 func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-subscription"
-	databaseName := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	subscriptionName := testRandomWithPrefix() + "-subscription"
+	databaseName := testRandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 
 	const databaseResourceName = "rediscloud_active_active_subscription_database.example"
@@ -253,8 +253,8 @@ func TestAccResourceRedisCloudActiveActiveDatabase_optionalAttributes(t *testing
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-subscription"
-	name := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	subscriptionName := testRandomWithPrefix() + "-subscription"
+	name := testRandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_active_active_subscription_database.example"
 	portNumber := 10101
@@ -279,7 +279,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_timeUtcRequiresValidInterval(
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	password := acctest.RandString(20)
 
@@ -431,7 +431,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_autoMinorVersionUpgrade(t *te
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 	t.Skip("auto_minor_version_upgrade feature temporarily removed")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-subscription"
+	subscriptionName := testRandomWithPrefix() + "-subscription"
 	const resourceName = "rediscloud_active_active_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -468,8 +468,8 @@ func TestAccResourceRedisCloudActiveActiveDatabase_autoMinorVersionUpgrade(t *te
 }
 
 func TestAccResourceRedisCloudActiveActiveDatabase_modulesImmutable(t *testing.T) {
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-modules-immutable"
-	databaseName := acctest.RandomWithPrefix(testResourcePrefix) + "-database"
+	subscriptionName := testRandomWithPrefix() + "-modules-immutable"
+	databaseName := testRandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/provider/rediscloud_active_active_private_link_test.go
+++ b/provider/rediscloud_active_active_private_link_test.go
@@ -29,8 +29,8 @@ func TestAccResourceRedisCloudActiveActivePrivateLink_CRUDI(t *testing.T) {
 	const datasourceName = "data.rediscloud_active_active_private_link.aa_private_link"
 
 	// Generate names reused across configs
-	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-aa-private-link"
-	shareName := acctest.RandomWithPrefix(testResourcePrefix) + "-privatelink-aa"
+	subName := testRandomWithPrefix() + "-aa-private-link"
+	shareName := testRandomWithPrefix() + "-privatelink-aa"
 	password := acctest.RandString(20)
 
 	terraformConfig := getRedisActiveActivePrivateLinkConfigWithNames(t, subName, shareName, password)
@@ -86,7 +86,7 @@ func TestAccResourceRedisCloudActiveActivePrivateLink_CRUDI(t *testing.T) {
 }
 
 func getRedisActiveActivePrivateLinkConfig(t *testing.T, testFile, shareName, password string) string {
-	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-aa-private-link"
+	subName := testRandomWithPrefix() + "-aa-private-link"
 	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	content := utils.GetTestConfig(t, testFile)
 	return fmt.Sprintf(content, subName, exampleCloudAccountName, shareName, password)

--- a/provider/rediscloud_active_active_private_service_connect_endpoint_accepter_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_endpoint_accepter_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/psc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -19,7 +18,7 @@ func TestAccResourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepter_
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-pscea"
+	baseName := testRandomWithPrefix() + "-pro-pscea"
 
 	const resourceName = "rediscloud_active_active_private_service_connect_endpoint_accepter.accepter"
 	gcpProjectId := os.Getenv("GCP_PROJECT_ID")

--- a/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -16,7 +15,7 @@ func TestAccResourceRedisCloudActiveActivePrivateServiceConnectEndpoint_CRUDI(t 
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-psce"
+	baseName := testRandomWithPrefix() + "-pro-psce"
 
 	const resourceName = "rediscloud_active_active_private_service_connect_endpoint.psce"
 	const datasourceName = "data.rediscloud_active_active_private_service_connect_endpoints.psce"

--- a/provider/rediscloud_active_active_private_service_connect_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -14,7 +13,7 @@ func TestAccResourceRedisCloudActiveActivePrivateServiceConnect_CRUDI(t *testing
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-psc"
+	baseName := testRandomWithPrefix() + "-pro-psc"
 
 	const resourceName = "rediscloud_active_active_private_service_connect.psc"
 	const datasourceName = "data.rediscloud_active_active_private_service_connect.psc"

--- a/provider/rediscloud_active_active_subscription_test.go
+++ b/provider/rediscloud_active_active_subscription_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -28,7 +27,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI_Redis7(t *testing.T
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 	const datasourceSubscriptionName = "data.rediscloud_active_active_subscription.example"
 	const datasourceRegionName = "data.rediscloud_active_active_subscription_regions.example"
@@ -280,7 +279,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CRUDI_Redis8(t *testing.T
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 	const datasourceSubscriptionName = "data.rediscloud_active_active_subscription.example"
 	const datasourceRegionName = "data.rediscloud_active_active_subscription_regions.example"
@@ -532,7 +531,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateContractPayme
 		t.Skip("The '-activeActiveContract' parameter wasn't provided in the test command.")
 	}
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_active_active_subscription.example"
 
@@ -572,7 +571,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 		t.Skip("The '-activeActiveMarketplace' parameter wasn't provided in the test command.")
 	}
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_active_active_subscription.example"
 
@@ -608,7 +607,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_PublicEndpointAccess(t *t
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -824,7 +823,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_RemoveRedisVersion(t *tes
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 
 	var subIdStep1 int

--- a/provider/rediscloud_active_active_transit_gateway_invitation_acceptor_test.go
+++ b/provider/rediscloud_active_active_transit_gateway_invitation_acceptor_test.go
@@ -19,8 +19,8 @@ func TestAccResourceRedisCloudActiveActiveTransitGatewayInvitationAcceptor_CRUDI
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	testAwsRegion := os.Getenv("AWS_REGION")
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-aa-tgw"
-	databaseName := acctest.RandomWithPrefix(testResourcePrefix) + "-aa-tgw-db"
+	subscriptionName := testRandomWithPrefix() + "-aa-tgw"
+	databaseName := testRandomWithPrefix() + "-aa-tgw-db"
 	databasePassword := acctest.RandString(20)
 
 	const invitationsDatasourceName = "data.rediscloud_active_active_transit_gateway_invitations.test"

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -44,7 +43,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Free_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	subscriptionNameUpdated := subscriptionName + "-updated"
 
 	const resourceName = "rediscloud_essentials_subscription.example"
@@ -109,7 +108,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_CreditCard_CRUDI(t *te
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	subscriptionNameUpdated := subscriptionName + "-updated"
 
 	const resourceName = "rediscloud_essentials_subscription.example"
@@ -175,7 +174,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_NoPaymentType_CRUDI(t 
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	subscriptionNameUpdated := subscriptionName + "-updated"
 
 	const resourceName = "rediscloud_essentials_subscription.example"
@@ -246,7 +245,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_Marketplace_CRUDI(t *t
 		t.Skip("The '-essentialsMarketplace' parameter wasn't provided in the test command.")
 	}
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	subscriptionNameUpdated := subscriptionName + "-updated"
 
 	const resourceName = "rediscloud_essentials_subscription.example"
@@ -312,7 +311,7 @@ func TestAccResourceRedisCloudEssentialsSubscription_Paid_Marketplace_CRUDI(t *t
 func TestAccResourceRedisCloudEssentialsSubscription_Incorrect_PaymentIdForType(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/provider/rediscloud_private_link_test.go
+++ b/provider/rediscloud_private_link_test.go
@@ -30,8 +30,8 @@ func TestAccResourceRedisCloudPrivateLink_CRUDI(t *testing.T) {
 	const datasourceName = "data.rediscloud_private_link.pro_private_link"
 
 	// Generate names reused across configs
-	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-private-link"
-	shareName := acctest.RandomWithPrefix(testResourcePrefix) + "-privatelink"
+	subName := testRandomWithPrefix() + "-pro-private-link"
+	shareName := testRandomWithPrefix() + "-privatelink"
 	password := acctest.RandString(20)
 
 	terraformConfig := getRedisPrivateLinkConfigWithNames(t, subName, shareName, password)
@@ -85,7 +85,7 @@ func TestAccResourceRedisCloudPrivateLink_CRUDI(t *testing.T) {
 }
 
 func getRedisPrivateLinkConfig(t *testing.T, shareName string) string {
-	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-private-link"
+	subName := testRandomWithPrefix() + "-pro-private-link"
 	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
 	password := acctest.RandString(20)
@@ -147,7 +147,7 @@ func TestAccResourceRedisCloudPrivateLink_PortConsistency(t *testing.T) {
 	const databaseResourceName = "rediscloud_subscription_database.pro_database"
 	const privateLinkResourceName = "rediscloud_private_link.pro_private_link"
 
-	shareName := acctest.RandomWithPrefix(testResourcePrefix) + "-port-test"
+	shareName := testRandomWithPrefix() + "-port-test"
 	terraformConfig := getRedisPrivateLinkConfig(t, shareName)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/provider/rediscloud_private_service_connect_endpoint_accepter_test.go
+++ b/provider/rediscloud_private_service_connect_endpoint_accepter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/psc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -19,7 +18,7 @@ func TestAccResourceRedisCloudPrivateServiceConnectEndpointAccepter_Create(t *te
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-pscea"
+	baseName := testRandomWithPrefix() + "-pro-pscea"
 
 	const resourceName = "rediscloud_private_service_connect_endpoint_accepter.accepter"
 	gcpProjectId := os.Getenv("GCP_PROJECT_ID")

--- a/provider/rediscloud_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_private_service_connect_endpoint_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -16,7 +15,7 @@ func TestAccResourceRedisCloudPrivateServiceConnectEndpoint_CRUDI(t *testing.T) 
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-psce"
+	baseName := testRandomWithPrefix() + "-pro-psce"
 
 	const resourceName = "rediscloud_private_service_connect_endpoint.psce"
 	const datasourceName = "data.rediscloud_private_service_connect_endpoints.psce"

--- a/provider/rediscloud_private_service_connect_test.go
+++ b/provider/rediscloud_private_service_connect_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -14,7 +13,7 @@ func TestAccResourceRedisCloudPrivateServiceConnect_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-psc"
+	baseName := testRandomWithPrefix() + "-pro-psc"
 
 	const resourceName = "rediscloud_private_service_connect.psc"
 	const datasourceName = "data.rediscloud_private_service_connect.psc"

--- a/provider/rediscloud_pro_database_block_public_endpoints_test.go
+++ b/provider/rediscloud_pro_database_block_public_endpoints_test.go
@@ -22,7 +22,7 @@ func TestAccRedisCloudProDatabase_DefaultSourceIPs_PrivateAccess(t *testing.T) {
 	const databaseResource = "rediscloud_subscription_database.example"
 	const datasourceName = "data.rediscloud_database.example"
 	password := acctest.RandString(20)
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	contentDisabled := utils.GetTestConfig(t, "./pro/testdata/pro_subscription_public_endpoint_disabled.tf")
 	configDisabled := fmt.Sprintf(contentDisabled, subscriptionName, password)
@@ -69,7 +69,7 @@ func TestAccRedisCloudProDatabase_DefaultSourceIPs_PublicAccess(t *testing.T) {
 	const databaseResource = "rediscloud_subscription_database.example"
 	const datasourceName = "data.rediscloud_database.example"
 	password := acctest.RandString(20)
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 
 	contentEnabled := utils.GetTestConfig(t, "./pro/testdata/pro_subscription_public_endpoint_enabled.tf")
 	configEnabled := fmt.Sprintf(contentEnabled, subscriptionName, password)

--- a/provider/rediscloud_transit_gateway_invitation_acceptor_test.go
+++ b/provider/rediscloud_transit_gateway_invitation_acceptor_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -19,7 +18,7 @@ func TestAccResourceRedisCloudTransitGatewayInvitationAcceptor_CRUDI(t *testing.
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	testAwsRegion := os.Getenv("AWS_REGION")
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix) + "-pro-tgw"
+	subscriptionName := testRandomWithPrefix() + "-pro-tgw"
 
 	const invitationsDatasourceName = "data.rediscloud_transit_gateway_invitations.test"
 	const acceptorResourceName = "rediscloud_transit_gateway_invitation_acceptor.test"

--- a/provider/resource_rediscloud_acl_rule_test.go
+++ b/provider/resource_rediscloud_acl_rule_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -19,7 +18,7 @@ func TestAccResourceRedisCloudAclRule_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	prefix := acctest.RandomWithPrefix(testResourcePrefix)
+	prefix := testRandomWithPrefix()
 	testName := prefix + "-test-rule"
 	const testRule = "+@all"
 

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
@@ -20,7 +19,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 	utils.AccRequiresEnvVar(t, "GCP_CMK_RESOURCE_NAME")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 	gcpCmkResourceName := os.Getenv("GCP_CMK_RESOURCE_NAME")
 
@@ -163,7 +162,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_Automated(t *testing.
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"
 	gcpProjectId := os.Getenv("GCP_PROJECT_ID")
 

--- a/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -20,7 +19,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_aws(t *testing.T) 
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TEST_PEERING")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	awsRegion := "eu-west-1"
 
 	const resourceName = "rediscloud_active_active_subscription_peering.test"
@@ -71,7 +70,7 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_gcp(t *testing.T) 
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TEST_PEERING")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudActiveActiveSubscriptionPeeringGCP,
 		name,

--- a/provider/resource_rediscloud_active_active_subscription_regions_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_regions_test.go
@@ -18,8 +18,8 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionRegions_CRUDI(t *testing.T
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TEST_SUB_ACTIVE_ACTIVE")
 
-	subName := acctest.RandomWithPrefix(testResourcePrefix) + "-regions-test"
-	dbName := acctest.RandomWithPrefix(testResourcePrefix) + "-regions" + "-db"
+	subName := testRandomWithPrefix() + "-regions-test"
+	dbName := testRandomWithPrefix() + "-regions" + "-db"
 	dbPass := acctest.RandString(20)
 	const resourceName = "rediscloud_active_active_subscription_regions.example"
 	const datasourceRegionName = "data.rediscloud_active_active_subscription_regions.example"

--- a/provider/resource_rediscloud_cloud_account_test.go
+++ b/provider/resource_rediscloud_cloud_account_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -24,7 +23,7 @@ func TestAccResourceRedisCloudCloudAccount_basic(t *testing.T) {
 		t.Skip("Required environment variables currently not available under CI")
 	}
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudCloudAccount,
 		os.Getenv("AWS_ACCESS_KEY_ID"),

--- a/provider/resource_rediscloud_essentials_database_test.go
+++ b/provider/resource_rediscloud_essentials_database_test.go
@@ -1,21 +1,20 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-
-	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
-
 	"fmt"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )
 
 func TestAccResourceRedisCloudEssentialsDatabase_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	databaseName := subscriptionName + "-db"
 	databaseNameUpdated := databaseName + "-updated"
 
@@ -272,7 +271,7 @@ data "rediscloud_essentials_database" "example" {
 func TestAccResourceRedisCloudEssentialsDatabase_DisableDefaultUser(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	databaseName := subscriptionName + "-db"
 	databaseNameUpdated := databaseName + "-updated"
 
@@ -339,7 +338,7 @@ func TestAccResourceRedisCloudEssentialsDatabase_DisableDefaultUser(t *testing.T
 func TestAccResourceRedisCloudEssentialsDatabase_RedisVersion(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	databaseName := subscriptionName + "-db"
 
 	const resourceName = "rediscloud_essentials_database.example"
@@ -373,7 +372,7 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersion(t *testing.T) {
 func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionUpgrade(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := acctest.RandomWithPrefix(testResourcePrefix)
+	subscriptionName := testRandomWithPrefix()
 	databaseName := subscriptionName + "-db"
 	password := "test-password-123!"
 

--- a/provider/resource_rediscloud_pro_database_qpf_test.go
+++ b/provider/resource_rediscloud_pro_database_qpf_test.go
@@ -109,7 +109,7 @@ func testErrorCase(t *testing.T, config string, expectedError *regexp.Regexp) {
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf(t *testing.T) {
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -143,7 +143,7 @@ func TestAccResourceRedisCloudProDatabase_qpf(t *testing.T) {
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf_missingModule(t *testing.T) {
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -153,7 +153,7 @@ func TestAccResourceRedisCloudProDatabase_qpf_missingModule(t *testing.T) {
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf_missingRediSearchModule(t *testing.T) {
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -163,7 +163,7 @@ func TestAccResourceRedisCloudProDatabase_qpf_missingRediSearchModule(t *testing
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf_invalidQueryPerformanceFactors(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-test")
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -173,7 +173,7 @@ func TestAccResourceRedisCloudProDatabase_qpf_invalidQueryPerformanceFactors(t *
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf_invalidQueryPerformanceFactors_outOfRange(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-test")
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/resource_rediscloud_pro_database_redis_8_test.go
+++ b/provider/resource_rediscloud_pro_database_redis_8_test.go
@@ -21,7 +21,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
@@ -101,7 +101,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_RamAndFlash_CRUDI(t *testing.T)
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
@@ -247,7 +247,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_Upgrade(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
@@ -335,7 +335,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_Upgrade(t *testing.T) {
 func TestAccResourceRedisCloudProDatabase_Redis8_ModulesBlocked(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/resource_rediscloud_pro_database_test.go
+++ b/provider/resource_rediscloud_pro_database_test.go
@@ -21,7 +21,7 @@ func TestAccResourceRedisCloudProDatabase_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
@@ -164,7 +164,7 @@ func TestAccResourceRedisCloudProDatabase_optionalAttributes(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	portNumber := 10101
@@ -193,7 +193,7 @@ func TestAccResourceRedisCloudProDatabase_timeUtcRequiresValidInterval(t *testin
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -214,7 +214,7 @@ func TestAccResourceRedisCloudProDatabase_MultiModules(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	dbName := "db-multi-modules"
 	const resourceName = "rediscloud_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
@@ -247,7 +247,7 @@ func TestAccResourceRedisCloudProDatabase_respversion(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	portNumber := 10101
@@ -297,7 +297,7 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 	t.Skip("auto_minor_version_upgrade feature temporarily removed")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription_database.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
@@ -19,7 +18,7 @@ func TestAccResourceRedisCloudProSubscription_CMK(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 	utils.AccRequiresEnvVar(t, "GCP_CMK_RESOURCE_NAME")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	gcpCmkResourceName := os.Getenv("GCP_CMK_RESOURCE_NAME")
 

--- a/provider/resource_rediscloud_pro_subscription_qpf_test.go
+++ b/provider/resource_rediscloud_pro_subscription_qpf_test.go
@@ -74,7 +74,7 @@ func testSubErrorCase(t *testing.T, config string, expectedError *regexp.Regexp)
 }
 
 func TestAccResourceRedisCloudProSubscription_qpf(t *testing.T) {
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	const resourceName = "rediscloud_subscription.example"
 
@@ -110,7 +110,7 @@ func TestAccResourceRedisCloudProSubscription_qpf(t *testing.T) {
 }
 
 func TestAccResourceRedisCloudProSubscription_invalidQueryPerformanceFactors(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-test")
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -120,7 +120,7 @@ func TestAccResourceRedisCloudProSubscription_invalidQueryPerformanceFactors(t *
 }
 
 func TestAccResourceRedisCloudProSubscription_invalidQueryPerformanceFactors_outOfRange(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-test")
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/resource_rediscloud_pro_subscription_test.go
+++ b/provider/resource_rediscloud_pro_subscription_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis7(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -143,7 +142,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis8(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -250,7 +249,7 @@ func TestAccResourceRedisCloudProSubscription_preferredAZsModulesOptional(t *tes
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -278,7 +277,7 @@ func TestAccResourceRedisCloudProSubscription_createUpdateContractPayment(t *tes
 		t.Skip("The '-contract' parameter wasn't provided in the test command.")
 	}
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
@@ -317,7 +316,7 @@ func TestAccResourceRedisCloudProSubscription_createUpdateMarketplacePayment(t *
 		t.Skip("The '-marketplace' parameter wasn't provided in the test command.")
 	}
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
@@ -350,7 +349,7 @@ func TestAccResourceRedisCloudProSubscription_RedisVersion(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
 	identifier := ""
@@ -398,7 +397,7 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix) + "-mw"
+	name := testRandomWithPrefix() + "-mw"
 	resourceName := "rediscloud_subscription.example"
 	datasourceName := "data.rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
@@ -551,7 +550,7 @@ func TestAccResourceRedisCloudProSubscription_PublicEndpointAccess(t *testing.T)
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	resourceName := "rediscloud_subscription.example"
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 

--- a/provider/resource_rediscloud_pro_tls_test.go
+++ b/provider/resource_rediscloud_pro_tls_test.go
@@ -24,7 +24,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"
@@ -131,7 +131,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"
@@ -210,7 +210,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -235,7 +235,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseAndDisabledTlsAn
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TEST_SUBSCRIPTION")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -260,7 +260,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithoutEnableTlsAndTlsCert(t
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -284,7 +284,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithSslCertAndTlsCert(t *tes
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -309,7 +309,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -17,7 +16,7 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
@@ -81,7 +80,7 @@ func TestAccResourceRedisCloudSubscriptionPeering_gcp(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := acctest.RandomWithPrefix(testResourcePrefix)
+	name := testRandomWithPrefix()
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudSubscriptionPeeringGCP,
 		name,

--- a/provider/sweeper_test.go
+++ b/provider/sweeper_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // testResourcePrefix is the prefix used for all test resource names.
-// Set TEST_RESOURCE_PREFIX env var to override (e.g. "tf-ci-<run_id>" in CI).
+// Set TEST_RESOURCE_PREFIX env var to override (e.g. "tf-ci-pr7-42" in CI).
 // This also controls which resources the sweeper targets.
 var testResourcePrefix = getTestResourcePrefix()
 
@@ -59,8 +59,7 @@ func sweepAgeThreshold() time.Duration {
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		log.Printf("[WARN] Invalid SWEEP_AGE_THRESHOLD %q, falling back to 24h: %v", raw, err)
-		return 24 * time.Hour
+		log.Fatalf("[ERROR] Invalid SWEEP_AGE_THRESHOLD %q: %v (expected Go duration like '2h', '30m', '0s')", raw, err)
 	}
 	log.Printf("[INFO] Sweep age threshold set to %s via SWEEP_AGE_THRESHOLD", d)
 	return d


### PR DESCRIPTION
# Changed

- CI: Isolated test resources per workflow run and added automatic cleanup sweeps to prevent orphaned cloud resources.