### PR TITLE
security: Bump gotoolchain to v1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 
 go 1.25.8
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.52.1


### PR DESCRIPTION
Addresses issues from `govulncheck`.

```
=== Symbol Results ===

Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
    Example traces found:
Error:       #1: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls tls.Conn.Handshake
Error:       #2: provider/cloudaccount/datasource_cloud_account_read.go:32:57: cloudaccount.cloudAccountDataSource.Read calls cloud_accounts.API.List, which eventually calls tls.Conn.HandshakeContext
Error:       #3: provider/utils/test_utils.go:31:25: utils.SharedTestClient calls sync.Once.Do, which eventually calls tls.Conn.Read
Error:       #4: main.go:42:23: terraform.main calls tf5server.Serve, which eventually calls tls.Conn.Write
Error:       #5: provider/cloudaccount/datasource_cloud_account_read.go:32:57: cloudaccount.cloudAccountDataSource.Read calls cloud_accounts.API.List, which eventually calls tls.Dialer.DialContext
```