### PR TITLE
OPCR-32: fix: nilcheck consistency for qpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
+# Unreleased
+
+## Fixed
+- `rediscloud_subscription_database`: Fixed inconsistent handling of `query_performance_factor` and `redis_version` when not set, ensuring nil values are not written to state as empty strings.
+
+
 # 2.14.0 (1st April 2026)
 
 ## Added

--- a/provider/pro/resource_rediscloud_pro_database.go
+++ b/provider/pro/resource_rediscloud_pro_database.go
@@ -609,12 +609,16 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
-		return diag.FromErr(err)
+	if db.QueryPerformanceFactor != nil {
+		if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
-		return diag.FromErr(err)
+	if db.RedisVersion != nil {
+		if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	// For Redis 8.0+, modules are bundled by default and returned by the API
@@ -753,7 +757,7 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if db.QueryPerformanceFactor != nil {
-		if err := d.Set("query_performance_factor", redis.String(*db.QueryPerformanceFactor)); err != nil {
+		if err := d.Set("query_performance_factor", redis.StringValue(db.QueryPerformanceFactor)); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
## Fixed
- `rediscloud_subscription_database`: Fixed inconsistent handling of `query_performance_factor` and `redis_version` when not set, ensuring nil values are not written to state as empty strings.