### PR TITLE
OPCR-14: Active-Active on BYOC - network resources managed by customer

### DIFF
--- a/docs/data-sources/rediscloud_active_active_subscription.md
+++ b/docs/data-sources/rediscloud_active_active_subscription.md
@@ -39,6 +39,8 @@ output "rediscloud_active_active_subscription" {
   Changes to) this attribute are ignored after creation.**
 * `payment_method_id` - A valid payment method pre-defined in the current account
 * `cloud_provider` - The cloud provider used with the subscription, (either `AWS` or `GCP`).
+* `cloud_account_id` - Cloud account identifier, (A Cloud Account Id = 1 implies using Redis Labs internal cloud account)
+* `regions` - A list of regions associated with the subscription, documented below
 * `number_of_databases` - The number of databases that are linked to this subscription.
 * `status` - Current status of the subscription
 * `customer_managed_key_enabled` - Whether customer managed key encryption is enabled for the subscription
@@ -70,3 +72,13 @@ The `pricing` object has these attributes:
 * `priceCurrency` - Self-explanatory e.g. 'USD'.
 * `pricePeriod` - Self-explanatory e.g. 'hour'.
 * `region` - Self-explanatory, if the cost is associated with a particular region.
+
+The `regions` object has these attributes:
+
+* `region` - Deployment region as defined by the cloud provider
+* `networking` - Networking details for the region, documented below
+
+The `networking` object has these attributes:
+
+* `deployment_cidr` - Deployment CIDR mask
+* `vpc_id` - VPC ID for the region

--- a/docs/resources/rediscloud_active_active_subscription.md
+++ b/docs/resources/rediscloud_active_active_subscription.md
@@ -62,10 +62,28 @@ The following arguments are supported:
 * `cloud_provider` - (Optional) The cloud provider to use with the subscription, (either `AWS` or `GCP`). Default: ‘AWS’. **Modifying this attribute will force creation of a new resource.**
 * `redis_version` - (Optional) The Redis version of the databases in the subscription. If omitted, the Redis version will be the default. **Deprecated: This attribute is deprecated on the subscription level. Please specify `redis_version` on databases directly instead.**
 * `creation_plan` - (Required) A creation plan object, documented below. Ignored after creation.
+* `cloud_account_id` - (Optional) The ID of the cloud account to use with the subscription. If omitted, the default cloud account will be used. **Modifying this attribute will force creation of a new resource.**   
+ (using Cloud Account ID = 1 implies using Redis Labs internal cloud account). Note that a GCP subscription can be created only with Redis Labs internal cloud account
+* `prevent_destroy_regions` - (Optional) Prevent regions from being destroyed when they are removed from `regions` block. Default: 'true'.
+* `regions` - (Optional) Cloud networking details, per region (multiple regions for Active-Active cluster), documented below.
 * `maintenance_windows` - (Optional) The subscription's maintenance window specification, documented below.
 * `customer_managed_key_enabled` - (Optional) Whether to enable the CMK flow.
 * `customer_managed_key_deletion_grace_period` - (Optional) The grace period for deleting the subscription. If not set, will default to immediate deletion grace period.
 * `customer_managed_key` - (Optional) The customer managed keys (CMK) to use for this subscription. In an active-active subscription, you must set a key for each region.
+
+The `regions` block supports:
+
+* `region` - (Required) Deployment region as defined by the cloud provider
+* `preferred_availability_zones` - (Optional) List of availability zones used
+* `write_operations_per_second` - (Optional) Write operations per second for databases in this region. Used only on database creation in region. Default: 1000. 
+* `read_operations_per_second` - (Optional) Read operations per second for databases in this region. Used only on database creation in region. Default: 1000.
+* `networking` - (Required) Networking details for the region, documented below
+
+The `networking` block supports:
+* `deployment_cidr` - (Optional) Deployment CIDR mask. The total number of bits must be 24 (x.x.x.x/24). Should not be set if `subnet_ids` or `security_group_id` is set.
+* `vpc_id` - (Optional) Either an existing VPC Id (already exists in the specific region) or create a new VPC (if no VPC is specified). VPC Identifier must be in a valid format (for example: ‘vpc-0125be68a4986384ad’) and exist within the hosting account. **Modifying this attribute will force creation of a new resource.**
+* `subnet_ids` - (Optional) List of existing subnets Ids (already exists in the specific region). Subnet Identifier must be in a valid format (for example: ‘subnet-0125be68a4986384ad’) and exist within the hosting account. **Modifying this attribute will force creation of a new resource.**
+* `security_group_id` - (Optional) The security group ID to use for the subscription. **Modifying this attribute will force creation of a new resource.**
 
 The `creation_plan` block supports:
 
@@ -115,6 +133,10 @@ The `pricing` object has these attributes:
 * `priceCurrency` - The price currency
 * `pricePeriod` - Price period. E.g. 'hour'.
 * `region` - Specify if the cost is associated with a particular region.
+
+The `regions` object has these attributes:
+
+* `multiple_availability_zones` - Support deployment on multiple availability zones within the selected region. Always `true` for active-active subscriptions.
 
 ### Timeouts
 

--- a/provider/datasource_rediscloud_active_active_subscription.go
+++ b/provider/datasource_rediscloud_active_active_subscription.go
@@ -74,6 +74,44 @@ func dataSourceRedisCloudActiveActiveSubscription() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"cloud_account_id": {
+				Description: "Cloud account identifier. Default: Redis Labs internal cloud account (using Cloud Account Id = 1 implies using Redis Labs internal cloud account). Note that a GCP subscription can be created only with Redis Labs internal cloud account",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"regions": {
+				Description: "Cloud networking details, per region (multiple regions for Active-Active cluster)",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Description: "Deployment region as defined by cloud provider",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"networking": {
+							Description: "Networking details for the region",
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deployment_cidr": {
+										Description: "Deployment CIDR mask",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"vpc_id": {
+										Description: "Identifier of the VPC to be peered, set by the API",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"maintenance_windows": {
 				Description: "Details about the subscription's maintenance window specification",
 				Type:        schema.TypeList,
@@ -177,25 +215,25 @@ func dataSourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sc
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
 
-	subs, err := api.Client.Subscription.List(ctx)
+	subs, err := api.Client.Subscription.ListActiveActive(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var filters []func(method *subscriptions.Subscription) bool
+	var filters []func(method *subscriptions.ActiveActiveSubscription) bool
 
 	// Filter to AA subscriptions only (pro subs come from the same endpoint)
-	filters = append(filters, func(sub *subscriptions.Subscription) bool {
+	filters = append(filters, func(sub *subscriptions.ActiveActiveSubscription) bool {
 		return redis.StringValue(sub.DeploymentType) == "active-active"
 	})
 
 	if name, ok := d.GetOk("name"); ok {
-		filters = append(filters, func(sub *subscriptions.Subscription) bool {
+		filters = append(filters, func(sub *subscriptions.ActiveActiveSubscription) bool {
 			return redis.StringValue(sub.Name) == name
 		})
 	}
 
-	subs = pro.FilterSubscriptions(subs, filters)
+	subs = filterSubscriptions(subs, filters)
 
 	if len(subs) == 0 {
 		return diag.Errorf("Your query returned no results. Please change your search criteria and try again.")
@@ -276,6 +314,24 @@ func dataSourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sc
 				return diag.FromErr(err)
 			}
 		}
+		if cloudDetails[0].CloudAccountID != nil {
+			if err := d.Set("cloud_account_id", strconv.Itoa(redis.IntValue(cloudDetails[0].CloudAccountID))); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+		if cloudDetails[0].Regions != nil && len(cloudDetails[0].Regions) > 0 {
+			regions := make([]map[string]interface{}, 0)
+			for _, region := range cloudDetails[0].Regions {
+				regionMap := make(map[string]interface{})
+				regionMap["region"] = redis.StringValue(region.Region)
+				regionMap["deployment_cidr"] = redis.StringValue(region.DeploymentCIDR)
+				regionMap["vpc_id"] = redis.StringValue(region.VpcId)
+				regions = append(regions, regionMap)
+			}
+			if err := d.Set("regions", regions); err != nil {
+				return diag.FromErr(err)
+			}
+		}
 	}
 
 	subId := redis.IntValue(sub.ID)
@@ -299,4 +355,24 @@ func dataSourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sc
 	d.SetId(strconv.Itoa(subId))
 
 	return diags
+}
+
+func filterSubscriptions(subs []*subscriptions.ActiveActiveSubscription, filters []func(sub *subscriptions.ActiveActiveSubscription) bool) []*subscriptions.ActiveActiveSubscription {
+	var filteredSubs []*subscriptions.ActiveActiveSubscription
+	for _, sub := range subs {
+		if filterSub(sub, filters) {
+			filteredSubs = append(filteredSubs, sub)
+		}
+	}
+
+	return filteredSubs
+}
+
+func filterSub(method *subscriptions.ActiveActiveSubscription, filters []func(method *subscriptions.ActiveActiveSubscription) bool) bool {
+	for _, f := range filters {
+		if !f(method) {
+			return false
+		}
+	}
+	return true
 }

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -5,9 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"time"
+
+	"github.com/RedisLabs/rediscloud-go-api/service/regions"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/pro"
@@ -93,6 +97,105 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"cloud_account_id": {
+				Description:      "Cloud account identifier. Default: Redis Labs internal cloud account (using Cloud Account Id = 1 implies using Redis Labs internal cloud account). Note that a GCP subscription can be created only with Redis Labs internal cloud account",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile("^\\d+$"), "must be a number")),
+				Default:          "1",
+			},
+			"prevent_destroy_regions": {
+				Description: "Prevent regions from being destroyed when they are removed from `regions` block.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
+			"regions": {
+				Description:  "Cloud networking details, per region (multiple regions for Active-Active cluster)",
+				Type:         schema.TypeList,
+				Optional:     true,
+				ExactlyOneOf: []string{"regions", "creation_plan.0.region"},
+				MinItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Description: "Deployment region as defined by cloud provider",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"multiple_availability_zones": {
+							Description: "Support deployment on multiple availability zones within the selected region",
+							Type:        schema.TypeBool,
+							Computed:    true,
+						},
+						"preferred_availability_zones": {
+							Description: "List of availability zones used",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"write_operations_per_second": {
+							Description: "Default write operations per second for databases in the region. Used only on region creation",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1000,
+						},
+						"read_operations_per_second": {
+							Description: "Default read operations per second for databases in the region. Used only on region creation",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1000,
+						},
+						"networking": {
+							Description: "Networking details for the region",
+							Type:        schema.TypeList,
+							Required:    true,
+							MinItems:    1,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deployment_cidr": {
+										Description:      "Deployment CIDR mask",
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										ValidateDiagFunc: validation.ToDiagFunc(validation.IsCIDR),
+									},
+									"vpc_id": {
+										Description: "Either an existing VPC Id (already exists in the specific region) or create a new VPC (if no VPC is specified)",
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    true,
+										Computed:    true,
+									},
+									"subnet_ids": {
+										Description: "List of subnet IDs used",
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										ForceNew:    true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"security_group_id": {
+										Description: "Security group ID used",
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										ForceNew:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"creation_plan": {
 				Description: "Information about the planned databases used to optimise the database infrastructure. This information is only used when creating a new subscription and any changes will be ignored after this.",
 				Type:        schema.TypeList,
@@ -100,7 +203,7 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 				// The block is required when the user provisions a new subscription.
 				// The block is ignored in the UPDATE operation or after IMPORTing the resource.
 				// Custom validation is handled in CustomizeDiff.
-				Optional: true,
+				Required: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if d.Id() == "" {
 						// We don't want to ignore the block if the resource is about to be created.
@@ -137,10 +240,11 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 							},
 						},
 						"region": {
-							Description: "Cloud networking details, per region (multiple regions for Active-Active cluster)",
-							Type:        schema.TypeSet,
-							Required:    true,
-							MinItems:    1,
+							Description:  "Cloud networking details, per region (multiple regions for Active-Active cluster)",
+							Type:         schema.TypeSet,
+							Optional:     true,
+							ExactlyOneOf: []string{"regions", "creation_plan.0.region"},
+							MinItems:     1,
 							Set: func(v interface{}) int {
 								var buf bytes.Buffer
 								m := v.(map[string]interface{})
@@ -364,13 +468,20 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
-	plan := d.Get("creation_plan").([]interface{})
+	var regions []map[string]interface{}
+	planMap := d.Get("creation_plan").([]interface{})[0].(map[string]interface{})
 
-	// Create creation-plan databases
-	planMap := plan[0].(map[string]interface{})
-
+	if creationPlanRegions := planMap["region"]; creationPlanRegions != nil && len(creationPlanRegions.(*schema.Set).List()) > 0 {
+		regions = creationPlanRegions.([]map[string]interface{})
+	} else {
+		schemaRegions := d.Get("regions").([]interface{})
+		for _, region := range schemaRegions {
+			regions = append(regions, region.(map[string]interface{}))
+		}
+	}
+	cloudAccountId, _ := strconv.Atoi(d.Get("cloud_account_id").(string))
 	// Create CloudProviders
-	providers, err := buildCreateActiveActiveCloudProviders(d.Get("cloud_provider").(string), planMap)
+	providers, err := buildCreateActiveActiveCloudProviders(d.Get("cloud_provider").(string), cloudAccountId, regions)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -385,7 +496,7 @@ func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *sc
 	}
 
 	// Create databases
-	var dbs []*subscriptions.CreateDatabase = buildSubscriptionCreatePlanAADatabases(planMap)
+	var dbs = buildSubscriptionCreatePlanAADatabases(planMap, regions)
 
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
 	publicEndpointAccess := d.Get("public_endpoint_access").(bool)
@@ -497,7 +608,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		notFound := &subscriptions.NotFound{}
 		if errors.As(err, &notFound) {
@@ -514,7 +625,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		}
 
 		// Re-fetch subscription after waiting for it to become active
-		subscription, err = api.Client.Subscription.Get(ctx, subId)
+		subscription, err = api.Client.Subscription.GetActiveActive(ctx, subId)
 		if err != nil {
 			notFound := &subscriptions.NotFound{}
 			if errors.As(err, &notFound) {
@@ -552,6 +663,20 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		if err := d.Set("aws_account_id", redis.StringValue(cloudDetails[0].AWSAccountID)); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if cloudDetails[0].CloudAccountID != nil {
+		if err := d.Set("cloud_account_id", strconv.Itoa(redis.IntValue(cloudDetails[0].CloudAccountID))); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	regions, regionDiags := readActiveActiveRegions(cloudDetails[0].Regions, d)
+	if regionDiags.HasError() {
+		return regionDiags
+	}
+	if err := d.Set("regions", regions); err != nil {
+		return diag.FromErr(err)
 	}
 
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
@@ -615,7 +740,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -631,7 +756,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	if d.HasChanges("name", "payment_method_id", "public_endpoint_access") {
+	if d.HasChanges("name", "payment_method_id", "public_endpoint_access", "regions") {
 		updateSubscriptionRequest := subscriptions.UpdateSubscription{}
 
 		if d.HasChange("name") {
@@ -653,9 +778,105 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 			updateSubscriptionRequest.PublicEndpointAccess = redis.Bool(publicEndpointAccess)
 		}
 
-		err = api.Client.Subscription.Update(ctx, subId, updateSubscriptionRequest)
-		if err != nil {
-			return diag.FromErr(err)
+		if d.HasChange("regions") {
+			original, changed := d.GetChange("regions")
+			originalRegions := original.([]interface{})
+			changedRegions := changed.([]interface{})
+			hasRealChange := !reflect.DeepEqual(originalRegions, changedRegions)
+			if hasRealChange {
+				apiRegions, err := api.Client.Subscription.ListActiveActiveRegions(ctx, subId)
+				regionDBs := apiRegions[0].Databases
+
+				if err != nil {
+					return diag.FromErr(err)
+				}
+
+				originalRegionNames := make([]string, 0)
+				changedRegionNames := make([]string, 0)
+				apiRegionNames := make([]string, 0)
+				for _, originalRegion := range originalRegions {
+					originalRegionNames = append(originalRegionNames, originalRegion.(map[string]interface{})["region"].(string))
+				}
+				for _, changedRegion := range changedRegions {
+					changedRegionNames = append(changedRegionNames, changedRegion.(map[string]interface{})["region"].(string))
+				}
+				for _, apiRegion := range apiRegions {
+					apiRegionNames = append(apiRegionNames, redis.StringValue(apiRegion.Region))
+				}
+				removedRegions := make([]string, 0)
+				for _, originalRegionName := range originalRegionNames {
+					if !slices.Contains(changedRegionNames, originalRegionName) {
+						removedRegions = append(removedRegions, originalRegionName)
+						break
+					}
+				}
+				if len(removedRegions) > 0 {
+					if d.Get("prevent_destroy_regions").(bool) {
+						return diag.Errorf("prevent_destroy_regions is set to true, but regions are being removed")
+					} else {
+						deleteRegions := regions.DeleteRegions{}
+						for _, region := range removedRegions {
+							deleteRegion := regions.DeleteRegion{
+								Region: redis.String(region),
+							}
+							deleteRegions.Regions = append(deleteRegions.Regions, &deleteRegion)
+						}
+
+						if err := api.Client.Regions.DeleteWithQuery(ctx, subId, deleteRegions); err != nil {
+							return diag.FromErr(err)
+						}
+						if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+							return diag.FromErr(err)
+						}
+
+					}
+				}
+
+				newRegionNames := make([]string, 0)
+				for _, changedRegionName := range changedRegionNames {
+					if !slices.Contains(originalRegionNames, changedRegionName) && !slices.Contains(apiRegionNames, changedRegionName) {
+						newRegionNames = append(newRegionNames, changedRegionName)
+					}
+				}
+
+				for _, changedRegion := range changedRegions {
+					if slices.Contains(newRegionNames, changedRegion.(map[string]interface{})["region"].(string)) {
+						networking := changedRegion.(map[string]interface{})["networking"].([]interface{})[0].(map[string]interface{})
+						createRegionDatabases := make([]*regions.CreateDatabase, 0)
+						for _, regionDB := range regionDBs {
+							createRegionDatabases = append(createRegionDatabases, &regions.CreateDatabase{
+								Name: regionDB.DatabaseName,
+								LocalThroughputMeasurement: &regions.CreateLocalThroughput{
+									Region:                   redis.String(changedRegion.(map[string]interface{})["region"].(string)),
+									WriteOperationsPerSecond: redis.Int(changedRegion.(map[string]interface{})["write_operations_per_second"].(int)),
+									ReadOperationsPerSecond:  redis.Int(changedRegion.(map[string]interface{})["read_operations_per_second"].(int)),
+								},
+							})
+						}
+						createRegion := regions.CreateRegion{
+							Region:          redis.String(changedRegion.(map[string]interface{})["region"].(string)),
+							DeploymentCIDR:  redis.String(networking["deployment_cidr"].(string)),
+							VpcId:           redis.String(networking["vpc_id"].(string)),
+							SubnetIds:       utils.InterfaceToStringSlice(networking["subnet_ids"].([]interface{})),
+							SecurityGroupId: redis.String(networking["security_group_id"].(string)),
+							Databases:       createRegionDatabases,
+						}
+
+						if _, err := api.Client.Regions.Create(ctx, subId, createRegion); err != nil {
+							return diag.FromErr(err)
+						}
+
+						if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+							return diag.FromErr(err)
+						}
+					}
+				}
+			}
+
+			err = api.Client.Subscription.Update(ctx, subId, updateSubscriptionRequest)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
@@ -749,7 +970,7 @@ func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *sc
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -803,40 +1024,53 @@ func newCreateSubscription(name string, paymentMethodID *int, paymentMethod stri
 }
 
 //nolint:unparam
-func buildCreateActiveActiveCloudProviders(provider string, creationPlan map[string]interface{}) ([]*subscriptions.CreateCloudProvider, error) {
+func buildCreateActiveActiveCloudProviders(provider string, cloudAccountId int, regions []map[string]interface{}) ([]*subscriptions.CreateCloudProvider, error) {
 	createRegions := make([]*subscriptions.CreateRegion, 0)
-	if regions := creationPlan["region"].(*schema.Set).List(); len(regions) != 0 {
+	for _, region := range regions {
 
-		for _, region := range regions {
-			regionMap := region.(map[string]interface{})
+		regionStr := region["region"].(string)
 
-			regionStr := regionMap["region"].(string)
+		createRegion := subscriptions.CreateRegion{
+			Region: redis.String(regionStr),
+		}
+		createRegion.Networking = &subscriptions.CreateNetworking{}
 
-			createRegion := subscriptions.CreateRegion{
-				Region: redis.String(regionStr),
+		if v, ok := region["networking_deployment_cidr"]; ok && v != "" {
+			createRegion.Networking.DeploymentCIDR = redis.String(v.(string))
+		}
+
+		if v, ok := region["networking_vpc_id"]; ok && v != "" {
+			createRegion.Networking.VPCId = redis.String(v.(string))
+		}
+		if v, ok := region["multiple_availability_zones"]; ok && v != "" {
+			createRegion.MultipleAvailabilityZones = redis.Bool(v.(bool))
+		}
+		if v, ok := region["preferred_availability_zones"]; ok && v != nil && len(v.([]interface{})) > 0 {
+			createRegion.PreferredAvailabilityZones = utils.InterfaceToStringSlice(v.([]interface{}))
+		}
+		if v, ok := region["networking"]; ok && v != nil && len(v.([]interface{})) > 0 {
+			networking := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := networking["subnet_ids"]; ok && v != nil && len(v.([]interface{})) > 0 {
+				createRegion.Networking.SubnetIds = utils.InterfaceToStringSlice(v.([]interface{}))
 			}
-
-			if v, ok := regionMap["networking_deployment_cidr"]; ok && v != "" {
-				createRegion.Networking = &subscriptions.CreateNetworking{
-					DeploymentCIDR: redis.String(v.(string)),
-				}
+			if v, ok := networking["security_group_id"]; ok && v != "" {
+				createRegion.Networking.SecurityGroupId = redis.String(v.(string))
 			}
-
-			if v, ok := regionMap["networking_vpc_id"]; ok && v != "" {
-				if createRegion.Networking == nil {
-					createRegion.Networking = &subscriptions.CreateNetworking{}
-				}
+			if v, ok := networking["deployment_cidr"]; ok && v != "" {
+				createRegion.Networking.DeploymentCIDR = redis.String(v.(string))
+			}
+			if v, ok := networking["vpc_id"]; ok && v != "" {
 				createRegion.Networking.VPCId = redis.String(v.(string))
 			}
-
-			createRegions = append(createRegions, &createRegion)
 		}
+
+		createRegions = append(createRegions, &createRegion)
 	}
 
 	createCloudProviders := make([]*subscriptions.CreateCloudProvider, 0)
 	createCloudProvider := &subscriptions.CreateCloudProvider{
 		Provider:       redis.String(provider),
-		CloudAccountID: redis.Int(1), // Active-Active subscriptions are created with Redis internal resources
+		CloudAccountID: redis.Int(cloudAccountId),
 		Regions:        createRegions,
 	}
 
@@ -845,7 +1079,7 @@ func buildCreateActiveActiveCloudProviders(provider string, creationPlan map[str
 	return createCloudProviders, nil
 }
 
-func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*subscriptions.CreateDatabase {
+func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}, regions []map[string]interface{}) []*subscriptions.CreateDatabase {
 	createDatabases := make([]*subscriptions.CreateDatabase, 0)
 
 	dbName := "creation-plan-db-"
@@ -853,10 +1087,8 @@ func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*s
 	numDatabases := planMap["quantity"].(int)
 	memoryLimitInGB := planMap["memory_limit_in_gb"].(float64)
 	datasetSizeInGB := planMap["dataset_size_in_gb"].(float64)
-	regions := planMap["region"]
 	var localThroughputs []*subscriptions.CreateLocalThroughput
-	for _, v := range regions.(*schema.Set).List() {
-		region := v.(map[string]interface{})
+	for _, region := range regions {
 		localThroughputs = append(localThroughputs, &subscriptions.CreateLocalThroughput{
 			Region:                   redis.String(region["region"].(string)),
 			WriteOperationsPerSecond: redis.Int(region["write_operations_per_second"].(int)),
@@ -916,4 +1148,72 @@ func buildAACmks(cmkResources []interface{}) []subscriptions.CustomerManagedKey 
 	}
 
 	return cmks
+}
+
+func readActiveActiveRegions(regions []*subscriptions.ActiveActiveRegion, d *schema.ResourceData) ([]map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	flattenedRegions := make([]map[string]interface{}, 0)
+	missingRegions := make([]map[string]interface{}, 0)
+	stateRegions := d.Get("regions").([]interface{})
+	for _, region := range regions {
+		var filteredStateRegion map[string]interface{}
+		for _, stateRegion := range stateRegions {
+			mapStateRegion := stateRegion.(map[string]interface{})
+			if mapStateRegion["region"] == redis.StringValue(region.Region) {
+				filteredStateRegion = mapStateRegion
+				break
+			}
+		}
+		//needed when importing a missing region, while API still doesn't return all information
+		if filteredStateRegion == nil {
+			filteredStateRegion = map[string]interface{}{
+				"subnet_ids":                   []string{},
+				"preferred_availability_zones": []string{},
+				"write_operations_per_second":  1000,
+				"read_operations_per_second":   1000,
+				"networking": []interface{}{map[string]interface{}{
+					"subnet_ids":        []string{},
+					"security_group_id": "",
+				}},
+			}
+
+		}
+		filteredNetworking := filteredStateRegion["networking"].([]interface{})
+		filteredNetworkingMap := filteredNetworking[0].(map[string]interface{})
+		networking := map[string]interface{}{
+			"deployment_cidr":   redis.StringValue(region.DeploymentCIDR),
+			"vpc_id":            redis.StringValue(region.VpcId),
+			"subnet_ids":        filteredNetworkingMap["subnet_ids"],        // Currently not returned by the API
+			"security_group_id": filteredNetworkingMap["security_group_id"], // Currently not returned by the API
+		}
+		regionMapString := map[string]interface{}{
+			"region":                       redis.StringValue(region.Region),
+			"multiple_availability_zones":  true,                                                // Currently not returned by the API
+			"preferred_availability_zones": filteredStateRegion["preferred_availability_zones"], // Currently not returned by the API
+			"write_operations_per_second":  filteredStateRegion["write_operations_per_second"],  // Currently not returned by the API
+			"read_operations_per_second":   filteredStateRegion["read_operations_per_second"],   // Currently not returned by the API
+			"networking":                   []interface{}{networking},
+		}
+		if filteredStateRegion["region"] == nil {
+			missingRegions = append(missingRegions, regionMapString)
+		}
+		flattenedRegions = append(flattenedRegions, regionMapString)
+	}
+
+	orderedRegions := make([]map[string]interface{}, 0)
+	for _, stateRegion := range stateRegions {
+		for _, region := range flattenedRegions {
+			if stateRegion.(map[string]interface{})["region"] == region["region"] {
+				orderedRegions = append(orderedRegions, region)
+				break
+			}
+		}
+	}
+
+	//needed for import
+	if len(missingRegions) > 0 {
+		orderedRegions = append(orderedRegions, missingRegions...)
+	}
+
+	return orderedRegions, diags
 }

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -5,9 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"time"
+
+	"github.com/RedisLabs/rediscloud-go-api/service/regions"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/pro"
@@ -93,6 +97,105 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"cloud_account_id": {
+				Description:      "Cloud account identifier. Default: Redis Labs internal cloud account (using Cloud Account Id = 1 implies using Redis Labs internal cloud account). Note that a GCP subscription can be created only with Redis Labs internal cloud account",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile("^\\d+$"), "must be a number")),
+				Default:          "1",
+			},
+			"prevent_destroy_regions": {
+				Description: "Prevent regions from being destroyed when they are removed from `regions` block.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
+			"regions": {
+				Description:  "Cloud networking details, per region (multiple regions for Active-Active cluster)",
+				Type:         schema.TypeList,
+				Optional:     true,
+				ExactlyOneOf: []string{"regions", "creation_plan.0.region"},
+				MinItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Description: "Deployment region as defined by cloud provider",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"multiple_availability_zones": {
+							Description: "Support deployment on multiple availability zones within the selected region",
+							Type:        schema.TypeBool,
+							Computed:    true,
+						},
+						"preferred_availability_zones": {
+							Description: "List of availability zones used",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"write_operations_per_second": {
+							Description: "Default write operations per second for databases in the region. Used only on region creation",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1000,
+						},
+						"read_operations_per_second": {
+							Description: "Default read operations per second for databases in the region. Used only on region creation",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1000,
+						},
+						"networking": {
+							Description: "Networking details for the region",
+							Type:        schema.TypeList,
+							Required:    true,
+							MinItems:    1,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deployment_cidr": {
+										Description:      "Deployment CIDR mask",
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										ValidateDiagFunc: validation.ToDiagFunc(validation.IsCIDR),
+									},
+									"vpc_id": {
+										Description: "Either an existing VPC Id (already exists in the specific region) or create a new VPC (if no VPC is specified)",
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    true,
+										Computed:    true,
+									},
+									"subnet_ids": {
+										Description: "List of subnet IDs used",
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										ForceNew:    true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"security_group_id": {
+										Description: "Security group ID used",
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										ForceNew:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"creation_plan": {
 				Description: "Information about the planned databases used to optimise the database infrastructure. This information is only used when creating a new subscription and any changes will be ignored after this.",
 				Type:        schema.TypeList,
@@ -100,7 +203,7 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 				// The block is required when the user provisions a new subscription.
 				// The block is ignored in the UPDATE operation or after IMPORTing the resource.
 				// Custom validation is handled in CustomizeDiff.
-				Optional: true,
+				Required: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if d.Id() == "" {
 						// We don't want to ignore the block if the resource is about to be created.
@@ -137,10 +240,11 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 							},
 						},
 						"region": {
-							Description: "Cloud networking details, per region (multiple regions for Active-Active cluster)",
-							Type:        schema.TypeSet,
-							Required:    true,
-							MinItems:    1,
+							Description:  "Cloud networking details, per region (multiple regions for Active-Active cluster)",
+							Type:         schema.TypeSet,
+							Optional:     true,
+							ExactlyOneOf: []string{"regions", "creation_plan.0.region"},
+							MinItems:     1,
 							Set: func(v interface{}) int {
 								var buf bytes.Buffer
 								m := v.(map[string]interface{})
@@ -364,13 +468,20 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
-	plan := d.Get("creation_plan").([]interface{})
+	var regions []map[string]interface{}
+	planMap := d.Get("creation_plan").([]interface{})[0].(map[string]interface{})
 
-	// Create creation-plan databases
-	planMap := plan[0].(map[string]interface{})
-
+	if creationPlanRegions := planMap["region"]; creationPlanRegions != nil && len(creationPlanRegions.(*schema.Set).List()) > 0 {
+		regions = creationPlanRegions.([]map[string]interface{})
+	} else {
+		schemaRegions := d.Get("regions").([]interface{})
+		for _, region := range schemaRegions {
+			regions = append(regions, region.(map[string]interface{}))
+		}
+	}
+	cloudAccountId, _ := strconv.Atoi(d.Get("cloud_account_id").(string))
 	// Create CloudProviders
-	providers, err := buildCreateActiveActiveCloudProviders(d.Get("cloud_provider").(string), planMap)
+	providers, err := buildCreateActiveActiveCloudProviders(d.Get("cloud_provider").(string), cloudAccountId, regions)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -385,7 +496,7 @@ func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *sc
 	}
 
 	// Create databases
-	var dbs []*subscriptions.CreateDatabase = buildSubscriptionCreatePlanAADatabases(planMap)
+	var dbs = buildSubscriptionCreatePlanAADatabases(planMap, regions)
 
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
 	publicEndpointAccess := d.Get("public_endpoint_access").(bool)
@@ -471,7 +582,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		notFound := &subscriptions.NotFound{}
 		if errors.As(err, &notFound) {
@@ -488,7 +599,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		}
 
 		// Re-fetch subscription after waiting for it to become active
-		subscription, err = api.Client.Subscription.Get(ctx, subId)
+		subscription, err = api.Client.Subscription.GetActiveActive(ctx, subId)
 		if err != nil {
 			notFound := &subscriptions.NotFound{}
 			if errors.As(err, &notFound) {
@@ -526,6 +637,20 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		if err := d.Set("aws_account_id", redis.StringValue(cloudDetails[0].AWSAccountID)); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if cloudDetails[0].CloudAccountID != nil {
+		if err := d.Set("cloud_account_id", strconv.Itoa(redis.IntValue(cloudDetails[0].CloudAccountID))); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	regions, regionDiags := readActiveActiveRegions(cloudDetails[0].Regions, d)
+	if regionDiags.HasError() {
+		return regionDiags
+	}
+	if err := d.Set("regions", regions); err != nil {
+		return diag.FromErr(err)
 	}
 
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
@@ -589,7 +714,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -605,7 +730,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	if d.HasChanges("name", "payment_method_id", "public_endpoint_access") {
+	if d.HasChanges("name", "payment_method_id", "public_endpoint_access", "regions") {
 		updateSubscriptionRequest := subscriptions.UpdateSubscription{}
 
 		if d.HasChange("name") {
@@ -627,9 +752,105 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 			updateSubscriptionRequest.PublicEndpointAccess = redis.Bool(publicEndpointAccess)
 		}
 
-		err = api.Client.Subscription.Update(ctx, subId, updateSubscriptionRequest)
-		if err != nil {
-			return diag.FromErr(err)
+		if d.HasChange("regions") {
+			original, changed := d.GetChange("regions")
+			originalRegions := original.([]interface{})
+			changedRegions := changed.([]interface{})
+			hasRealChange := !reflect.DeepEqual(originalRegions, changedRegions)
+			if hasRealChange {
+				apiRegions, err := api.Client.Subscription.ListActiveActiveRegions(ctx, subId)
+				regionDBs := apiRegions[0].Databases
+
+				if err != nil {
+					return diag.FromErr(err)
+				}
+
+				originalRegionNames := make([]string, 0)
+				changedRegionNames := make([]string, 0)
+				apiRegionNames := make([]string, 0)
+				for _, originalRegion := range originalRegions {
+					originalRegionNames = append(originalRegionNames, originalRegion.(map[string]interface{})["region"].(string))
+				}
+				for _, changedRegion := range changedRegions {
+					changedRegionNames = append(changedRegionNames, changedRegion.(map[string]interface{})["region"].(string))
+				}
+				for _, apiRegion := range apiRegions {
+					apiRegionNames = append(apiRegionNames, redis.StringValue(apiRegion.Region))
+				}
+				removedRegions := make([]string, 0)
+				for _, originalRegionName := range originalRegionNames {
+					if !slices.Contains(changedRegionNames, originalRegionName) {
+						removedRegions = append(removedRegions, originalRegionName)
+						break
+					}
+				}
+				if len(removedRegions) > 0 {
+					if d.Get("prevent_destroy_regions").(bool) {
+						return diag.Errorf("prevent_destroy_regions is set to true, but regions are being removed")
+					} else {
+						deleteRegions := regions.DeleteRegions{}
+						for _, region := range removedRegions {
+							deleteRegion := regions.DeleteRegion{
+								Region: redis.String(region),
+							}
+							deleteRegions.Regions = append(deleteRegions.Regions, &deleteRegion)
+						}
+
+						if err := api.Client.Regions.DeleteWithQuery(ctx, subId, deleteRegions); err != nil {
+							return diag.FromErr(err)
+						}
+						if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+							return diag.FromErr(err)
+						}
+
+					}
+				}
+
+				newRegionNames := make([]string, 0)
+				for _, changedRegionName := range changedRegionNames {
+					if !slices.Contains(originalRegionNames, changedRegionName) && !slices.Contains(apiRegionNames, changedRegionName) {
+						newRegionNames = append(newRegionNames, changedRegionName)
+					}
+				}
+
+				for _, changedRegion := range changedRegions {
+					if slices.Contains(newRegionNames, changedRegion.(map[string]interface{})["region"].(string)) {
+						networking := changedRegion.(map[string]interface{})["networking"].([]interface{})[0].(map[string]interface{})
+						createRegionDatabases := make([]*regions.CreateDatabase, 0)
+						for _, regionDB := range regionDBs {
+							createRegionDatabases = append(createRegionDatabases, &regions.CreateDatabase{
+								Name: regionDB.DatabaseName,
+								LocalThroughputMeasurement: &regions.CreateLocalThroughput{
+									Region:                   redis.String(changedRegion.(map[string]interface{})["region"].(string)),
+									WriteOperationsPerSecond: redis.Int(changedRegion.(map[string]interface{})["write_operations_per_second"].(int)),
+									ReadOperationsPerSecond:  redis.Int(changedRegion.(map[string]interface{})["read_operations_per_second"].(int)),
+								},
+							})
+						}
+						createRegion := regions.CreateRegion{
+							Region:          redis.String(changedRegion.(map[string]interface{})["region"].(string)),
+							DeploymentCIDR:  redis.String(networking["deployment_cidr"].(string)),
+							VpcId:           redis.String(networking["vpc_id"].(string)),
+							SubnetIds:       utils.InterfaceToStringSlice(networking["subnet_ids"].([]interface{})),
+							SecurityGroupId: redis.String(networking["security_group_id"].(string)),
+							Databases:       createRegionDatabases,
+						}
+
+						if _, err := api.Client.Regions.Create(ctx, subId, createRegion); err != nil {
+							return diag.FromErr(err)
+						}
+
+						if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+							return diag.FromErr(err)
+						}
+					}
+				}
+			}
+
+			err = api.Client.Subscription.Update(ctx, subId, updateSubscriptionRequest)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
@@ -728,7 +949,7 @@ func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *sc
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
-	subscription, err := api.Client.Subscription.Get(ctx, subId)
+	subscription, err := api.Client.Subscription.GetActiveActive(ctx, subId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -783,40 +1004,53 @@ func newCreateSubscription(name string, paymentMethodID *int, paymentMethod stri
 }
 
 //nolint:unparam
-func buildCreateActiveActiveCloudProviders(provider string, creationPlan map[string]interface{}) ([]*subscriptions.CreateCloudProvider, error) {
+func buildCreateActiveActiveCloudProviders(provider string, cloudAccountId int, regions []map[string]interface{}) ([]*subscriptions.CreateCloudProvider, error) {
 	createRegions := make([]*subscriptions.CreateRegion, 0)
-	if regions := creationPlan["region"].(*schema.Set).List(); len(regions) != 0 {
+	for _, region := range regions {
 
-		for _, region := range regions {
-			regionMap := region.(map[string]interface{})
+		regionStr := region["region"].(string)
 
-			regionStr := regionMap["region"].(string)
+		createRegion := subscriptions.CreateRegion{
+			Region: redis.String(regionStr),
+		}
+		createRegion.Networking = &subscriptions.CreateNetworking{}
 
-			createRegion := subscriptions.CreateRegion{
-				Region: redis.String(regionStr),
+		if v, ok := region["networking_deployment_cidr"]; ok && v != "" {
+			createRegion.Networking.DeploymentCIDR = redis.String(v.(string))
+		}
+
+		if v, ok := region["networking_vpc_id"]; ok && v != "" {
+			createRegion.Networking.VPCId = redis.String(v.(string))
+		}
+		if v, ok := region["multiple_availability_zones"]; ok && v != "" {
+			createRegion.MultipleAvailabilityZones = redis.Bool(v.(bool))
+		}
+		if v, ok := region["preferred_availability_zones"]; ok && v != nil && len(v.([]interface{})) > 0 {
+			createRegion.PreferredAvailabilityZones = utils.InterfaceToStringSlice(v.([]interface{}))
+		}
+		if v, ok := region["networking"]; ok && v != nil && len(v.([]interface{})) > 0 {
+			networking := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := networking["subnet_ids"]; ok && v != nil && len(v.([]interface{})) > 0 {
+				createRegion.Networking.SubnetIds = utils.InterfaceToStringSlice(v.([]interface{}))
 			}
-
-			if v, ok := regionMap["networking_deployment_cidr"]; ok && v != "" {
-				createRegion.Networking = &subscriptions.CreateNetworking{
-					DeploymentCIDR: redis.String(v.(string)),
-				}
+			if v, ok := networking["security_group_id"]; ok && v != "" {
+				createRegion.Networking.SecurityGroupId = redis.String(v.(string))
 			}
-
-			if v, ok := regionMap["networking_vpc_id"]; ok && v != "" {
-				if createRegion.Networking == nil {
-					createRegion.Networking = &subscriptions.CreateNetworking{}
-				}
+			if v, ok := networking["deployment_cidr"]; ok && v != "" {
+				createRegion.Networking.DeploymentCIDR = redis.String(v.(string))
+			}
+			if v, ok := networking["vpc_id"]; ok && v != "" {
 				createRegion.Networking.VPCId = redis.String(v.(string))
 			}
-
-			createRegions = append(createRegions, &createRegion)
 		}
+
+		createRegions = append(createRegions, &createRegion)
 	}
 
 	createCloudProviders := make([]*subscriptions.CreateCloudProvider, 0)
 	createCloudProvider := &subscriptions.CreateCloudProvider{
 		Provider:       redis.String(provider),
-		CloudAccountID: redis.Int(1), // Active-Active subscriptions are created with Redis internal resources
+		CloudAccountID: redis.Int(cloudAccountId),
 		Regions:        createRegions,
 	}
 
@@ -825,7 +1059,7 @@ func buildCreateActiveActiveCloudProviders(provider string, creationPlan map[str
 	return createCloudProviders, nil
 }
 
-func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*subscriptions.CreateDatabase {
+func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}, regions []map[string]interface{}) []*subscriptions.CreateDatabase {
 	createDatabases := make([]*subscriptions.CreateDatabase, 0)
 
 	dbName := "creation-plan-db-"
@@ -833,10 +1067,8 @@ func buildSubscriptionCreatePlanAADatabases(planMap map[string]interface{}) []*s
 	numDatabases := planMap["quantity"].(int)
 	memoryLimitInGB := planMap["memory_limit_in_gb"].(float64)
 	datasetSizeInGB := planMap["dataset_size_in_gb"].(float64)
-	regions := planMap["region"]
 	var localThroughputs []*subscriptions.CreateLocalThroughput
-	for _, v := range regions.(*schema.Set).List() {
-		region := v.(map[string]interface{})
+	for _, region := range regions {
 		localThroughputs = append(localThroughputs, &subscriptions.CreateLocalThroughput{
 			Region:                   redis.String(region["region"].(string)),
 			WriteOperationsPerSecond: redis.Int(region["write_operations_per_second"].(int)),
@@ -896,4 +1128,72 @@ func buildAACmks(cmkResources []interface{}) []subscriptions.CustomerManagedKey 
 	}
 
 	return cmks
+}
+
+func readActiveActiveRegions(regions []*subscriptions.ActiveActiveRegion, d *schema.ResourceData) ([]map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	flattenedRegions := make([]map[string]interface{}, 0)
+	missingRegions := make([]map[string]interface{}, 0)
+	stateRegions := d.Get("regions").([]interface{})
+	for _, region := range regions {
+		var filteredStateRegion map[string]interface{}
+		for _, stateRegion := range stateRegions {
+			mapStateRegion := stateRegion.(map[string]interface{})
+			if mapStateRegion["region"] == redis.StringValue(region.Region) {
+				filteredStateRegion = mapStateRegion
+				break
+			}
+		}
+		//needed when importing a missing region, while API still doesn't return all information
+		if filteredStateRegion == nil {
+			filteredStateRegion = map[string]interface{}{
+				"subnet_ids":                   []string{},
+				"preferred_availability_zones": []string{},
+				"write_operations_per_second":  1000,
+				"read_operations_per_second":   1000,
+				"networking": []interface{}{map[string]interface{}{
+					"subnet_ids":        []string{},
+					"security_group_id": "",
+				}},
+			}
+
+		}
+		filteredNetworking := filteredStateRegion["networking"].([]interface{})
+		filteredNetworkingMap := filteredNetworking[0].(map[string]interface{})
+		networking := map[string]interface{}{
+			"deployment_cidr":   redis.StringValue(region.DeploymentCIDR),
+			"vpc_id":            redis.StringValue(region.VpcId),
+			"subnet_ids":        filteredNetworkingMap["subnet_ids"],        // Currently not returned by the API
+			"security_group_id": filteredNetworkingMap["security_group_id"], // Currently not returned by the API
+		}
+		regionMapString := map[string]interface{}{
+			"region":                       redis.StringValue(region.Region),
+			"multiple_availability_zones":  true,                                                // Currently not returned by the API
+			"preferred_availability_zones": filteredStateRegion["preferred_availability_zones"], // Currently not returned by the API
+			"write_operations_per_second":  filteredStateRegion["write_operations_per_second"],  // Currently not returned by the API
+			"read_operations_per_second":   filteredStateRegion["read_operations_per_second"],   // Currently not returned by the API
+			"networking":                   []interface{}{networking},
+		}
+		if filteredStateRegion["region"] == nil {
+			missingRegions = append(missingRegions, regionMapString)
+		}
+		flattenedRegions = append(flattenedRegions, regionMapString)
+	}
+
+	orderedRegions := make([]map[string]interface{}, 0)
+	for _, stateRegion := range stateRegions {
+		for _, region := range flattenedRegions {
+			if stateRegion.(map[string]interface{})["region"] == region["region"] {
+				orderedRegions = append(orderedRegions, region)
+				break
+			}
+		}
+	}
+
+	//needed for import
+	if len(missingRegions) > 0 {
+		orderedRegions = append(orderedRegions, missingRegions...)
+	}
+
+	return orderedRegions, diags
 }


### PR DESCRIPTION
- adds `regions` block to `resource_rediscloud_active_active_subscription` and `datasource_rediscloud_active_active_subscription`
- adds `cloud_account_id` to `resource_rediscloud_active_active_subscription` and `datasource_rediscloud_active_active_subscription`
- adds `prevent_destroy_regions` to `resource_rediscloud_active_active_subscription`