### PR TITLE
chore: bump Go toolchain to go1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 
 go 1.25.8
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.50.0


### PR DESCRIPTION
Based on [failing CI vulncheck step](https://github.com/RedisLabs/terraform-provider-rediscloud/actions/runs/29087505901/job/86344627124?pr=884)

Fixes GO-2026-5856 (Encrypted Client Hello privacy leak in crypto/tls), a Go standard-library vulnerability present in go1.26.4 and fixed in go1.26.5. govulncheck flags it as called (exit 3) on any TLS path, so CI fails on every branch until the toolchain is bumped.