### PR TITLE
chore: Bump Go toolchain to v1.26.4

### DIFF
--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -111,6 +111,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # master (fixes actions/setup-go resolution)
         with:
+          # Force usage of `go-version-file` as this sets "stable" by default which
+          # _MAY_ be different from the one defined in the `go.mod` file.
+          go-version-input: ''
           go-version-file: go.mod
           repo-checkout: false
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 
 go 1.25.8
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.49.0


### PR DESCRIPTION
```sh
$ govulncheck .
=== Symbol Results ===

Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.26.2
    Fixed in: net/textproto@go1.26.4
    Example traces found:
      #1: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.26.2
    Fixed in: crypto/x509@go1.26.4
    Example traces found:
      #1: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls x509.Certificate.Verify
      #2: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls x509.Certificate.VerifyHostname
      #3: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls x509.HostnameError.Error

Vulnerability #3: GO-2026-4971
    Panic in Dial and LookupPort when handling NUL byte on Windows in net
  More info: https://pkg.go.dev/vuln/GO-2026-4971
  Standard library
    Found in: net@go1.26.2
    Fixed in: net@go1.26.3
    Example traces found:
      #1: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls net.Dial
      #2: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls net.Dialer.DialContext
      #3: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls net.Listen

Vulnerability #4: GO-2026-4918
    Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in
    net/http/internal/http2 in golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2026-4918
  Standard library
    Found in: net/http@go1.26.2
    Fixed in: net/http@go1.26.3
    Example traces found:
      #1: provider/paymentmethod/datasource_payment_method_read.go:34:60: paymentmethod.paymentMethodDataSource.Read calls account.API.ListPaymentMethods, which eventually calls http.Client.Do```