### PR TITLE
Proposal: Terraform provider retries GET requests on transient error

### DIFF
--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -249,6 +249,10 @@ func waitForEssentialsSubscriptionToBeActive(ctx context.Context, id int, api *c
 
 			subscription, err := api.Client.FixedSubscriptions.Get(ctx, id)
 			if err != nil {
+				if utils.IsTransientSubscriptionGetError(err) {
+					log.Printf("[WARN] Transient 5xx while polling fixed subscription %d, will continue polling: %s", id, err)
+					return nil, subscriptions.SubscriptionStatusPending, nil
+				}
 				return nil, "", err
 			}
 

--- a/provider/utils/utils_test.go
+++ b/provider/utils/utils_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,32 @@ func TestIsTime(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			actual := IsTime()(test.input, nil)
 			assert.Equal(t, test.errors, actual.HasError(), "%+v", actual)
+		})
+	}
+}
+
+func TestIsTransientSubscriptionGetError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"500 from go-api", errors.New("failed to get subscription 123: 500 - internal server error"), true},
+		{"500 wrapped", fmt.Errorf("wrapped: %w", errors.New("failed to get subscription 123: 500 - boom")), true},
+		{"502 bad gateway", errors.New("failed to get subscription 123: 502 - bad gateway"), true},
+		{"503 unavailable", errors.New("failed to get subscription 123: 503 - unavailable"), true},
+		{"504 gateway timeout", errors.New("failed to get subscription 123: 504 - gateway timeout"), true},
+		{"404 not found", errors.New("failed to get subscription 123: 404 - not found"), false},
+		{"429 rate limit", errors.New("failed to get subscription 123: 429 - too many requests"), false},
+		{"501 not implemented", errors.New("failed to get subscription 123: 501 - not implemented"), false},
+		{"unrelated error", errors.New("context deadline exceeded"), false},
+		{"body contains 500 without code", errors.New("failed to get subscription 123: 400 - value 500 invalid"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsTransientSubscriptionGetError(tt.err))
 		})
 	}
 }

--- a/provider/utils/wait.go
+++ b/provider/utils/wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
@@ -15,6 +16,32 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 )
+
+// transientSubscriptionGetStatusCodes are HTTP status codes returned by subscription GET
+// calls that we treat as transient and safe to retry by continuing to poll.
+var transientSubscriptionGetStatusCodes = []string{
+	": 500 -", // Internal Server Error
+	": 502 -", // Bad Gateway
+	": 503 -", // Service Unavailable
+	": 504 -", // Gateway Timeout
+}
+
+// IsTransientSubscriptionGetError reports whether the given error from a subscription GET
+// call is a transient HTTP 5xx that can safely be retried by continuing to poll. The
+// rediscloud-go-api client's HTTPError type is unexported, but its Error() method formats
+// as "failed to <name>: <code> - <body>", so we detect the status by matching the code fragment.
+func IsTransientSubscriptionGetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, code := range transientSubscriptionGetStatusCodes {
+		if strings.Contains(msg, code) {
+			return true
+		}
+	}
+	return false
+}
 
 func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
 	wait := &retry.StateChangeConf{
@@ -29,6 +56,10 @@ func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiC
 
 			subscription, err := api.Client.Subscription.Get(ctx, id)
 			if err != nil {
+				if IsTransientSubscriptionGetError(err) {
+					log.Printf("[WARN] Transient 5xx while polling subscription %d, will continue polling: %s", id, err)
+					return nil, subscriptions.SubscriptionStatusPending, nil
+				}
 				return nil, "", err
 			}
 
@@ -317,6 +348,10 @@ func WaitForSubscriptionToBeEncryptionKeyPending(ctx context.Context, id int, ap
 
 			subscription, err := api.Client.Subscription.Get(ctx, id)
 			if err != nil {
+				if IsTransientSubscriptionGetError(err) {
+					log.Printf("[WARN] Transient 5xx while polling subscription %d, will continue polling: %s", id, err)
+					return nil, subscriptions.SubscriptionStatusPending, nil
+				}
 				return nil, "", err
 			}
 


### PR DESCRIPTION
When creating new Redis Cloud Pro subscriptions we sometimes encounter transient errors polling for subscription state which return a `500`.  These requests can be safely retried so the terraform apply doesn't fail if the subscription is still pending.