### PR TITLE
chore: Use GoReleaser version from .goreleaser.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: latest
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
A warning is emitted in the `release` action (ref: https://github.com/RedisLabs/terraform-provider-rediscloud/actions/runs/26226112551/job/77173480662#step:5:28, check the `Run Go Releaser` step).

Match the setup in the ``:
- https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/187a12b15672fb3812a39a5c82c8a00c264df333/.github/workflows/release.yml#L37
- https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/187a12b15672fb3812a39a5c82c8a00c264df333/.goreleaser.yml#L3