### PR TITLE
ci: Run extend Terraform provider linter

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,8 +80,7 @@ endif
 	@echo "WARNING: This will destroy infrastructure matching prefix '$(TEST_RESOURCE_PREFIX)'. Use only in development accounts."
 	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) SWEEP_AGE_THRESHOLD=0s go test ./provider -v -sweep=ALL $(SWEEPARGS) -timeout 30m
 
-tfproviderlintx: $(BIN)/tfproviderlintx
-	$(BIN)/tfproviderlintx $(TFPROVIDERLINT_ARGS) ./...
-
-tfproviderlint: $(BIN)/tfproviderlint
-	$(BIN)/tfproviderlint $(TFPROVIDERLINT_ARGS) ./...
+tfproviderlint: $(BIN)/tfproviderlintx
+  # XS001 — disables "schema should configure Description"
+  # XS002 — disables "schema attributes should be in alphabetical order"
+	$(BIN)/tfproviderlintx $(TFPROVIDERLINT_ARGS) -XS001=false -XS002=false ./...


### PR DESCRIPTION
`tfproviderlintx` includes everything from the `tfproviderlint` and add some more checks.

2 reported errors are suppressed as this would require changes in a lot of our resource definitions.

NOTE: Unfortunately, the linter itself is not actively maintained and doesn't work properly with acceptance tests now that `terraform-plugin-framework` is used.