### PR TITLE
OPCR-187: Maintenance window not set after CMK flow (Active-Active Subscription)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
-# 2.17.0 (TBD)
+# 2.17.1 (TBD)
+## Changed
+- Added validation for `maintenance_window` being set in CMK workflow tests
+
+## Fixed
+- `maintenance_window` not being set after CMK workflow in active-active subscription
+- CMK workflow test for active_active subscription not being runnable
+
+# 2.17.0 (10.06.2026)
 
 ## Added
 - Added `redis_version_actual` attribute to the `rediscloud_subscription_database` resource.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 # 2.17.1 (TBD)
 ## Changed
-- Added validation for `maintenance_window` being set in CMK workflow tests
+- Added validation for `maintenance_windows` being set in CMK workflow tests for `rediscloud_active_active_subscription` resource
 
 ## Fixed
-- `maintenance_window` not being set after CMK workflow in active-active subscription
-- CMK workflow test for active_active subscription not being runnable
+- `maintenance_windows` not being set after CMK workflow in `rediscloud_active_active_subscription` resource
+- CMK workflow test for `rediscloud_active_active_subscription` not being runnable
+- Read logic for `maintenance_windows` and `pricing` not triggering properly when in CMK workflow
 
-# 2.17.0 (10.06.2026)
+# 2.17.0 (10th June 2026)
 
 ## Added
 - Added `redis_version_actual` attribute to the `rediscloud_subscription_database` resource.
@@ -33,12 +34,12 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - State drift on `redis_version` caused by `auto_minor_version_upgrade` being set to `true`
 - State drift on `redis_version` in `rediscloud_essentials_database` resource caused by auto minor version upgrade feature.
 
-# 2.16.1 (May 2026)
+# 2.16.1 (21st May 2026)
 
 ## Fixed
 - Remove usage of immutable GitHub releases
 
-# 2.16.0 (May 2026)
+# 2.16.0 (19th May 2026)
 
 ## Added
 - Added `prometheus_endpoint` attribute to the `rediscloud_subscription` resource.

--- a/provider/activeactive/testdata/cmk_aws_step1.tf
+++ b/provider/activeactive/testdata/cmk_aws_step1.tf
@@ -11,6 +11,17 @@ variable "name" {
   type = string
 }
 
+variable "maintenance_windows" {
+  type = list(object({
+    mode = string
+    window = list(object({
+      start_hour        = number
+      duration_in_hours = number
+      days              = list(string)
+    }))
+  }))
+}
+
 provider "aws" {
   region = "us-east-1"
 }
@@ -63,12 +74,18 @@ resource "rediscloud_active_active_subscription" "example" {
   customer_managed_key_enabled = true
   cloud_provider               = "AWS"
 
-  maintenance_windows {
-    mode = "manual"
-    window {
-      start_hour        = 22
-      duration_in_hours = 8
-      days              = ["Monday", "Thursday"]
+  dynamic "maintenance_windows" {
+    for_each = var.maintenance_windows
+    content {
+      mode = maintenance_windows.value.mode
+      dynamic "window" {
+        for_each = maintenance_windows.value.window
+        content {
+          start_hour        = window.value.start_hour
+          duration_in_hours = window.value.duration_in_hours
+          days              = window.value.days
+        }
+      }
     }
   }
 

--- a/provider/activeactive/testdata/cmk_aws_step1.tf
+++ b/provider/activeactive/testdata/cmk_aws_step1.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }
@@ -53,6 +62,15 @@ resource "rediscloud_active_active_subscription" "example" {
   payment_method_id            = data.rediscloud_payment_method.card.id
   customer_managed_key_enabled = true
   cloud_provider               = "AWS"
+
+  maintenance_windows {
+    mode = "manual"
+    window {
+      start_hour        = 22
+      duration_in_hours = 8
+      days              = ["Monday", "Thursday"]
+    }
+  }
 
   creation_plan {
     memory_limit_in_gb = 1

--- a/provider/activeactive/testdata/cmk_aws_step2.tf
+++ b/provider/activeactive/testdata/cmk_aws_step2.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }
@@ -91,6 +100,15 @@ resource "rediscloud_active_active_subscription" "example" {
   payment_method_id            = data.rediscloud_payment_method.card.id
   customer_managed_key_enabled = true
   cloud_provider               = "AWS"
+
+  maintenance_windows {
+    mode = "manual"
+    window {
+      start_hour        = 22
+      duration_in_hours = 8
+      days              = ["Monday", "Thursday"]
+    }
+  }
 
   customer_managed_key {
     resource_name = aws_kms_key.cmk_primary.arn

--- a/provider/activeactive/testdata/cmk_aws_step2.tf
+++ b/provider/activeactive/testdata/cmk_aws_step2.tf
@@ -11,6 +11,17 @@ variable "name" {
   type = string
 }
 
+variable "maintenance_windows" {
+  type = list(object({
+    mode = string
+    window = list(object({
+      start_hour        = number
+      duration_in_hours = number
+      days              = list(string)
+    }))
+  }))
+}
+
 provider "aws" {
   region = "us-east-1"
 }
@@ -101,12 +112,18 @@ resource "rediscloud_active_active_subscription" "example" {
   customer_managed_key_enabled = true
   cloud_provider               = "AWS"
 
-  maintenance_windows {
-    mode = "manual"
-    window {
-      start_hour        = 22
-      duration_in_hours = 8
-      days              = ["Monday", "Thursday"]
+  dynamic "maintenance_windows" {
+    for_each = var.maintenance_windows
+    content {
+      mode = maintenance_windows.value.mode
+      dynamic "window" {
+        for_each = maintenance_windows.value.window
+        content {
+          start_hour        = window.value.start_hour
+          duration_in_hours = window.value.duration_in_hours
+          days              = window.value.days
+        }
+      }
     }
   }
 

--- a/provider/activeactive/testdata/cmk_step1.tf
+++ b/provider/activeactive/testdata/cmk_step1.tf
@@ -15,6 +15,17 @@ variable "gcp_project_id" {
   type = string
 }
 
+variable "maintenance_windows" {
+  type = list(object({
+    mode = string
+    window = list(object({
+      start_hour        = number
+      duration_in_hours = number
+      days              = list(string)
+    }))
+  }))
+}
+
 data "rediscloud_payment_method" "card" {
   card_type         = "Visa"
   last_four_numbers = "5556"
@@ -44,12 +55,18 @@ resource "rediscloud_active_active_subscription" "example" {
   customer_managed_key_enabled = true
   cloud_provider               = "GCP"
 
-  maintenance_windows {
-    mode = "manual"
-    window {
-      start_hour        = 22
-      duration_in_hours = 8
-      days              = ["Monday", "Thursday"]
+  dynamic "maintenance_windows" {
+    for_each = var.maintenance_windows
+    content {
+      mode = maintenance_windows.value.mode
+      dynamic "window" {
+        for_each = maintenance_windows.value.window
+        content {
+          start_hour        = window.value.start_hour
+          duration_in_hours = window.value.duration_in_hours
+          days              = window.value.days
+        }
+      }
     }
   }
 

--- a/provider/activeactive/testdata/cmk_step1.tf
+++ b/provider/activeactive/testdata/cmk_step1.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.5"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }
@@ -34,6 +43,15 @@ resource "rediscloud_active_active_subscription" "example" {
   payment_method_id            = data.rediscloud_payment_method.card.id
   customer_managed_key_enabled = true
   cloud_provider               = "GCP"
+
+  maintenance_windows {
+    mode = "manual"
+    window {
+      start_hour        = 22
+      duration_in_hours = 8
+      days              = ["Monday", "Thursday"]
+    }
+  }
 
   creation_plan {
     memory_limit_in_gb = 1

--- a/provider/activeactive/testdata/cmk_step2.tf
+++ b/provider/activeactive/testdata/cmk_step2.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.5"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }
@@ -44,6 +53,15 @@ resource "rediscloud_active_active_subscription" "example" {
   payment_method_id            = data.rediscloud_payment_method.card.id
   customer_managed_key_enabled = true
   cloud_provider               = "GCP"
+
+  maintenance_windows {
+    mode = "manual"
+    window {
+      start_hour        = 22
+      duration_in_hours = 8
+      days              = ["Monday", "Thursday"]
+    }
+  }
 
   customer_managed_key {
     resource_name = google_kms_crypto_key.cmk.id

--- a/provider/activeactive/testdata/cmk_step2.tf
+++ b/provider/activeactive/testdata/cmk_step2.tf
@@ -15,6 +15,17 @@ variable "gcp_project_id" {
   type = string
 }
 
+variable "maintenance_windows" {
+  type = list(object({
+    mode = string
+    window = list(object({
+      start_hour        = number
+      duration_in_hours = number
+      days              = list(string)
+    }))
+  }))
+}
+
 data "rediscloud_payment_method" "card" {
   card_type         = "Visa"
   last_four_numbers = "5556"
@@ -54,12 +65,18 @@ resource "rediscloud_active_active_subscription" "example" {
   customer_managed_key_enabled = true
   cloud_provider               = "GCP"
 
-  maintenance_windows {
-    mode = "manual"
-    window {
-      start_hour        = 22
-      duration_in_hours = 8
-      days              = ["Monday", "Thursday"]
+  dynamic "maintenance_windows" {
+    for_each = var.maintenance_windows
+    content {
+      mode = maintenance_windows.value.mode
+      dynamic "window" {
+        for_each = maintenance_windows.value.window
+        content {
+          start_hour        = window.value.start_hour
+          duration_in_hours = window.value.duration_in_hours
+          days              = window.value.days
+        }
+      }
     }
   }
 

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -625,9 +625,10 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 	}
 
 	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
-
+	wasCmkPending := false
 	// CMK flow
 	if *subscription.Status == subscriptions.SubscriptionStatusEncryptionKeyPending && cmkEnabled {
+		wasCmkPending = true
 		diags := resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx, d, api, subId)
 
 		if diags != nil {
@@ -699,7 +700,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	if d.HasChange("maintenance_windows") {
+	if d.HasChange("maintenance_windows") || wasCmkPending {
 		var updateMaintenanceRequest maintenance.Maintenance
 		if m, ok := d.GetOk("maintenance_windows"); ok {
 			mMap := m.([]interface{})[0].(map[string]interface{})

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -552,9 +552,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	cmkEnabled := d.Get("customer_managed_key_enabled").(bool)
-
-	if !cmkEnabled {
+	if *subscription.Status == subscriptions.SubscriptionStatusActive {
 		m, err := api.Client.Maintenance.Get(ctx, subId)
 		if err != nil {
 			return diag.FromErr(err)

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -375,6 +375,7 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 }
 
 func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	//TODO fix mapping of empty objects to remove non-empty plan on refresh
 	api := meta.(*client.ApiClient)
 
 	plan := d.Get("creation_plan").([]interface{})

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -30,22 +30,16 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testAccGcpProjectPreCheck(t); testAccGcpCredentialsPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"google": {
-				Source:            "hashicorp/google",
-				VersionConstraint: "~> 6.5",
-			},
-		},
+		PreCheck:     func() { testAccPreCheck(t); testAccGcpProjectPreCheck(t); testAccGcpCredentialsPreCheck(t) },
 		CheckDestroy: testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create subscription with CMK enabled (enters encryption_key_pending state)
 				// Also creates GCP KMS key and grants IAM permissions to the Redis service account
-				ConfigFile:         config.StaticFile("./activeactive/testdata/cmk_step1.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_step1.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_redis_service_account"),
@@ -58,9 +52,10 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 			{
 				// Step 2: Add CMK blocks to activate encryption
 				// This triggers the UpdateCmk code path which should also clean up creation plan databases
-				ConfigFile:         config.StaticFile("./activeactive/testdata/cmk_step2.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_step2.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_redis_service_account"),
@@ -68,6 +63,8 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider"),
 					resource.TestCheckResourceAttr(resourceName, "customer_managed_key_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_windows.0.window"),
 					testAccCheckNoCreationPlanDatabases(resourceName),
 				),
 			},
@@ -96,21 +93,15 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 			testAccAwsPreExistingCloudAccountPreCheck(t)
 			testAccAwsApiCredsPreCheck(t)
 		},
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {
-				Source:            "hashicorp/aws",
-				VersionConstraint: "~> 5.0",
-			},
-		},
 		CheckDestroy: testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Step 1: subscription enters encryption_key_pending; both key policies
 				// (primary + replica) reference the role ARN returned by the subscription.
-				ConfigFile:         config.StaticFile("./activeactive/testdata/cmk_aws_step1.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_aws_step1.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
@@ -123,9 +114,10 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 			{
 				// Step 2: subscription supplies the per-region KMS ARNs (primary + replica)
 				// and transitions out of encryption_key_pending.
-				ConfigFile:         config.StaticFile("./activeactive/testdata/cmk_aws_step2.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_aws_step2.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
@@ -133,6 +125,8 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider"),
 					resource.TestCheckResourceAttr(resourceName, "customer_managed_key_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_windows.0.window"),
 					testAccCheckNoCreationPlanDatabases(resourceName),
 				),
 			},

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
@@ -39,8 +40,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_step1.tf"),
 				ConfigVariables:          configVars,
-				ExpectNonEmptyPlan:       true,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				}, Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_redis_service_account"),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -55,8 +59,17 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_step2.tf"),
 				ConfigVariables:          configVars,
-				ExpectNonEmptyPlan:       true,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				}, Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_redis_service_account"),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -64,7 +77,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider"),
 					resource.TestCheckResourceAttr(resourceName, "customer_managed_key_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_windows.0.window"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "1"),
 					testAccCheckNoCreationPlanDatabases(resourceName),
 				),
 			},
@@ -101,8 +114,11 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_aws_step1.tf"),
 				ConfigVariables:          configVars,
-				ExpectNonEmptyPlan:       true,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				}, Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -117,7 +133,17 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_aws_step2.tf"),
 				ConfigVariables:          configVars,
-				ExpectNonEmptyPlan:       true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
@@ -126,7 +152,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider"),
 					resource.TestCheckResourceAttr(resourceName, "customer_managed_key_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_windows.0.window"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "1"),
 					testAccCheckNoCreationPlanDatabases(resourceName),
 				),
 			},

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -28,6 +28,17 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 	configVars := config.Variables{
 		"name":           config.StringVariable(name),
 		"gcp_project_id": config.StringVariable(gcpProjectId),
+		"maintenance_windows": config.ListVariable(config.ObjectVariable(
+			map[string]config.Variable{
+				"mode": config.StringVariable("manual"),
+				"window": config.ListVariable(config.ObjectVariable(
+					map[string]config.Variable{
+						"start_hour":        config.IntegerVariable(22),
+						"duration_in_hours": config.IntegerVariable(8),
+						"days":              config.ListVariable(config.StringVariable("Monday"), config.StringVariable("Thursday")),
+					})),
+			},
+		)),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -40,11 +51,8 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_step1.tf"),
 				ConfigVariables:          configVars,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				}, Check: resource.ComposeAggregateTestCheckFunc(
+				ExpectNonEmptyPlan:       true,
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_redis_service_account"),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -98,6 +106,17 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 
 	configVars := config.Variables{
 		"name": config.StringVariable(name),
+		"maintenance_windows": config.ListVariable(config.ObjectVariable(
+			map[string]config.Variable{
+				"mode": config.StringVariable("manual"),
+				"window": config.ListVariable(config.ObjectVariable(
+					map[string]config.Variable{
+						"start_hour":        config.IntegerVariable(22),
+						"duration_in_hours": config.IntegerVariable(8),
+						"days":              config.ListVariable(config.StringVariable("Monday"), config.StringVariable("Thursday")),
+					})),
+			},
+		)),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -114,11 +133,8 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				ConfigFile:               config.StaticFile("./activeactive/testdata/cmk_aws_step1.tf"),
 				ConfigVariables:          configVars,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				}, Check: resource.ComposeAggregateTestCheckFunc(
+				ExpectNonEmptyPlan:       true,
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),


### PR DESCRIPTION
- Adds missing update logic for `maintenance_window` following CMK flow completion
- Updates CMK tests to check for `maintenance_window` to be set