### PR TITLE
tests: Add manual trigger to the "main" workflow

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+  workflow_dispatch:
 env:
   TERRAFORM_VERSION: "1.2.6"
   REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_STAGING }}


### PR DESCRIPTION
We should be able to run the "main" test suite against an arbitrary branch.