### PR TITLE
RED-202463: Enable proper logging from framework provider config

### DIFF
--- a/provider/framework_provider.go
+++ b/provider/framework_provider.go
@@ -138,7 +138,7 @@ func (p *redisCloudFrameworkProvider) Configure(ctx context.Context, req provide
 
 	// Enable request logging in debug mode
 	clientConfig = append(clientConfig, rediscloudApi.LogRequests(true))
-	clientConfig = append(clientConfig, rediscloudApi.Logger(&frameworkDebugLogger{}))
+	clientConfig = append(clientConfig, rediscloudApi.Logger(&frameworkDebugLogger{ctx: ctx}))
 
 	// Create the API client
 	apiClient, err := rediscloudApi.NewClient(clientConfig...)
@@ -185,12 +185,14 @@ func (p *redisCloudFrameworkProvider) DataSources(_ context.Context) []func() da
 }
 
 // frameworkDebugLogger implements the rediscloud-go-api Logger interface for Plugin Framework.
-type frameworkDebugLogger struct{}
+type frameworkDebugLogger struct {
+	ctx context.Context
+}
 
 func (l *frameworkDebugLogger) Printf(format string, v ...interface{}) {
-	tflog.Debug(context.Background(), fmt.Sprintf("[rediscloud-go-api] "+format, v...))
+	tflog.Debug(l.ctx, fmt.Sprintf("[rediscloud-go-api] "+format, v...))
 }
 
 func (l *frameworkDebugLogger) Println(v ...interface{}) {
-	tflog.Debug(context.Background(), fmt.Sprintf("[rediscloud-go-api] %v", v))
+	tflog.Debug(l.ctx, fmt.Sprintf("[rediscloud-go-api] %v", v))
 }


### PR DESCRIPTION
All logs coming from Plugin Framework migrated data sources and resources, are not actually logged, due to the wrong context being provided to the logging functions