### PR TITLE
chore: Fix concurrency group id in GitHub actions

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -30,7 +30,7 @@ env:
   TEST_RESOURCE_PREFIX: "tf-ci-main-${{ github.run_number }}"
 
 concurrency:
-  group: <span class="math-inline">\{\{ github\.workflow \}\}\-</span>{{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -31,7 +31,7 @@ env:
   TEST_RESOURCE_PREFIX: "tf-ci-pr${{ github.event.pull_request.number }}-${{ github.run_number }}"
 
 concurrency:
-  group: <span class="math-inline">\{\{ github\.workflow \}\}\-</span>{{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Since every workflow shared the same hardcoded prefix, the PR workflow and the main workflow were in the same concurrency group (when targeting the same ref). With `cancel-in-progress: true`, a push to `main` could cancel a running PR workflow, or vice versa — cross-workflow cancellation that was never intended.                                                                                                                                            

Introduced with #606.