### PR TITLE
chore: Remove SDK v2 usage from tests

### DIFF
--- a/provider/activeactive/active_active_database_passwordless_test.go
+++ b/provider/activeactive/active_active_database_passwordless_test.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"

--- a/provider/activeactive/helpers_test.go
+++ b/provider/activeactive/helpers_test.go
@@ -11,7 +11,7 @@ import (
 	rediscloudApi "github.com/RedisLabs/rediscloud-go-api"
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider"

--- a/provider/cloudaccount/datasource_cloud_account_test.go
+++ b/provider/cloudaccount/datasource_cloud_account_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"

--- a/provider/datapersistence/datasource_data_persistence_test.go
+++ b/provider/datapersistence/datasource_data_persistence_test.go
@@ -3,7 +3,7 @@ package datapersistence_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"

--- a/provider/datasource_rediscloud_database_modules_test.go
+++ b/provider/datasource_rediscloud_database_modules_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceRedisCloudDatabaseModules_basic(t *testing.T) {

--- a/provider/datasource_rediscloud_essentials_plan_test.go
+++ b/provider/datasource_rediscloud_essentials_plan_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/datasource_rediscloud_pro_database_test.go
+++ b/provider/datasource_rediscloud_pro_database_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/datasource_rediscloud_pro_subscription_test.go
+++ b/provider/datasource_rediscloud_pro_subscription_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 const (

--- a/provider/datasource_rediscloud_subscription_peerings_test.go
+++ b/provider/datasource_rediscloud_subscription_peerings_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {

--- a/provider/paymentmethod/datasource_payment_method_test.go
+++ b/provider/paymentmethod/datasource_payment_method_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"

--- a/provider/pro/rediscloud_pro_database_passwordless_test.go
+++ b/provider/pro/rediscloud_pro_database_passwordless_test.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"

--- a/provider/pro/rediscloud_pro_subscription_datasource_resource_tags_test.go
+++ b/provider/pro/rediscloud_pro_subscription_datasource_resource_tags_test.go
@@ -3,8 +3,8 @@ package pro_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"

--- a/provider/pro/rediscloud_pro_subscription_resource_tags_test.go
+++ b/provider/pro/rediscloud_pro_subscription_resource_tags_test.go
@@ -3,8 +3,8 @@ package pro_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"

--- a/provider/rediscloud_acl_role_test.go
+++ b/provider/rediscloud_acl_role_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_acl_user_test.go
+++ b/provider/rediscloud_acl_user_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_active_active_database_block_public_endpoints_test.go
+++ b/provider/rediscloud_active_active_database_block_public_endpoints_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_active_active_database_enable_default_user_test.go
+++ b/provider/rediscloud_active_active_database_enable_default_user_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_active_active_database_test.go
+++ b/provider/rediscloud_active_active_database_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_active_active_private_link_test.go
+++ b/provider/rediscloud_active_active_private_link_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
 	pl "github.com/RedisLabs/rediscloud-go-api/service/privatelink"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testActiveActivePrivateLinkConfigFile = "./privatelink/testdata/active_active_private_link.tf"

--- a/provider/rediscloud_active_active_private_service_connect_endpoint_accepter_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_endpoint_accepter_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/psc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccResourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepter_Create(t *testing.T) {

--- a/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccResourceRedisCloudActiveActivePrivateServiceConnectEndpoint_CRUDI(t *testing.T) {

--- a/provider/rediscloud_active_active_private_service_connect_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccResourceRedisCloudActiveActivePrivateServiceConnect_CRUDI(t *testing.T) {

--- a/provider/rediscloud_active_active_subscription_test.go
+++ b/provider/rediscloud_active_active_subscription_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_active_active_transit_gateway_invitation_acceptor_test.go
+++ b/provider/rediscloud_active_active_transit_gateway_invitation_acceptor_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_essentials_subscription_test.go
+++ b/provider/rediscloud_essentials_subscription_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"

--- a/provider/rediscloud_private_link_test.go
+++ b/provider/rediscloud_private_link_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	pl "github.com/RedisLabs/rediscloud-go-api/service/privatelink"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_private_service_connect_endpoint_accepter_test.go
+++ b/provider/rediscloud_private_service_connect_endpoint_accepter_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/psc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_private_service_connect_endpoint_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccResourceRedisCloudPrivateServiceConnectEndpoint_CRUDI(t *testing.T) {

--- a/provider/rediscloud_private_service_connect_test.go
+++ b/provider/rediscloud_private_service_connect_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccResourceRedisCloudPrivateServiceConnect_CRUDI(t *testing.T) {

--- a/provider/rediscloud_pro_database_block_public_endpoints_test.go
+++ b/provider/rediscloud_pro_database_block_public_endpoints_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/rediscloud_transit_gateway_invitation_acceptor_test.go
+++ b/provider/rediscloud_transit_gateway_invitation_acceptor_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_acl_rule_test.go
+++ b/provider/resource_rediscloud_acl_rule_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_active_active_subscription_regions_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_regions_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_cloud_account_test.go
+++ b/provider/resource_rediscloud_cloud_account_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_essentials_database_test.go
+++ b/provider/resource_rediscloud_essentials_database_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_pro_database_qpf_test.go
+++ b/provider/resource_rediscloud_pro_database_qpf_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // Generates the base Terraform config for a Pro Subscription with QPF

--- a/provider/resource_rediscloud_pro_database_redis_8_test.go
+++ b/provider/resource_rediscloud_pro_database_redis_8_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_pro_database_test.go
+++ b/provider/resource_rediscloud_pro_database_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )

--- a/provider/resource_rediscloud_pro_subscription_qpf_test.go
+++ b/provider/resource_rediscloud_pro_subscription_qpf_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // Generates the base Terraform config for a Pro Subscription with QPF

--- a/provider/resource_rediscloud_pro_subscription_test.go
+++ b/provider/resource_rediscloud_pro_subscription_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
@@ -830,7 +829,7 @@ func TestFlexSubRedisGraphThroughputMeasurementWhenReplicationIsTrue(t *testing.
 	}
 	createDbs, diags := pro.BuildSubscriptionCreatePlanDatabases(databases.MemoryStorageRam, planMap)
 	assert.Len(t, diags, 1, "Warning should be reported when storage was ram and using `average_item_size_in_bytes`")
-	assert.Equal(t, diag.Warning, diags[0].Severity)
+	assert.False(t, diags.HasError(), "diagnostic should be a warning, not an error")
 	createDb := createDbs[0]
 	assert.Equal(t, "operations-per-second", *createDb.ThroughputMeasurement.By)
 	assert.Equal(t, 2*500, *createDb.ThroughputMeasurement.Value)

--- a/provider/resource_rediscloud_pro_subscription_test.go
+++ b/provider/resource_rediscloud_pro_subscription_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/pro"

--- a/provider/resource_rediscloud_pro_tls_test.go
+++ b/provider/resource_rediscloud_pro_tls_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var sslCertificate = "-----BEGIN CERTIFICATE-----\\nMIIFYzCCA0ugAwIBAgIUSy/xBxWLHmzVkfsC7GeF/fYzIaUwDQYJKoZIhvcNAQEL\\nBQAwQDELMAkGA1UEBhMCR0IxDzANBgNVBAgMBkxvbmRvbjEPMA0GA1UEBwwGTG9u\\nZG9uMQ8wDQYDVQQKDAZPQyBMdGQwIBcNMjQwNzAzMTQzMjI4WhgPMzAwNDA5MDQx\\nNDMyMjhaMEAxCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcM\\nBkxvbmRvbjEPMA0GA1UECgwGT0MgTHRkMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A\\nMIICCgKCAgEAmxpumNhDKi74Q0HsJ/2/V1WlpMPwuiquYklw9MQmmvYDP1peQ6hu\\nH1dMAg/dw59r0r3S/AOWReJNT6WWQnlXbWXyHbAILJfeFXweZOh3A99ei7YKEtB1\\n4wLjWypIYmtcvFRgXTo6kayBy1pBBKPJ0sl+I8UQ+StRB/cHfMoQy07Cx0TMhJPd\\nZH3OTlyPgdIsZ+CNr5YK8T9MmyExzOuA3yFB03Gd2SZxD4M3hbQQefsX8v6HqJSp\\nDe7wEvC083K7FxpXFzckamUatuQ5TV6TQERaFCoMYXTJUchIc56boRUthOhU56Tl\\n8ozcxria0KB930tyjd6fIT97Yctzth+ZVCIzp0U16q2jBYPQhjHU3C4rtVInFaN2\\nl/NDTAt3sCo6pAxVAw6ovmdRRZWZaiDm5Gx45aNRpcz9UHw0kjkG2HPW+PiZoaeQ\\nRcUTLOfr+Z7SDIBlyBNwzNt8j6s88SDTin9tp5oNL/WnCtNLkjf9SjN+nj3nxopW\\n9s7ocjV3nbBwfODI/t0u5yVwmM/xvrI1lail7IXwqHV2v1DTnh5BELstw+8i9NI0\\nj1dhIVQhwzsu5tgwQig8iXQTg6/kVxNnMgcUQdEJckk3aonjECOCJjs9aDULAbA1\\n9mcZnx57WeugJj8eMBeixIoRzHJcYTx92Mcrr0hUHi+OmIxTpu7ydRMCAwEAAaNT\\nMFEwHQYDVR0OBBYEFNA3DgT/I4yju8Im0fKb9u08WiPUMB8GA1UdIwQYMBaAFNA3\\nDgT/I4yju8Im0fKb9u08WiPUMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL\\nBQADggIBAIIwf2fKxLpgh7kTmMRI7zHPlzwEMo2xzgjT1JifpMTHjv+xusdrYdRZ\\nN92vLy3BZ89XcdlVuYOQYdrrniWZ9hDk/lWP5PyAvyFkVAMijmwcySW5BioddDfc\\n7augJmaP2X8Qg0CwOAJazC9RSV6x31G9ah5x89Nsh0uQc5e4udLQsV68DOD9S7Go\\nQxFB8qK/Xx8Z0OytCch9Oh/yZZzL5xBZtla5TWFG8kgoaj7m91lddhX+px04l/fC\\n48zxHRMJSjr5O8SUX3AKx189D9aZEXWLVyfdDtJ7yJmbhOVMjB60+20Jqa1fgb0h\\n1Hh6E+TP5ObDFni3ocjcmnSwwBr9Ih6PlES/z77AK4KiA7S0A+MZQVshLN6n9GVw\\nK78HS19IAHO0A8BKdxphaGBKJzye8+/S6Meyemq2hysHczNFeYWU13UKu9daWOYS\\nPlmhjikHCOii7eipK0+GtTfmkgYmL6f7OykkZ+pVjYtiq7qTU5ZIlWlW2uoPh2Oq\\ngVf//6zduKBxxEcl0i0qDHclx144uCnDnibhlnXcngqexMqNZWEn2Ld/7/mm+jYN\\nMnA37eTHAJrJ+urvEmkdonF5FFUpZtet53abyd0eYzRrVXof6iroQcetgnJA+k+I\\n4HrYoxJnDrzHJ+ycJ457/tggup254bgeqmCzalLTUeVNr9H2/lbT\\n-----END CERTIFICATE-----"

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {

--- a/provider/sweeper_test.go
+++ b/provider/sweeper_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
 	fixedSubscriptions "github.com/RedisLabs/rediscloud-go-api/service/fixed/subscriptions"
 	"github.com/RedisLabs/rediscloud-go-api/service/subscriptions"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // testResourcePrefix is the prefix used for all test resource names.

--- a/provider/utils/test_utils.go
+++ b/provider/utils/test_utils.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 )


### PR DESCRIPTION
Initial migration of the TF tests we have in the repository.

No non-test code is changed here, minimizing the chance of introducing breakage.