### PR TITLE
ci: Use "-diff" flag to report go mod drift

### DIFF
--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -73,20 +73,14 @@ jobs:
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
 
   go-mod-tidy:
-    name: go mod tidy
+    name: go mod tidy -diff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - run: go mod tidy
-      - name: Check for changes
-        run: |
-          if ! git diff --exit-code go.mod go.sum; then
-            echo "::error::go.mod or go.sum is not tidy. Run 'go mod tidy' and commit the changes."
-            exit 1
-          fi
+      - run: go mod tidy -diff
 
   terraform-fmt:
     name: terraform fmt


### PR DESCRIPTION
From the `go help mod tidy`:

```
...

The -diff flag causes tidy not to modify go.mod or go.sum but
instead print the necessary changes as a unified diff. It exits
with a non-zero code if the diff is not empty.

...
```