### PR TITLE
OPCR-170: Support Auto minor DB version upgrades on Essentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
+# 2.17.0 (TBD)
+
+## Added
+- Added `redis_version_actual` attribute to the `rediscloud_essentials_database` resource.
+
+## Changed
+- Upgraded Go dependencies and CI workflow actions.
+- Removed use of `RenderTestConfig` from tests
+- Removed imports from `terraform-plugin-sdk/v2/` from tests
+- Tests sending `dev` as provider version, changed to `99.99.99`
+- Enabled `unused` check in linter
+
+## Fixed
+- State drift on `redis_version` in `rediscloud_essentials_database` resource caused by auto minor version upgrade feature.
+
 # 2.16.1 (May 2026)
 
 ## Fixed

--- a/docs/resources/rediscloud_essentials_database.md
+++ b/docs/resources/rediscloud_essentials_database.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `subscription_id` - (Required) The ID of the subscription to create the database in. **Modifying this attribute will force creation of a new resource.**
 * `name` - (Required) A meaningful name to identify the database.
 * `protocol` - (Optional) Database protocol. 'stack' is a suite of all Redis' data modules. Default: 'stack'. Either: 'redis', 'memcached' or 'stack'. **'redis' is only used with Pay-As-You-Go databases.**
-* `redis_version` - (Optional) Defines the Redis database version. If omitted, the Redis version will be set to the default version.
+* `redis_version` - (Optional) Defines the requested Redis database version. If omitted, the Redis version will be set to the default version. May differ if a minor version upgrade has been automatically applied. Use `redis_version_actual` to fetch the Redis version used by the database.
 * `resp_version` - (Optional) RESP version must be compatible with the Redis version.
 * `data_persistence` - (Required) Rate of database data persistence (in persistent storage). Either: 'none', 'aof-every-1-second', 'aof-every-write', 'snapshot-every-1-hour', 'snapshot-every-6-hours' or 'snapshot-every-12-hours'.
 * `data_eviction` - (Optional) Data items eviction method. Either: 'allkeys-lru', 'allkeys-lfu', 'allkeys-random', 'volatile-lru', 'volatile-lfu', 'volatile-random', 'volatile-ttl' or 'noeviction'. Default: 'volatile-lru'.
@@ -106,6 +106,7 @@ Each `modules` entry provides the following attributes:
 * `activated_on` - When this database was activated.
 * `public_endpoint` - Public endpoint to access the database.
 * `private_endpoint` - Private endpoint to access the database.
+* `redis_version_actual` - The Redis version of the database. Can differ from `redis_version` if a minor version upgrade has been automatically applied.
 
 ## Import
 `rediscloud_essentials_database` can be imported using the ID of the subscription and the ID of the database in the format {subscription ID}/{database ID}, e.g.

--- a/provider/essentials/testdata/essentials_database_basic_8.tf
+++ b/provider/essentials/testdata/essentials_database_basic_8.tf
@@ -1,0 +1,50 @@
+variable "subscription_name" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+variable "redis_version" {
+  type = string
+}
+variable "password" {
+  type = string
+}
+variable "database_protocol" {
+  type = string
+}
+
+
+data "rediscloud_payment_method" "card" {
+  card_type         = "Visa"
+  last_four_numbers = "5556"
+}
+
+data "rediscloud_essentials_plan" "example" {
+  name           = "Single-Zone_1GB"
+  cloud_provider = "AWS"
+  region         = "us-east-1"
+}
+
+resource "rediscloud_essentials_subscription" "example" {
+  name              = var.subscription_name
+  plan_id           = data.rediscloud_essentials_plan.example.id
+  payment_method_id = data.rediscloud_payment_method.card.id
+}
+
+resource "rediscloud_essentials_database" "example" {
+  subscription_id  = rediscloud_essentials_subscription.example.id
+  name             = var.database_name
+  protocol         = var.database_protocol
+  redis_version    = var.redis_version
+  replication      = false
+  data_persistence = "none"
+
+  password = var.password
+
+  alert {
+    name  = "throughput-higher-than"
+    value = 80
+  }
+}

--- a/provider/resource_rediscloud_essentials_database.go
+++ b/provider/resource_rediscloud_essentials_database.go
@@ -84,7 +84,7 @@ func resourceRedisCloudEssentialsDatabase() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"actual_redis_version": {
+			"redis_version_actual": {
 				Description: "The actual Redis database version",
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -485,7 +485,7 @@ func resourceRedisCloudEssentialsDatabaseRead(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	if db.RedisVersion != nil {
-		if err := d.Set("actual_redis_version", redis.StringValue(db.RedisVersion)); err != nil {
+		if err := d.Set("redis_version_actual", redis.StringValue(db.RedisVersion)); err != nil {
 			return diag.FromErr(err)
 		}
 		_, inState := d.GetOk("redis_version")
@@ -633,7 +633,7 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 	// Handle redis_version upgrades before other updates
 	if d.HasChange("redis_version") {
 		originalVersion, newVersion := d.GetChange("redis_version")
-		actualRedisVersion := d.Get("actual_redis_version")
+		actualRedisVersion := d.Get("redis_version_actual")
 
 		// Only perform upgrade if both versions are non-empty (prevents unnecessary upgrades on creation)
 		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion.(string) != newVersion.(string) {

--- a/provider/resource_rediscloud_essentials_database.go
+++ b/provider/resource_rediscloud_essentials_database.go
@@ -84,6 +84,11 @@ func resourceRedisCloudEssentialsDatabase() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"actual_redis_version": {
+				Description: "The actual Redis database version",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"cloud_provider": {
 				Description: "The Cloud Provider hosting this database",
 				Type:        schema.TypeString,
@@ -479,8 +484,18 @@ func resourceRedisCloudEssentialsDatabaseRead(ctx context.Context, d *schema.Res
 	if err := d.Set("protocol", redis.StringValue(db.Protocol)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
-		return diag.FromErr(err)
+	if db.RedisVersion != nil {
+		if err := d.Set("actual_redis_version", redis.StringValue(db.RedisVersion)); err != nil {
+			return diag.FromErr(err)
+		}
+		_, inState := d.GetOk("redis_version")
+
+		if !inState {
+			if err := d.Set("redis_version", redis.StringValue(db.RedisVersion)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
 	}
 	if err := d.Set("cloud_provider", redis.StringValue(db.Provider)); err != nil {
 		return diag.FromErr(err)
@@ -618,9 +633,10 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 	// Handle redis_version upgrades before other updates
 	if d.HasChange("redis_version") {
 		originalVersion, newVersion := d.GetChange("redis_version")
+		actualRedisVersion := d.Get("actual_redis_version")
 
 		// Only perform upgrade if both versions are non-empty (prevents unnecessary upgrades on creation)
-		if originalVersion.(string) != "" && newVersion.(string) != "" {
+		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion.(string) != newVersion.(string) {
 			if upgradeDiags := upgradeRedisVersionEssentials(ctx, api, subId, databaseId, newVersion.(string)); upgradeDiags != nil {
 				return upgradeDiags
 			}

--- a/provider/resource_rediscloud_essentials_database_test.go
+++ b/provider/resource_rediscloud_essentials_database_test.go
@@ -413,7 +413,7 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionUpgrade(t *testing.
 	})
 }
 
-// Test redis_version no incorrect diff and actual_redis_version always has correct version
+// Test redis_version no incorrect diff and redis_version_actual always has correct version
 func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t *testing.T) {
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
@@ -434,7 +434,7 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t 
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseName),
-					"redis_version":     config.StringVariable("8.4"),
+					"redis_version":     config.StringVariable("8.6"),
 					"password":          config.StringVariable(password),
 					"database_protocol": config.StringVariable("stack"),
 				},
@@ -443,8 +443,8 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t 
 					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "db_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
-					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
-					resource.TestCheckResourceAttr(resourceName, "actual_redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.6"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
 				),
 			},
 			// Step 2: Simulate that an auto_minor_version_upgrade happened, not throwing an error when receiving a `downgrade` request, is currently expected behaviour
@@ -453,15 +453,15 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t 
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseName),
-					"redis_version":     config.StringVariable("8.2"),
+					"redis_version":     config.StringVariable("8.4"),
 					"password":          config.StringVariable(password),
 					"database_protocol": config.StringVariable("stack"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile("^\\d+/\\d+$")),
 					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
-					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.2"),
-					resource.TestCheckResourceAttr(resourceName, "actual_redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
 					// Verify database is still active and accessible
 					resource.TestCheckResourceAttrSet(resourceName, "public_endpoint"),
 				),

--- a/provider/resource_rediscloud_essentials_database_test.go
+++ b/provider/resource_rediscloud_essentials_database_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
@@ -403,6 +405,63 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionUpgrade(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
 					resource.TestCheckResourceAttr(resourceName, "redis_version", "7.4"),
 					resource.TestCheckResourceAttr(resourceName, "data_persistence", "aof-every-write"),
+					// Verify database is still active and accessible
+					resource.TestCheckResourceAttrSet(resourceName, "public_endpoint"),
+				),
+			},
+		},
+	})
+}
+
+// Test redis_version no incorrect diff and actual_redis_version always has correct version
+func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t *testing.T) {
+	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
+
+	subscriptionName := utils.RandomWithPrefix()
+	databaseName := subscriptionName + "-db"
+	password := acctest.RandString(20)
+
+	const resourceName = "rediscloud_essentials_database.example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckEssentialsSubscription(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEssentialsSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create database with Redis 8.4
+			{
+				ConfigFile: config.StaticFile("./essentials/testdata/essentials_database_basic_8.tf"),
+				ConfigVariables: config.Variables{
+					"subscription_name": config.StringVariable(subscriptionName),
+					"database_name":     config.StringVariable(databaseName),
+					"redis_version":     config.StringVariable("8.4"),
+					"password":          config.StringVariable(password),
+					"database_protocol": config.StringVariable("stack"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile("^\\d+/\\d+$")),
+					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "db_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "actual_redis_version", "8.4"),
+				),
+			},
+			// Step 2: Simulate that an auto_minor_version_upgrade happened, not throwing an error when receiving a `downgrade` request, is currently expected behaviour
+			{
+				ConfigFile: config.StaticFile("./essentials/testdata/essentials_database_basic_8.tf"),
+				ConfigVariables: config.Variables{
+					"subscription_name": config.StringVariable(subscriptionName),
+					"database_name":     config.StringVariable(databaseName),
+					"redis_version":     config.StringVariable("8.2"),
+					"password":          config.StringVariable(password),
+					"database_protocol": config.StringVariable("stack"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile("^\\d+/\\d+$")),
+					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(resourceName, "actual_redis_version", "8.4"),
 					// Verify database is still active and accessible
 					resource.TestCheckResourceAttrSet(resourceName, "public_endpoint"),
 				),


### PR DESCRIPTION
- fixes state drift in redis_version
- introduces actual_redis_version to fetch version even post auto_minor_version_upgrade