### PR TITLE
fix: Auto-minor upgrade logic for Pro/Essentials databases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/RedisLabs/rediscloud-go-api v0.50.0
 	github.com/bflad/tfproviderlint v0.31.0
 	github.com/hashicorp/go-cty v1.5.0
+	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
@@ -37,7 +38,6 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.4 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/provider/pro/resource_rediscloud_pro_database.go
+++ b/provider/pro/resource_rediscloud_pro_database.go
@@ -131,8 +131,9 @@ func ResourceRedisCloudProDatabase() *schema.Resource {
 				Description: "Defines the requested Redis database version. If omitted, the Redis version will be set to the default version. Use `redis_version_actual` to get the version on which the database is running.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				//TODO(TF3.0) remove computed , as it is a breaking change. Previously value could also be received from API, but should become write-only
-				Computed: true,
+				//TODO(TF3.0) drop Computed and stop writing redis_version from Read — makes the field write-only-by-convention (no plugin-framework migration), so state only ever holds what the user wrote in config and auto-upgrades can't drift state. DSF stays to heal state poisoned by older provider versions.
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressIfRedisVersionSatisfied,
 			},
 			"redis_version_actual": {
 				Description: "The actual Redis database version",
@@ -992,6 +993,7 @@ func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.Resource
 
 		// if either version is blank, it could attempt to upgrade unnecessarily.
 		// only upgrade when a known version goes to another known version
+		//TODO(TF3.0) once redis_version goes write-only-by-convention (Computed dropped, not written from Read), drop the actualRedisVersion guard — DSF already makes it unreachable in normal operation. Kept today as belt-and-suspenders against DSF regressions.
 		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion != newVersion.(string) {
 			if upgradeDiags, unlocked := upgradeRedisVersion(ctx, api, subId, dbId, newVersion.(string)); upgradeDiags != nil {
 				if !unlocked {

--- a/provider/resource_rediscloud_essentials_database.go
+++ b/provider/resource_rediscloud_essentials_database.go
@@ -79,10 +79,11 @@ func resourceRedisCloudEssentialsDatabase() *schema.Resource {
 				ForceNew:         true,
 			},
 			"redis_version": {
-				Description: "Defines the Redis database version. If omitted, the Redis version will be set to the default version",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Description:      "Defines the Redis database version. If omitted, the Redis version will be set to the default version",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressIfRedisVersionSatisfied,
 			},
 			"redis_version_actual": {
 				Description: "The actual Redis database version",
@@ -636,6 +637,7 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 		actualRedisVersion := d.Get("redis_version_actual")
 
 		// Only perform upgrade if both versions are non-empty (prevents unnecessary upgrades on creation)
+		//TODO(TF3.0) once redis_version goes write-only-by-convention (Computed dropped, not written from Read), drop the actualRedisVersion guard — DSF already makes it unreachable in normal operation. Kept today as belt-and-suspenders against DSF regressions.
 		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion.(string) != newVersion.(string) {
 			if upgradeDiags := upgradeRedisVersionEssentials(ctx, api, subId, databaseId, newVersion.(string)); upgradeDiags != nil {
 				return upgradeDiags

--- a/provider/resource_rediscloud_essentials_database_test.go
+++ b/provider/resource_rediscloud_essentials_database_test.go
@@ -447,7 +447,10 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t 
 					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
 				),
 			},
-			// Step 2: Simulate that an auto_minor_version_upgrade happened, not throwing an error when receiving a `downgrade` request, is currently expected behaviour
+			// Step 2: Simulate that an auto_minor_version_upgrade happened: actual ("8.6") is now ahead
+			// of the requested version ("8.4"). DiffSuppressFunc (utils.SuppressIfRedisVersionSatisfied)
+			// must treat the request as satisfied and produce a clean plan — PlanOnly with the default
+			// ExpectNonEmptyPlan=false fails if any diff sneaks through.
 			{
 				ConfigFile: config.StaticFile("./essentials/testdata/essentials_database_basic_8.tf"),
 				ConfigVariables: config.Variables{
@@ -457,12 +460,13 @@ func TestAccResourceRedisCloudEssentialsDatabase_RedisVersionAutoMinorUpgrade(t 
 					"password":          config.StringVariable(password),
 					"database_protocol": config.StringVariable("stack"),
 				},
+				PlanOnly: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile("^\\d+/\\d+$")),
 					resource.TestCheckResourceAttr(resourceName, "name", databaseName),
-					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					// DSF makes the field look unchanged, so state retains the value from the prior step.
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.6"),
 					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
-					// Verify database is still active and accessible
 					resource.TestCheckResourceAttrSet(resourceName, "public_endpoint"),
 				),
 			},

--- a/provider/resource_rediscloud_pro_database_test.go
+++ b/provider/resource_rediscloud_pro_database_test.go
@@ -348,7 +348,10 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
 				),
 			},
-			//simulate that an auto_minor_version_upgrade happened, not throwing an error when receiving a `downgrade` request, is currently expected behaviour
+			// Simulate that an auto_minor_version_upgrade happened: actual ("8.6") is now ahead of the
+			// requested version ("8.4"). DiffSuppressFunc (utils.SuppressIfRedisVersionSatisfied) must
+			// treat the request as satisfied and produce a clean plan — PlanOnly with the default
+			// ExpectNonEmptyPlan=false fails if any diff sneaks through.
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_auto_minor_version_upgrade.tf"),
 				ConfigVariables: config.Variables{
@@ -358,9 +361,11 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 					"auto_minor_version_upgrade":   config.BoolVariable(true),
 					"redis_version":                config.StringVariable("8.4"),
 				},
+				PlanOnly: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
-					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					// DSF makes the field look unchanged, so state retains the value from the prior step.
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.6"),
 					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
 				),
 			},

--- a/provider/utils/redis_version.go
+++ b/provider/utils/redis_version.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// SuppressIfRedisVersionSatisfied suppresses diffs on `redis_version` when the
+// database's actual version (`redis_version_actual`) already meets or exceeds the
+// configured value *within the same major*. This treats `redis_version` as a
+// minimum-requested version so server-side auto minor upgrades — and state
+// poisoned by older provider versions that mirrored the API value into
+// `redis_version` — do not surface as drift on every plan.
+//
+// A major-version mismatch (e.g. config "7.4" vs actual "8.0") is NOT suppressed:
+// crossing a major boundary is a meaningful change that should surface as a real
+// diff so the user sees the intent and the Update path can act on it.
+func SuppressIfRedisVersionSatisfied(_, _, newVal string, d *schema.ResourceData) bool {
+	if newVal == "" {
+		return true
+	}
+	// Compare against redis_version_actual (live API value) rather than the DSF's
+	// oldVal (prior state). State can be poisoned by older provider versions that
+	// mirrored the API into redis_version; trusting oldVal would never heal that
+	// drift. redis_version_actual is always written from the API on Read, so it's
+	// the trustworthy reference for "what version is the database really running".
+	actualRaw, ok := d.GetOk("redis_version_actual")
+	if !ok {
+		return false
+	}
+	requested, err := version.NewVersion(newVal)
+	if err != nil {
+		return false
+	}
+	actual, err := version.NewVersion(actualRaw.(string))
+	if err != nil {
+		return false
+	}
+	if requested.Segments()[0] != actual.Segments()[0] {
+		return false
+	}
+	return actual.GreaterThanOrEqual(requested)
+}

--- a/provider/utils/redis_version_test.go
+++ b/provider/utils/redis_version_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuppressIfRedisVersionSatisfied(t *testing.T) {
+	tests := []struct {
+		name     string
+		newVal   string
+		actual   string
+		suppress bool
+	}{
+		{name: "empty config value suppresses (Computed fallback)", newVal: "", actual: "8.6", suppress: true},
+		{name: "missing actual does not suppress (e.g. create)", newVal: "8.4", actual: "", suppress: false},
+		{name: "actual ahead within same major suppresses", newVal: "8.4", actual: "8.6", suppress: true},
+		{name: "actual equal suppresses", newVal: "8.6", actual: "8.6", suppress: true},
+		{name: "actual behind does not suppress (real upgrade)", newVal: "8.6", actual: "8.4", suppress: false},
+		{name: "patch-level actual ahead suppresses", newVal: "7.4", actual: "7.4.2", suppress: true},
+		{name: "actual ahead across major does not suppress", newVal: "7.4", actual: "8.0", suppress: false},
+		{name: "actual behind across major does not suppress", newVal: "8.0", actual: "7.4", suppress: false},
+		{name: "malformed new does not suppress", newVal: "not-a-version", actual: "8.6", suppress: false},
+		{name: "malformed actual does not suppress", newVal: "8.4", actual: "not-a-version", suppress: false},
+	}
+
+	rsrc := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"redis_version_actual": {Type: schema.TypeString, Optional: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]interface{}{}
+			if tc.actual != "" {
+				raw["redis_version_actual"] = tc.actual
+			}
+			d := schema.TestResourceDataRaw(t, rsrc.Schema, raw)
+			got := SuppressIfRedisVersionSatisfied("redis_version", "", tc.newVal, d)
+			assert.Equal(t, tc.suppress, got)
+		})
+	}
+}


### PR DESCRIPTION
Introduce [DiffSupressFunc](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc) to ignore lower _MAJOR_ versions based on the `redis_version_actual`.

Note in the reported repro, the actual diff is reported during a `tf plan`. Although the state itself is _NOT_ persisted, TF uses a refreshed state which has already drifted _FORWARDS_. That's the exact thing we want to ignore (the minor upgrade), hence the introduction of `DiffSupressFunc` mentioned above.

NOTE: The [old supress code](https://github.com/RedisLabs/terraform-provider-rediscloud/pull/858/changes#diff-38461ad9d30441de2f5b3b4c8730c4d1accd0fdf2d0416d8003e5bc3a507bfcbR969) (and for [Essentials](https://github.com/RedisLabs/terraform-provider-rediscloud/pull/858/changes#diff-cbd880cdd24e3a1f960f95bcde32733f9a06d812cb5de112961c5d1d552f5e62R640) as well) are left as-is although we should never get there as the *DSF* would remove the diff from the plan altogether! This will be deleted once we migrate to `WriteOnly: true` attribute after TF Plugin framework is used, the code is left to minimize the impact of this PR.

## Reproduction

1. Start on provider v2.16 with a Terraform config specifying Redis version 8.4
2. Perform a minor version upgrade outside of Terraform (via UI or API), bumping the actual Redis version to 8.6
3. Run terraform plan → plan is dirty, showing a diff between the configured 8.4 and actual 8.6 (drift is now present)
4. Upgrade the provider to v2.17.0
5. Run terraform plan → drift persists, plan is still dirty