### PR TITLE
RED-202160: Support DB Upgrade for A-A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,32 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
-# 2.17.1 (TBD)
+# 2.18.0 (TBD)
+
+## Added
+- Ability to upgrade `redis_version` in `rediscloud_active_active_subscription_database` resource without recreating the resource.
+- Exposed `redis_version_actual` attribute on the `rediscloud_active_active_subscription_database` resource.
 
 ## Changed
-- Added validation for `maintenance_windows` being set in CMK workflow tests in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources
+- Migrated `rediscloud_essentials_plan` data source from Terraform SDK v2 to the Terraform Plugin Framework. This is an internal architectural change with no breaking changes to the data source schema or behaviour.
 
 ## Fixed
-- `maintenance_windows` not being set after CMK workflow in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources
-- `maintenance_windows` not being set on creation in `rediscloud_subscription` resource
-- Read logic for `maintenance_windows` and `pricing` not triggering properly during CMK workflow in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources
-- CMK workflow test for `rediscloud_subscription` and `rediscloud_active_active_subscription` not being runnable
-- `rediscloud_subscription` tests for setting `maintenance_windows`
-- Read logic for `maintenance_windows` and `pricing` not triggering properly when in CMK workflow
+- Inconsistent state around `remote_backup` block in `override_region` argument for the `rediscloud_active_active_subscription_database` resource.
 
+# 2.17.1 (16th June 2026)
 
-# 2.17.0 (10.06.2026)
+## Changed
+- Added validation for `maintenance_windows` being set in CMK workflow tests in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources.
+
+## Fixed
+- `maintenance_windows` not being set after CMK workflow in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources.
+- `maintenance_windows` not being set on creation in `rediscloud_subscription` resource.
+- Read logic for `maintenance_windows` and `pricing` not triggering properly during CMK workflow in `rediscloud_subscription` and `rediscloud_active_active_subscription` resources.
+- CMK workflow test for `rediscloud_subscription` and `rediscloud_active_active_subscription` not being runnable.
+- `rediscloud_subscription` tests for setting `maintenance_windows`.
+- Read logic for `maintenance_windows` and `pricing` not triggering properly when in CMK workflow.
+
+# 2.17.0 (10th June 2026)
 
 ## Added
 - Added `redis_version_actual` attribute to the `rediscloud_subscription_database` resource.

--- a/docs/resources/rediscloud_active_active_subscription_database.md
+++ b/docs/resources/rediscloud_active_active_subscription_database.md
@@ -87,7 +87,7 @@ output "us-east-2-private-endpoints" {
 The following arguments are supported:
 * `subscription_id`: (Required) The ID of the Active-Active subscription to create the database in. **Modifying this attribute will force creation of a new resource.**
 * `name` - (Required) A meaningful name to identify the database (maximum 40 characters).
-* `redis_version` - (Optional) The Redis version of the database. If omitted, the Redis version will be the default.  **Modifying this attribute will force creation of a new resource.**
+* `redis_version` - (Optional) The Redis version of the database. If omitted, the Redis version will be the default. May differ if `auto_minor_version_upgrade` is set to `true`. Use `redis_version_actual` to fetch the Redis version used by the database.
 * `memory_limit_in_gb` - (Optional - **Required if `dataset_size_in_gb` is unset**) Maximum memory usage for this specific database, including replication and other overhead **Deprecated in favor of `dataset_size_in_gb` - not possible to import databases with this attribute set**
 * `dataset_size_in_gb` - (Optional - **Required if `memory_limit_in_gb` is unset**) The maximum amount of data in the dataset for this specific database is in GB
 * `support_oss_cluster_api` - (Optional) Support Redis open-source (OSS) Cluster API. Default: ‘false’
@@ -147,6 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `db_id` - Identifier of the database created
 * `public_endpoint` - A map of which public endpoints can to access the database per region, uses region name as key.
 * `private_endpoint` - A map of which private endpoints can to access the database per region, uses region name as key.
+* `redis_version_actual` - The Redis version of the database. Can differ from `redis_version` if `auto_minor_version_upgrade` is set to `true`.
 
 ## Import
 `rediscloud_active_active_subscription_database` can be imported using the ID of the Active-Active subscription and the ID of the database in the format {subscription ID}/{database ID}, e.g.

--- a/provider/activeactive/rediscloud_active_active_database_test.go
+++ b/provider/activeactive/rediscloud_active_active_database_test.go
@@ -1,4 +1,4 @@
-package provider
+package activeactive_test
 
 import (
 	"context"
@@ -14,13 +14,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
+
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )
 
 // Checks CRUDI (CREATE, READ, UPDATE, IMPORT) operations on the database resource.
 func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
-	subscriptionName := testRandomWithPrefix() + "-subscription"
-	databaseName := testRandomWithPrefix() + "-database"
+	subscriptionName := utils.RandomWithPrefix() + "-subscription"
+	databaseName := utils.RandomWithPrefix() + "-database"
 	databaseNameUpdated := databaseName + "-updated"
 	password := acctest.RandString(20)
 
@@ -32,21 +34,24 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 	var subId, dbId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
+		PreCheck:                 func() { testhelpers.BasicPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Test database creation
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/database_crudi_create.tf"),
+				ConfigFile: config.StaticFile("./testdata/database_crudi_create.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseName),
 					"password":          config.StringVariable(password),
+					"redis_version":     config.StringVariable("8.2"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Test resource attributes
 					resource.TestCheckResourceAttr(databaseResourceName, "name", databaseName),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version_actual", "8.2"),
 					resource.TestCheckResourceAttr(databaseResourceName, "dataset_size_in_gb", "1"),
 					resource.TestCheckResourceAttr(databaseResourceName, "support_oss_cluster_api", "false"),
 					resource.TestCheckResourceAttr(databaseResourceName, "global_data_persistence", "none"),
@@ -98,7 +103,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 							return fmt.Errorf("couldn't parse database ID: %s", dbResource.Primary.Attributes["db_id"])
 						}
 
-						apiClient := sharedTestClient(t)
+						apiClient := utils.SharedTestClient(t)
 
 						// Verify subscription
 						sub, err := apiClient.Client.Subscription.Get(context.TODO(), subId)
@@ -128,6 +133,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "subscription_id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "db_id"),
 					resource.TestCheckResourceAttr(datasourceName, "name", databaseName),
+					resource.TestCheckResourceAttr(datasourceName, "redis_version", "8.2"),
 					resource.TestCheckResourceAttr(datasourceName, "dataset_size_in_gb", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "support_oss_cluster_api", "false"),
 					resource.TestCheckResourceAttr(datasourceName, "external_endpoint_for_oss_cluster_api", "false"),
@@ -149,13 +155,16 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 			},
 			// Test database update: change global and local alerts, enable OSS cluster API, update DB name
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/database_crudi_update.tf"),
+				ConfigFile: config.StaticFile("./testdata/database_crudi_update.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseNameUpdated),
+					"redis_version":     config.StringVariable("8.4"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(databaseResourceName, "name", databaseNameUpdated),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version_actual", "8.4"),
 					resource.TestCheckResourceAttr(databaseResourceName, "dataset_size_in_gb", "1"),
 					resource.TestCheckResourceAttr(databaseResourceName, "support_oss_cluster_api", "true"),
 					resource.TestCheckResourceAttr(databaseResourceName, "external_endpoint_for_oss_cluster_api", "true"),
@@ -165,7 +174,6 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(databaseResourceName, "global_alert.0.name", "dataset-size"),
 					resource.TestCheckResourceAttr(databaseResourceName, "global_alert.0.value", "60"),
 					resource.TestCheckResourceAttr(databaseResourceName, "global_enable_default_user", "false"),
-					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.2"),
 					resource.TestCheckResourceAttr(databaseResourceName, "global_modules.#", "0"),
 
 					resource.TestCheckResourceAttr(databaseResourceName, "override_region.#", "1"),
@@ -179,7 +187,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 
 					// API check: verify updates applied
 					func(s *terraform.State) error {
-						apiClient := sharedTestClient(t)
+						apiClient := utils.SharedTestClient(t)
 						db, err := apiClient.Client.Database.GetActiveActive(context.TODO(), subId, dbId)
 						if err != nil {
 							return fmt.Errorf("failed to get database: %w", err)
@@ -195,18 +203,75 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 
 					// Test data source reflects updates
 					resource.TestCheckResourceAttr(datasourceName, "name", databaseNameUpdated),
+					resource.TestCheckResourceAttr(datasourceName, "redis_version", "8.4"),
 					resource.TestCheckResourceAttr(datasourceName, "dataset_size_in_gb", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "support_oss_cluster_api", "true"),
-					resource.TestCheckResourceAttr(datasourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(datasourceName, "external_endpoint_for_oss_cluster_api", "true"),
+				),
+			},
+			// Simulate auto_minor_version_upgrade having gone through
+			{
+				ConfigFile: config.StaticFile("./testdata/database_crudi_update.tf"),
+				ConfigVariables: config.Variables{
+					"subscription_name": config.StringVariable(subscriptionName),
+					"database_name":     config.StringVariable(databaseNameUpdated),
+					"redis_version":     config.StringVariable("8.2"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(databaseResourceName, "name", databaseNameUpdated),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version_actual", "8.4"),
+					resource.TestCheckResourceAttr(databaseResourceName, "dataset_size_in_gb", "1"),
+					resource.TestCheckResourceAttr(databaseResourceName, "support_oss_cluster_api", "true"),
+					resource.TestCheckResourceAttr(databaseResourceName, "external_endpoint_for_oss_cluster_api", "true"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_data_persistence", "aof-every-1-second"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_password", "updated-password"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_alert.#", "1"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_alert.0.name", "dataset-size"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_alert.0.value", "60"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_enable_default_user", "false"),
+					resource.TestCheckResourceAttr(databaseResourceName, "global_modules.#", "0"),
+
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.#", "1"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.name", "us-east-1"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_data_persistence", "none"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_password", "password-updated"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_alert.#", "1"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_alert.0.name", "dataset-size"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_alert.0.value", "41"),
+					resource.TestCheckResourceAttr(databaseResourceName, "override_region.0.override_global_source_ips.#", "0"),
+
+					// API check: verify updates applied
+					func(s *terraform.State) error {
+						apiClient := utils.SharedTestClient(t)
+						db, err := apiClient.Client.Database.GetActiveActive(context.TODO(), subId, dbId)
+						if err != nil {
+							return fmt.Errorf("failed to get database: %w", err)
+						}
+						if redis.StringValue(db.GlobalDataPersistence) != "aof-every-1-second" {
+							return fmt.Errorf("expected global_data_persistence %q, got %q", "aof-every-1-second", redis.StringValue(db.GlobalDataPersistence))
+						}
+						if redis.BoolValue(db.SupportOSSClusterAPI) != true {
+							return fmt.Errorf("expected support_oss_cluster_api true, got false")
+						}
+						return nil
+					},
+
+					// Test data source reflects updates
+					resource.TestCheckResourceAttr(datasourceName, "name", databaseNameUpdated),
+					resource.TestCheckResourceAttr(datasourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(datasourceName, "dataset_size_in_gb", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "support_oss_cluster_api", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "external_endpoint_for_oss_cluster_api", "true"),
 				),
 			},
 			// Test database update: remove alerts, restore default user
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/database_crudi_update_no_alerts.tf"),
+				ConfigFile: config.StaticFile("./testdata/database_crudi_update_no_alerts.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseNameUpdated),
+					"redis_version":     config.StringVariable("8.2"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(databaseResourceName, "dataset_size_in_gb", "1"),
@@ -228,7 +293,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 			},
 			// Test import
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/database_crudi_import.tf"),
+				ConfigFile: config.StaticFile("./testdata/database_crudi_import.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseNameUpdated),
@@ -237,6 +302,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"redis_version",
 					"global_password",
 					"global_source_ips.#",
 					"global_source_ips.0",
@@ -251,6 +317,15 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 					"override_region.0.override_global_password",
 					"override_region.0.enable_default_user",
 				},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+					if got := states[0].Attributes["redis_version"]; got != "8.4" {
+						return fmt.Errorf("expected imported redis_version %q, got %q", "8.4", got)
+					}
+					return nil
+				},
 			},
 		},
 	})
@@ -261,16 +336,16 @@ func TestAccResourceRedisCloudActiveActiveDatabase_optionalAttributes(t *testing
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
-	subscriptionName := testRandomWithPrefix() + "-subscription"
-	name := testRandomWithPrefix() + "-database"
+	subscriptionName := utils.RandomWithPrefix() + "-subscription"
+	name := utils.RandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_active_active_subscription_database.example"
 	portNumber := 10101
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
+		PreCheck:                 func() { testhelpers.BasicPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceRedisCloudActiveActiveDatabaseOptionalAttributes, subscriptionName, name, password, portNumber),
@@ -287,14 +362,14 @@ func TestAccResourceRedisCloudActiveActiveDatabase_timeUtcRequiresValidInterval(
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	name := testRandomWithPrefix()
+	name := utils.RandomWithPrefix()
 	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
+		PreCheck:                 func() { testhelpers.BasicPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      fmt.Sprintf(testAccResourceRedisCloudActiveActiveDatabaseInvalidTimeUtc, testCloudAccountName, name, password),
@@ -438,18 +513,18 @@ func TestAccResourceRedisCloudActiveActiveDatabase_autoMinorVersionUpgrade(t *te
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	subscriptionName := testRandomWithPrefix() + "-subscription"
-	databaseName := testRandomWithPrefix() + "-database"
+	subscriptionName := utils.RandomWithPrefix() + "-subscription"
+	databaseName := utils.RandomWithPrefix() + "-database"
 	const resourceName = "rediscloud_active_active_subscription_database.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
+		PreCheck:                 func() { testhelpers.BasicPreCheck(t) },
+		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Test database creation with auto_minor_version_upgrade set to false
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/auto_minor_version_upgrade.tf"), ConfigVariables: config.Variables{
+				ConfigFile: config.StaticFile("./testdata/auto_minor_version_upgrade.tf"), ConfigVariables: config.Variables{
 					"subscription_name":          config.StringVariable(subscriptionName),
 					"database_name":              config.StringVariable(databaseName),
 					"auto_minor_version_upgrade": config.BoolVariable(false),
@@ -461,7 +536,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_autoMinorVersionUpgrade(t *te
 			},
 			// Test database update with auto_minor_version_upgrade set to true
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/auto_minor_version_upgrade.tf"),
+				ConfigFile: config.StaticFile("./testdata/auto_minor_version_upgrade.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name":          config.StringVariable(subscriptionName),
 					"database_name":              config.StringVariable(databaseName),
@@ -476,18 +551,18 @@ func TestAccResourceRedisCloudActiveActiveDatabase_autoMinorVersionUpgrade(t *te
 }
 
 func TestAccResourceRedisCloudActiveActiveDatabase_modulesImmutable(t *testing.T) {
-	subscriptionName := testRandomWithPrefix() + "-modules-immutable"
-	databaseName := testRandomWithPrefix() + "-database"
+	subscriptionName := utils.RandomWithPrefix() + "-modules-immutable"
+	databaseName := utils.RandomWithPrefix() + "-database"
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
-		ProtoV5ProviderFactories: protoV5ProviderFactories,
-		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
+		PreCheck:                 func() { testhelpers.BasicPreCheck(t); testAccAwsPreExistingCloudAccountPreCheck(t) },
+		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: Create database with RedisJSON module
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/modules_immutable_create.tf"),
+				ConfigFile: config.StaticFile("./testdata/modules_immutable_create.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseName),
@@ -500,7 +575,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_modulesImmutable(t *testing.T
 			},
 			// Step 2: Try to change modules - changes should be silently ignored
 			{
-				ConfigFile: config.StaticFile("./activeactive/testdata/modules_immutable_change.tf"),
+				ConfigFile: config.StaticFile("./testdata/modules_immutable_change.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(subscriptionName),
 					"database_name":     config.StringVariable(databaseName),

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -227,6 +227,9 @@ func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ resource.Sche
 				Optional:    true,
 				//TODO(TF3.0) drop Computed and stop writing redis_version from Read — makes the field write-only-by-convention (no plugin-framework migration), so state only ever holds what the user wrote in config and auto-upgrades can't drift state. DSF stays to heal state poisoned by older provider versions.
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"redis_version_actual": schema.StringAttribute{
 				Description: "The actual Redis database version",

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -223,13 +223,14 @@ func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ resource.Sche
 				},
 			},
 			"redis_version": schema.StringAttribute{
-				Description: "Defines the Redis database version. If omitted, the Redis version will be set to the default version",
+				Description: "Defines the requested Redis database version. If omitted, the Redis version will be set to the default version. Use `redis_version_actual` to get the version on which the database is running.",
 				Optional:    true,
+				//TODO(TF3.0) drop Computed and stop writing redis_version from Read — makes the field write-only-by-convention (no plugin-framework migration), so state only ever holds what the user wrote in config and auto-upgrades can't drift state. DSF stays to heal state poisoned by older provider versions.
+				Computed: true,
+			},
+			"redis_version_actual": schema.StringAttribute{
+				Description: "The actual Redis database version",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"support_oss_cluster_api": schema.BoolAttribute{
 				Description: "Support Redis open-source (OSS) Cluster API",

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -199,7 +199,10 @@ func (r *activeActiveDatabaseResource) readDatabase(ctx context.Context, state *
 	state.DataEviction = types.StringValue(redis.StringValue(db.DataEvictionPolicy))
 	state.SupportOssClusterAPI = types.BoolValue(redis.BoolValue(db.SupportOSSClusterAPI))
 	state.ExternalEndpointForOssClusterAPI = types.BoolValue(redis.BoolValue(db.UseExternalEndpointForOSSClusterAPI))
-	state.RedisVersion = types.StringValue(redis.StringValue(db.RedisVersion))
+	if state.RedisVersion.IsNull() || state.RedisVersion.ValueString() == "" {
+		state.RedisVersion = types.StringPointerValue(db.RedisVersion)
+	}
+	state.RedisVersionActual = types.StringPointerValue(db.RedisVersion)
 
 	// Set global_data_persistence - Optional+Computed, always from API
 	utils.SetStringFromAPI(&state.GlobalDataPersistence, db.GlobalDataPersistence)
@@ -371,6 +374,27 @@ func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan 
 	// Acquire subscription mutex
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
+
+	// Update database version first if changed
+	if !plan.RedisVersion.IsNull() && state != nil && !state.RedisVersion.IsNull() && plan.RedisVersion.ValueString() != state.RedisVersion.ValueString() {
+		upgradeVersionRequest := databases.UpgradeRedisVersion{TargetRedisVersion: plan.RedisVersion.ValueStringPointer()}
+		if err := r.client.Client.Database.UpgradeRedisVersion(ctx, subId, dbId, upgradeVersionRequest); err != nil {
+			diagnostics.AddError("Failed to upgrade database version", err.Error())
+			return
+		}
+
+		// Wait for database to be active
+		if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client); err != nil {
+			diagnostics.AddError("Database failed to become active after update", err.Error())
+			return
+		}
+
+		// Wait for subscription to be active
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+			diagnostics.AddError("Subscription failed to become active after update", err.Error())
+			return
+		}
+	}
 
 	// Build alerts from plan
 	alerts, diags := buildAlertsFromSet(ctx, plan.GlobalAlert)

--- a/provider/activeactive/resource_active_active_database_model.go
+++ b/provider/activeactive/resource_active_active_database_model.go
@@ -13,6 +13,7 @@ type ActiveActiveDatabaseModel struct {
 	MemoryLimitInGB                  types.Float64 `tfsdk:"memory_limit_in_gb"`
 	DatasetSizeInGB                  types.Float64 `tfsdk:"dataset_size_in_gb"`
 	RedisVersion                     types.String  `tfsdk:"redis_version"`
+	RedisVersionActual               types.String  `tfsdk:"redis_version_actual"`
 	SupportOssClusterAPI             types.Bool    `tfsdk:"support_oss_cluster_api"`
 	ExternalEndpointForOssClusterAPI types.Bool    `tfsdk:"external_endpoint_for_oss_cluster_api"`
 	EnableTLS                        types.Bool    `tfsdk:"enable_tls"`

--- a/provider/activeactive/testdata/database_crudi_create.tf
+++ b/provider/activeactive/testdata/database_crudi_create.tf
@@ -11,6 +11,10 @@ variable "password" {
   sensitive = true
 }
 
+variable "redis_version" {
+  type = string
+}
+
 data "rediscloud_payment_method" "card" {
   card_type         = "Visa"
   last_four_numbers = "5556"
@@ -46,7 +50,7 @@ resource "rediscloud_active_active_subscription_database" "example" {
   support_oss_cluster_api               = false
   external_endpoint_for_oss_cluster_api = false
   enable_tls                            = false
-  redis_version                         = "8.2"
+  redis_version                         = var.redis_version
 
   global_data_persistence    = "none"
   global_password            = var.password

--- a/provider/activeactive/testdata/database_crudi_import.tf
+++ b/provider/activeactive/testdata/database_crudi_import.tf
@@ -38,5 +38,4 @@ resource "rediscloud_active_active_subscription_database" "example" {
   subscription_id    = rediscloud_active_active_subscription.example.id
   name               = var.database_name
   dataset_size_in_gb = 1
-  redis_version      = "8.2"
 }

--- a/provider/activeactive/testdata/database_crudi_update.tf
+++ b/provider/activeactive/testdata/database_crudi_update.tf
@@ -6,6 +6,9 @@ variable "database_name" {
   type = string
 }
 
+variable "redis_version" {
+  type = string
+}
 
 data "rediscloud_payment_method" "card" {
   card_type         = "Visa"
@@ -41,7 +44,7 @@ resource "rediscloud_active_active_subscription_database" "example" {
   dataset_size_in_gb                    = 1
   support_oss_cluster_api               = true
   external_endpoint_for_oss_cluster_api = true
-  redis_version                         = "8.2"
+  redis_version                         = var.redis_version
 
   global_data_persistence    = "aof-every-1-second"
   global_password            = "updated-password"

--- a/provider/activeactive/testdata/database_crudi_update_no_alerts.tf
+++ b/provider/activeactive/testdata/database_crudi_update_no_alerts.tf
@@ -6,6 +6,10 @@ variable "database_name" {
   type = string
 }
 
+variable "redis_version" {
+  type = string
+}
+
 data "rediscloud_payment_method" "card" {
   card_type         = "Visa"
   last_four_numbers = "5556"
@@ -40,7 +44,7 @@ resource "rediscloud_active_active_subscription_database" "example" {
   dataset_size_in_gb                    = 1
   support_oss_cluster_api               = true
   external_endpoint_for_oss_cluster_api = true
-  redis_version                         = "8.2"
+  redis_version                         = var.redis_version
 
   global_data_persistence = "aof-every-1-second"
   global_password         = "updated-password"

--- a/provider/rediscloud_private_service_connect_test.go
+++ b/provider/rediscloud_private_service_connect_test.go
@@ -13,7 +13,8 @@ func TestAccResourceRedisCloudPrivateServiceConnect_CRUDI(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	baseName := testRandomWithPrefix() + "-pro-psc"
+	subName := testRandomWithPrefix() + "-pro-psc"
+	databaseName := subName + "-database"
 
 	const resourceName = "rediscloud_private_service_connect.psc"
 	const datasourceName = "data.rediscloud_private_service_connect.psc"
@@ -24,7 +25,7 @@ func TestAccResourceRedisCloudPrivateServiceConnect_CRUDI(t *testing.T) {
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudPrivateServiceConnectProStep1, baseName),
+				Config: fmt.Sprintf(testAccResourceRedisCloudPrivateServiceConnectProStep1, subName, databaseName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
@@ -32,7 +33,7 @@ func TestAccResourceRedisCloudPrivateServiceConnect_CRUDI(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudPrivateServiceConnectProStep2, baseName),
+				Config: fmt.Sprintf(testAccResourceRedisCloudPrivateServiceConnectProStep2, subName, databaseName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "subscription_id"),
@@ -78,8 +79,18 @@ resource "rediscloud_subscription" "subscription_resource" {
   }
 }
 
+resource "rediscloud_subscription_database" "database_resource" {
+  name                         = "%s"
+  subscription_id              = rediscloud_subscription.subscription_resource.id
+  dataset_size_in_gb           = 1
+  replication                  = true
+  throughput_measurement_by    = "operations-per-second"
+  throughput_measurement_value = 20000
+}
+
 resource "rediscloud_private_service_connect" "psc" {
   subscription_id = rediscloud_subscription.subscription_resource.id
+  depends_on = [rediscloud_subscription_database.database_resource]
 }
 `
 

--- a/provider/utils/test_utils.go
+++ b/provider/utils/test_utils.go
@@ -27,6 +27,16 @@ func GetTestClient() (*client.ApiClient, error) {
 	return sharedTestClient, sharedTestClientErr
 }
 
+func SharedTestClient(t *testing.T) *client.ApiClient {
+	sharedTestClientOnce.Do(func() {
+		sharedTestClient, sharedTestClientErr = client.NewClient()
+	})
+	if sharedTestClientErr != nil {
+		t.Fatalf("Failed to create test API client: %s", sharedTestClientErr)
+	}
+	return sharedTestClient
+}
+
 // CheckNoDatabasesForSubscription verifies that no databases exist in a subscription.
 // Combines GetTestClient with CheckNoDatabasesInSubscription for convenience in test check functions.
 func CheckNoDatabasesForSubscription(ctx context.Context, subId int) error {


### PR DESCRIPTION
## Added
- Ability to upgrade `redis_version` in `rediscloud_active_active_subscription_database` resource without recreating the resource.
- Exposed `redis_version_actual` attribute on the `rediscloud_active_active_subscription_database` resource.