### PR TITLE
ci: Use "@dorny/paths-filter" GitHub action to detect changed files

### DIFF
--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -41,26 +41,18 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - name: Check for code changes
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
-        run: |
-          set -euo pipefail
-          BASE="origin/${{ github.base_ref }}"
-          if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
-            echo "::error::Could not resolve $BASE - defaulting to code=true"
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          CHANGED=$(git diff --name-only "$BASE...HEAD")
-          if echo "$CHANGED" | \
-             grep -qE '\.go$|^go\.(mod|sum)$|^GNUmakefile$|provider/.*/testdata/|^\.github/|^scripts/'; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "code=false" >> "$GITHUB_OUTPUT"
-          fi
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'GNUmakefile'
+              - 'provider/**/testdata/**'
+              - '.github/**'
+              - 'scripts/**'
 
   golangci-lint:
     name: golangci-lint


### PR DESCRIPTION
No need to checkout the repo to check what's been changed in a PR. The action uses the GitHub API to fetch the list of changed files.

Also, it removes all the shell logic for this detection.