### PR TITLE
OPCR-32: nilcheck consistency for qpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
+# Unreleased
+
+## Fixed
+- `rediscloud_subscription_database`: Fixed inconsistent handling of `query_performance_factor` and `redis_version` when not set, ensuring nil values are not written to state as empty strings.
+
 # 2.11.0 (16th February 2026)
 
 ## Added

--- a/provider/pro/resource_rediscloud_pro_database.go
+++ b/provider/pro/resource_rediscloud_pro_database.go
@@ -600,12 +600,16 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
-		return diag.FromErr(err)
+	if db.QueryPerformanceFactor != nil {
+		if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
-		return diag.FromErr(err)
+	if db.RedisVersion != nil {
+		if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	// For Redis 8.0+, modules are bundled by default and returned by the API
@@ -730,7 +734,7 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if db.QueryPerformanceFactor != nil {
-		if err := d.Set("query_performance_factor", redis.String(*db.QueryPerformanceFactor)); err != nil {
+		if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/provider/pro/resource_rediscloud_pro_subscription.go
+++ b/provider/pro/resource_rediscloud_pro_subscription.go
@@ -167,8 +167,8 @@ func ResourceRedisCloudProSubscription() *schema.Resource {
 							Set: func(v interface{}) int {
 								var buf bytes.Buffer
 								m := v.(map[string]interface{})
-								buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
-								buf.WriteString(fmt.Sprintf("%t-", m["multiple_availability_zones"].(bool)))
+								fmt.Fprintf(&buf, "%s-", m["region"].(string))
+								fmt.Fprintf(&buf, "%t-", m["multiple_availability_zones"].(bool))
 								return schema.HashString(buf.String())
 							},
 							Elem: &schema.Resource{

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -144,7 +144,7 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 							Set: func(v interface{}) int {
 								var buf bytes.Buffer
 								m := v.(map[string]interface{})
-								buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
+								fmt.Fprintf(&buf, "%s-", m["region"].(string))
 								return schema.HashString(buf.String())
 							},
 							Elem: &schema.Resource{


### PR DESCRIPTION
## Fixed
`rediscloud_subscription_database`: Fixed inconsistent handling of `query_performance_factor` and `redis_version` when not set, ensuring nil values are not written to state as empty strings.