### PR TITLE
tests: Use "run-testacc" GitHub action for the "main" workflow

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -125,7 +125,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Database_.*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Database_.*
 
   go_test_subscriptions:
     name: go test Subscriptions
@@ -136,7 +138,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Subscription_.*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Subscription_.*
 
   go_test_subscriptions_tls:
     name: go test Subscriptions TLS
@@ -147,7 +151,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloudSubscriptionTls_.*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloudSubscriptionTls_.*
 
   go_test_essentials_plan:
     name: go test Essentials Plan
@@ -158,7 +164,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloudEssentialsPlan_.*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloudEssentialsPlan_.*
 
   go_test_persistence_modules_regions_acl:
     name: go test Other
@@ -169,7 +177,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(DataPersistence|DatabaseModules|Regions|Acl).*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloud(DataPersistence|DatabaseModules|Regions|Acl).*
 
   go_test_cloud_account:
     name: go test Cloud Account
@@ -180,7 +190,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(CloudAccount).*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloud(CloudAccount).*
 
   go_test_transit_payment:
     name: go test Transit Gateway & Payment
@@ -191,7 +203,9 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: EXECUTE_TESTS=true make testacc TESTARGS='-run="TestAcc(DataSource|Resource)RedisCloud(TransitGatewayAttachment|PaymentMethod).*"'
+      - uses: ./.github/actions/run-testacc
+        with:
+          test_pattern: TestAcc(DataSource|Resource)RedisCloud(TransitGatewayAttachment|PaymentMethod).*
 
   go_unit_test:
     name: go unit test


### PR DESCRIPTION
Remove direct `make testacc` usage from GitHub. This aligns the usage of the `pr.yml` workflow as well.

This consolidation lays the foundation to move the checkout + setup steps in the action itself. At a later point, the credentials issuing will be moved there as well.