### PR TITLE
tests: Remove redundant "short" flag for skipped test

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-test.short -run="TestAcc(DataSource|Resource)RedisCloud(CloudAccount).*"'
+      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(CloudAccount).*"'
 
   go_test_transit_payment:
     name: go test Transit Gateway & Payment

--- a/provider/resource_rediscloud_cloud_account_test.go
+++ b/provider/resource_rediscloud_cloud_account_test.go
@@ -19,9 +19,7 @@ func TestAccResourceRedisCloudCloudAccount_basic(t *testing.T) {
 
 	utils.AccRequiresEnvVar(t, "EXECUTE_TESTS")
 
-	if testing.Short() {
-		t.Skip("Required environment variables currently not available under CI")
-	}
+	t.Skip("Required environment variables currently not available under CI")
 
 	name := testRandomWithPrefix()
 


### PR DESCRIPTION
Always skip the tests with the missing env vars. The potential downside is when this is run locally it will get skipped. This is a pre-requisite to use the `run-testacc` GitHub action, no need to add a meaningless flag to the action itself.

Either way, it's not obvious at all this would happen. Also, seemingly all the required env vars should be available to the GitHub workflow.

We will go through all skipped tests at a later point.