### PR TITLE
chore: Use "fetch-depth=0" in GitHub checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
       -
         name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
No need to manually "unshallow", we can just fetch everything, similar to https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/release.yml#L23