### PR TITLE
chore: Use crazy-max/ghaction-import-gpg action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588 # v2.1.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
The current action is _VERY_ outdated (more than 6 years). A lot of [warnings](https://github.com/RedisLabs/terraform-provider-rediscloud/actions/runs/26226112551/job/77173480662#step:5:28) are emitted as well.


Match the `terraform-provider-scaffolding-framework`: https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/187a12b15672fb3812a39a5c82c8a00c264df333/.github/workflows/release.yml#L29