### PR TITLE
fix: Inconsistent result after apply for `remote_backup` for Active-Active databases

### DIFF
--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -212,9 +212,16 @@ func flattenAlertsToSet(alerts []*databases.Alert) (types.Set, diag.Diagnostics)
 }
 
 // buildBackupPlan converts a RemoteBackupModel to the API request format.
+// Returns Active=false when the block is absent so a removed remote_backup
+// disables the backup on the API side, matching the empty list produced by
+// the read path.
 func buildBackupPlan(ctx context.Context, remoteBackupList types.List) (*databases.DatabaseBackupConfig, diag.Diagnostics) {
-	if remoteBackupList.IsNull() || remoteBackupList.IsUnknown() || len(remoteBackupList.Elements()) == 0 {
+	if remoteBackupList.IsUnknown() {
 		return nil, nil
+	}
+
+	if remoteBackupList.IsNull() || len(remoteBackupList.Elements()) == 0 {
+		return &databases.DatabaseBackupConfig{Active: redis.Bool(false)}, nil
 	}
 
 	var backups []RemoteBackupModel
@@ -224,7 +231,7 @@ func buildBackupPlan(ctx context.Context, remoteBackupList types.List) (*databas
 	}
 
 	if len(backups) == 0 {
-		return nil, nil
+		return &databases.DatabaseBackupConfig{Active: redis.Bool(false)}, nil
 	}
 
 	backup := backups[0]

--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -259,10 +259,15 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 		"storage_path": types.StringType,
 	}
 
-	emptyList := types.ListValueMust(types.ObjectType{AttrTypes: remoteBackupAttrTypes}, []attr.Value{})
+	objectType := types.ObjectType{AttrTypes: remoteBackupAttrTypes}
+
+	emptyList, diags := types.ListValue(objectType, []attr.Value{})
+	if diags.HasError() {
+		return emptyList, diags
+	}
 
 	if backup == nil || !redis.BoolValue(backup.Enabled) {
-		return emptyList, nil
+		return emptyList, diags
 	}
 
 	timeUTC := types.StringNull()
@@ -273,17 +278,20 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 	// Storage type is not returned by API, preserve from state
 	storageType := types.StringValue(stateStorageType)
 
-	obj, diags := types.ObjectValue(remoteBackupAttrTypes, map[string]attr.Value{
+	obj, objDiags := types.ObjectValue(remoteBackupAttrTypes, map[string]attr.Value{
 		"interval":     types.StringValue(redis.StringValue(backup.Interval)),
 		"time_utc":     timeUTC,
 		"storage_type": storageType,
 		"storage_path": types.StringValue(redis.StringValue(backup.Destination)),
 	})
+	diags.Append(objDiags...)
 	if diags.HasError() {
 		return emptyList, diags
 	}
 
-	return types.ListValue(types.ObjectType{AttrTypes: remoteBackupAttrTypes}, []attr.Value{obj})
+	list, listDiags := types.ListValue(objectType, []attr.Value{obj})
+	diags.Append(listDiags...)
+	return list, diags
 }
 
 // waitForDatabaseToBeDeleted waits for the database to be deleted using retry.StateChangeConf.

--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -252,8 +252,10 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 		"storage_path": types.StringType,
 	}
 
+	emptyList := types.ListValueMust(types.ObjectType{AttrTypes: remoteBackupAttrTypes}, []attr.Value{})
+
 	if backup == nil || !redis.BoolValue(backup.Enabled) {
-		return types.ListNull(types.ObjectType{AttrTypes: remoteBackupAttrTypes}), nil
+		return emptyList, nil
 	}
 
 	timeUTC := types.StringNull()
@@ -271,7 +273,7 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 		"storage_path": types.StringValue(redis.StringValue(backup.Destination)),
 	})
 	if diags.HasError() {
-		return types.ListNull(types.ObjectType{AttrTypes: remoteBackupAttrTypes}), diags
+		return emptyList, diags
 	}
 
 	return types.ListValue(types.ObjectType{AttrTypes: remoteBackupAttrTypes}, []attr.Value{obj})

--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -257,8 +257,8 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 	}
 
 	timeUTC := types.StringNull()
-	if backup.TimeUTC != nil {
-		timeUTC = types.StringValue(redis.StringValue(backup.TimeUTC))
+	if v := redis.StringValue(backup.TimeUTC); v != "" {
+		timeUTC = types.StringValue(v)
 	}
 
 	// Storage type is not returned by API, preserve from state

--- a/provider/activeactive/helpers_internal_test.go
+++ b/provider/activeactive/helpers_internal_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func TestFlattenBackupPlan_AbsentBackupIsEmptyList(t *testing.T) {
+	cases := []struct {
+		name   string
+		backup *databases.Backup
+	}{
+		{name: "nil backup", backup: nil},
+		{name: "disabled backup", backup: &databases.Backup{Enabled: redis.Bool(false)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list, diags := flattenBackupPlan(tc.backup, "")
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if list.IsNull() {
+				t.Fatalf("expected empty list, got null — would cause 'planned set element does not correlate' on block removal")
+			}
+			if len(list.Elements()) != 0 {
+				t.Fatalf("expected empty list, got %d elements", len(list.Elements()))
+			}
+		})
+	}
+}
+
 func TestFlattenBackupPlan_TimeUTC(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/provider/activeactive/helpers_internal_test.go
+++ b/provider/activeactive/helpers_internal_test.go
@@ -1,0 +1,59 @@
+package activeactive
+
+import (
+	"testing"
+
+	"github.com/RedisLabs/rediscloud-go-api/redis"
+	"github.com/RedisLabs/rediscloud-go-api/service/databases"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlattenBackupPlan_TimeUTC(t *testing.T) {
+	cases := []struct {
+		name      string
+		timeUTC   *string
+		wantNull  bool
+		wantValue string
+	}{
+		{name: "nil pointer is null", timeUTC: nil, wantNull: true},
+		{name: "empty string is null", timeUTC: redis.String(""), wantNull: true},
+		{name: "set value is preserved", timeUTC: redis.String("12:00"), wantValue: "12:00"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backup := &databases.Backup{
+				Enabled:     redis.Bool(true),
+				Interval:    redis.String("every-24-hours"),
+				TimeUTC:     tc.timeUTC,
+				Destination: redis.String("s3://example"),
+			}
+
+			list, diags := flattenBackupPlan(backup, "aws-s3")
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+
+			elems := list.Elements()
+			if len(elems) != 1 {
+				t.Fatalf("expected 1 element, got %d", len(elems))
+			}
+
+			obj := elems[0].(types.Object)
+			timeUTC := obj.Attributes()["time_utc"].(types.String)
+
+			if tc.wantNull {
+				if !timeUTC.IsNull() {
+					t.Fatalf("expected time_utc to be null, got %q", timeUTC.ValueString())
+				}
+				return
+			}
+			if timeUTC.IsNull() {
+				t.Fatalf("expected time_utc %q, got null", tc.wantValue)
+			}
+			if got := timeUTC.ValueString(); got != tc.wantValue {
+				t.Fatalf("expected time_utc %q, got %q", tc.wantValue, got)
+			}
+		})
+	}
+}

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -97,6 +97,31 @@ func UseStateOnUpdate() planmodifier.List {
 	return useStateOnUpdateListModifier{}
 }
 
+type emptyStringToNullModifier struct{}
+
+var _ planmodifier.String = emptyStringToNullModifier{}
+
+func (m emptyStringToNullModifier) Description(_ context.Context) string {
+	return "Normalizes an empty string config value to null in the plan, so it matches the null produced by the read path."
+}
+
+func (m emptyStringToNullModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m emptyStringToNullModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.PlanValue.IsNull() && !req.PlanValue.IsUnknown() && req.PlanValue.ValueString() == "" {
+		resp.PlanValue = types.StringNull()
+	}
+}
+
+// EmptyStringToNull returns a plan modifier that converts an empty string to null in the plan.
+// Use this when the read path produces null for missing/empty values, to keep plan and apply
+// in agreement and avoid "planned set element does not correlate" errors on parent set blocks.
+func EmptyStringToNull() planmodifier.String {
+	return emptyStringToNullModifier{}
+}
+
 // Schema defines the schema for the resource.
 func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	// Alert block schema (used in global_alert and override_global_alert)
@@ -131,6 +156,9 @@ func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ resource.Sche
 				Optional:    true,
 				Validators: []validator.String{
 					TimeValidator(),
+				},
+				PlanModifiers: []planmodifier.String{
+					EmptyStringToNull(),
 				},
 			},
 			"storage_type": schema.StringAttribute{

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -102,7 +102,7 @@ type emptyStringToNullModifier struct{}
 var _ planmodifier.String = emptyStringToNullModifier{}
 
 func (m emptyStringToNullModifier) Description(_ context.Context) string {
-	return "Normalizes an empty string config value to null in the plan, so it matches the null produced by the read path."
+	return "Normalises an empty string config value to null in the plan, so it matches the null produced by the read path."
 }
 
 func (m emptyStringToNullModifier) MarkdownDescription(ctx context.Context) string {

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -771,7 +771,9 @@ func (r *activeActiveDatabaseResource) buildOverrideRegionFromAPI(ctx context.Co
 			allDiags.Append(diags...)
 			regionConfig["override_global_alert"] = alertSet
 		} else {
-			regionConfig["override_global_alert"] = types.SetValueMust(types.ObjectType{AttrTypes: alertAttrTypes}, []attr.Value{})
+			alertSet, diags := types.SetValue(types.ObjectType{AttrTypes: alertAttrTypes}, []attr.Value{})
+			allDiags.Append(diags...)
+			regionConfig["override_global_alert"] = alertSet
 		}
 
 		// Handle enable_default_user

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -771,7 +771,7 @@ func (r *activeActiveDatabaseResource) buildOverrideRegionFromAPI(ctx context.Co
 			allDiags.Append(diags...)
 			regionConfig["override_global_alert"] = alertSet
 		} else {
-			regionConfig["override_global_alert"] = types.SetNull(types.ObjectType{AttrTypes: alertAttrTypes})
+			regionConfig["override_global_alert"] = types.SetValueMust(types.ObjectType{AttrTypes: alertAttrTypes}, []attr.Value{})
 		}
 
 		// Handle enable_default_user


### PR DESCRIPTION
A lot of issues were found in the respective changes:

## `time_utc`
Omitting `time_utc` in the TF config in inconsistent result after apply.

```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to rediscloud_active_active_subscription_database.database-resource, provider "provider[\"registry.terraform.io/redislabs/rediscloud\"]" produced an unexpected new value: .override_region:
│ planned set element cty.ObjectVal(map[string]cty.Value{"enable_default_user":cty.NullVal(cty.Bool), "name":cty.StringVal("us-east-2"),
│ "override_global_alert":cty.SetValEmpty(cty.Object(map[string]cty.Type{"name":cty.String, "value":cty.Number})), "override_global_data_persistence":cty.NullVal(cty.String),
│ "override_global_enable_passwordless":cty.NullVal(cty.Bool), "override_global_password":cty.NullVal(cty.String), "override_global_source_ips":cty.SetVal([]cty.Value{cty.StringVal("192.10.0.0/16")}),
│ "remote_backup":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"interval":cty.StringVal("every-6-hours"), "storage_path":cty.StringVal("s3://steliyan-tf-remote-backup/"),
│ "storage_type":cty.StringVal("aws-s3"), "time_utc":cty.NullVal(cty.String)})})}) does not correlate with any element in actual.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

State:
```
"remote_backup": [
	{
		"interval": "every-6-hours",
		"storage_path": "s3://steliyan-tf-remote-backup/",
		"storage_type": "aws-s3",
		"time_utc": ""
	}
]
```

## `remote_backup`
```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to rediscloud_active_active_subscription_database.database-resource, provider "provider[\"registry.terraform.io/redislabs/rediscloud\"]" produced an unexpected new value: .override_region:
│ planned set element cty.ObjectVal(map[string]cty.Value{"enable_default_user":cty.NullVal(cty.Bool), "name":cty.StringVal("us-east-2"),
│ "override_global_alert":cty.SetValEmpty(cty.Object(map[string]cty.Type{"name":cty.String, "value":cty.Number})), "override_global_data_persistence":cty.NullVal(cty.String),
│ "override_global_enable_passwordless":cty.NullVal(cty.Bool), "override_global_password":cty.NullVal(cty.String), "override_global_source_ips":cty.SetVal([]cty.Value{cty.StringVal("192.10.0.0/16")}),
│ "remote_backup":cty.ListValEmpty(cty.Object(map[string]cty.Type{"interval":cty.String, "storage_path":cty.String, "storage_type":cty.String, "time_utc":cty.String}))}) does not correlate with any element in
│ actual.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵```

State: It doesn't detect `remote_backup` removal as it sets `null` instead of an empty list.

Ticket: https://redislabs.atlassian.net/browse/RED-196844