### PR TITLE
RED-208028: Test: ValueAndCheck functions

### DIFF
--- a/provider/activeactive/active_active_database_passwordless_test.go
+++ b/provider/activeactive/active_active_database_passwordless_test.go
@@ -23,7 +23,7 @@ func TestAccActiveActiveDatabase_Passwordless(t *testing.T) {
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -78,7 +78,7 @@ func TestAccActiveActiveDatabase_PasswordlessWithPasswordConflict(t *testing.T) 
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -104,7 +104,7 @@ func TestAccActiveActiveDatabase_PasswordlessRegionOverride(t *testing.T) {
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -140,7 +140,7 @@ func TestAccActiveActiveDatabase_PasswordlessDisableWithoutPassword(t *testing.T
 	subscriptionName := testRandomWithPrefix()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -175,7 +175,7 @@ func TestAccActiveActiveDatabase_PasswordlessRegionOverrideWithPasswordConflict(
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/activeactive/rediscloud_active_active_database_test.go
+++ b/provider/activeactive/rediscloud_active_active_database_test.go
@@ -3,7 +3,6 @@ package activeactive_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -36,7 +35,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 	var subId, dbId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -399,7 +398,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_optionalAttributes(t *testing
 	portNumber := 10101
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -417,16 +416,16 @@ func TestAccResourceRedisCloudActiveActiveDatabase_optionalAttributes(t *testing
 func TestAccResourceRedisCloudActiveActiveDatabase_timeUtcRequiresValidInterval(t *testing.T) {
 
 	name := utils.RandomWithPrefix()
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudActiveActiveDatabaseInvalidTimeUtc, testCloudAccountName, name, password),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudActiveActiveDatabaseInvalidTimeUtc, cloudAccountName, name, password),
 				ExpectError: regexp.MustCompile(`(?s)'time_utc' can only be set when 'interval' is 'every-12-hours' or\s+'every-24-hours'`),
 			},
 		},
@@ -608,7 +607,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_modulesImmutable(t *testing.T
 	password := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkAASubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/cloudaccount/datasource_cloud_account_test.go
+++ b/provider/cloudaccount/datasource_cloud_account_test.go
@@ -1,7 +1,6 @@
 package cloudaccount_test
 
 import (
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,24 +14,24 @@ import (
 
 func TestAccDataSourceRedisCloudCloudAccount_basic(t *testing.T) {
 
-	name := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	const testCloudAccount = "data.rediscloud_cloud_account.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             nil, // test doesn't create a resource at the moment, so don't need to check anything
 		Steps: []resource.TestStep{
 			{
 				ConfigFile: config.StaticFile("./testdata/datasource_basic.tf"),
 				ConfigVariables: config.Variables{
-					"name": config.StringVariable(name),
+					"name": config.StringVariable(cloudAccountName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(testCloudAccount, "id", regexp.MustCompile("^\\d*$")),
 					resource.TestCheckResourceAttr(testCloudAccount, "provider_type", "AWS"),
-					resource.TestCheckResourceAttr(testCloudAccount, "name", name),
+					resource.TestCheckResourceAttr(testCloudAccount, "name", cloudAccountName),
 					resource.TestCheckResourceAttrSet(testCloudAccount, "access_key_id"),
 				),
 			},

--- a/provider/datasource_rediscloud_pro_database_test.go
+++ b/provider/datasource_rediscloud_pro_database_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -20,14 +19,14 @@ func TestAccDataSourceRedisCloudProDatabase_basic(t *testing.T) {
 	const dataSourceByName = "data.rediscloud_database.example-by-name"
 	password := acctest.RandString(20)
 
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	subscriptionName := testRandomWithPrefix()
 
 	content := utils.GetTestConfig(t, "./pro/testdata/pro_database_data_source.tf")
-	config := fmt.Sprintf(content, testCloudAccountName, subscriptionName, password)
+	config := fmt.Sprintf(content, cloudAccountName, subscriptionName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/datasource_rediscloud_pro_subscription_test.go
+++ b/provider/datasource_rediscloud_pro_subscription_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -26,16 +25,16 @@ func TestAccDataSourceRedisCloudProSubscription_basic(t *testing.T) {
 
 	const resourceName = "rediscloud_subscription.example"
 	const dataSourceName = "data.rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	proSubConfig := utils.GetTestConfig(t, proSubscriptionConfigPath)
-	proSubConfig = fmt.Sprintf(proSubConfig, testCloudAccountName, name)
+	proSubConfig = fmt.Sprintf(proSubConfig, cloudAccountName, name)
 
 	proSubDataConfig := utils.GetTestConfig(t, proSubscriptionDataSourceConfigPath)
 	proSubDataConfig = fmt.Sprintf(proSubDataConfig, name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +87,7 @@ func TestAccDataSourceRedisCloudProSubscription_ignoresAA(t *testing.T) {
 	config = fmt.Sprintf(config, name+"-subscription", name+"-database", password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/datasource_rediscloud_subscription_peerings_test.go
+++ b/provider/datasource_rediscloud_subscription_peerings_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -21,25 +20,22 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 	// Chose a CIDR range for the subscription that's unlikely to overlap with any VPC CIDR
 	const subCidrRange = "10.0.0.0/24"
 
-	awsAccountId := os.Getenv("AWS_ACCOUNT_ID")
-	awsVPCId := os.Getenv("AWS_VPC_ID")
-	awsVPCCidr := os.Getenv("AWS_VPC_CIDR")
-	awsRegion := os.Getenv("AWS_PEERING_REGION")
+	awsPeering, awsPeeringCheck := envchecks.AwsPeeringValueAndCheck(t)
 	tf := fmt.Sprintf(testAccDatasourceRedisCloudSubscriptionPeeringsDataSource,
 		cloudAccountName,
 		name,
 		subCidrRange,
-		awsRegion,
-		awsAccountId,
-		awsVPCId,
-		awsVPCCidr,
+		awsPeering.Region,
+		awsPeering.AccountId,
+		awsPeering.VpcId,
+		awsPeering.VpcCidr,
 	)
 	const dataSourceName = "data.rediscloud_subscription_peerings.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
-			envchecks.AwsPeeringCheck(t)
+			awsPeeringCheck()
 			cloudAccountCheck()
 		},
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
@@ -50,11 +46,11 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchTypeSetElemNestedAttrs(dataSourceName, "peerings.*", map[string]*regexp.Regexp{
 						"provider_name":  regexp.MustCompile("AWS"),
-						"aws_account_id": regexp.MustCompile(awsAccountId),
-						"vpc_id":         regexp.MustCompile(awsVPCId),
-						"vpc_cidr":       regexp.MustCompile(awsVPCCidr),
+						"aws_account_id": regexp.MustCompile(awsPeering.AccountId),
+						"vpc_id":         regexp.MustCompile(awsPeering.VpcId),
+						"vpc_cidr":       regexp.MustCompile(awsPeering.VpcCidr),
 						"aws_peering_id": regexp.MustCompile("^pcx-"),
-						"region":         regexp.MustCompile(awsRegion),
+						"region":         regexp.MustCompile(awsPeering.Region),
 					}),
 				),
 			},

--- a/provider/datasource_rediscloud_subscription_peerings_test.go
+++ b/provider/datasource_rediscloud_subscription_peerings_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 
 	name := testRandomWithPrefix()
 
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	// Chose a CIDR range for the subscription that's unlikely to overlap with any VPC CIDR
 	const subCidrRange = "10.0.0.0/24"
@@ -26,7 +26,7 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 	awsVPCCidr := os.Getenv("AWS_VPC_CIDR")
 	awsRegion := os.Getenv("AWS_PEERING_REGION")
 	tf := fmt.Sprintf(testAccDatasourceRedisCloudSubscriptionPeeringsDataSource,
-		testCloudAccountName,
+		cloudAccountName,
 		name,
 		subCidrRange,
 		awsRegion,
@@ -40,7 +40,7 @@ func TestAccDataSourceRedisCloudSubscriptionPeerings_basic(t *testing.T) {
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
 			envchecks.AwsPeeringCheck(t)
-			envchecks.AWSBYOCloudAccountCheck(t)
+			cloudAccountCheck()
 		},
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,

--- a/provider/envchecks/precheck.go
+++ b/provider/envchecks/precheck.go
@@ -37,11 +37,6 @@ func AWSProviderAndRegionCheck(t *testing.T) {
 	RequireEnvVars(t, "AWS_REGION")
 }
 
-func AWSBYOCloudAccountCheck(t *testing.T) {
-	t.Helper()
-	RequireEnvVars(t, "AWS_TEST_CLOUD_ACCOUNT_NAME")
-}
-
 func AwsPeeringCheck(t *testing.T) {
 	t.Helper()
 	RequireEnvVars(t, "AWS_PEERING_REGION", "AWS_ACCOUNT_ID", "AWS_VPC_ID", "AWS_VPC_CIDR")
@@ -56,4 +51,15 @@ func GCPProviderCheck(t *testing.T) {
 	t.Helper()
 	GCPProjectCheck(t)
 	RequireEnvVars(t, "GOOGLE_CREDENTIALS")
+}
+
+func ValueAndCheck(t *testing.T, key string) (string, func()) {
+	t.Helper()
+	value := os.Getenv(key)
+	return value, func() { RequireEnvVars(t, key) }
+}
+
+func AWSBYOCValueAndCheck(t *testing.T) (string, func()) {
+	t.Helper()
+	return ValueAndCheck(t, "AWS_TEST_CLOUD_ACCOUNT_NAME")
 }

--- a/provider/envchecks/precheck.go
+++ b/provider/envchecks/precheck.go
@@ -7,7 +7,7 @@ import (
 	rediscloudApi "github.com/RedisLabs/rediscloud-go-api"
 )
 
-// RequireEnvVars skips or fails the test if any of the named environment
+// RequireEnvVars fails the test if any of the named environment
 // variables are not set.
 func RequireEnvVars(t *testing.T, names ...string) {
 	t.Helper()
@@ -37,11 +37,6 @@ func AWSProviderAndRegionCheck(t *testing.T) {
 	RequireEnvVars(t, "AWS_REGION")
 }
 
-func AwsPeeringCheck(t *testing.T) {
-	t.Helper()
-	RequireEnvVars(t, "AWS_PEERING_REGION", "AWS_ACCOUNT_ID", "AWS_VPC_ID", "AWS_VPC_CIDR")
-}
-
 func GCPProviderCheck(t *testing.T) {
 	t.Helper()
 	RequireEnvVars(t, "GOOGLE_CREDENTIALS", "GCP_PROJECT_ID")
@@ -61,4 +56,20 @@ func AWSBYOCValueAndCheck(t *testing.T) (string, func()) {
 func GCPProjectValueAndCheck(t *testing.T) (string, func()) {
 	t.Helper()
 	return ValueAndCheck(t, "GCP_PROJECT_ID")
+}
+
+type AWSPeering struct {
+	Region    string
+	AccountId string
+	VpcId     string
+	VpcCidr   string
+}
+
+func AwsPeeringValueAndCheck(t *testing.T) (AWSPeering, func()) {
+	t.Helper()
+	region, regionCheck := ValueAndCheck(t, "AWS_PEERING_REGION")
+	accountId, accountIdCheck := ValueAndCheck(t, "AWS_ACCOUNT_ID")
+	vpcId, vpcIdCheck := ValueAndCheck(t, "AWS_VPC_ID")
+	vpcCidr, vpcCidrCheck := ValueAndCheck(t, "AWS_VPC_CIDR")
+	return AWSPeering{Region: region, AccountId: accountId, VpcId: vpcId, VpcCidr: vpcCidr}, func() { regionCheck(); accountIdCheck(); vpcIdCheck(); vpcCidrCheck() }
 }

--- a/provider/envchecks/precheck.go
+++ b/provider/envchecks/precheck.go
@@ -42,15 +42,9 @@ func AwsPeeringCheck(t *testing.T) {
 	RequireEnvVars(t, "AWS_PEERING_REGION", "AWS_ACCOUNT_ID", "AWS_VPC_ID", "AWS_VPC_CIDR")
 }
 
-func GCPProjectCheck(t *testing.T) {
-	t.Helper()
-	RequireEnvVars(t, "GCP_PROJECT_ID")
-}
-
 func GCPProviderCheck(t *testing.T) {
 	t.Helper()
-	GCPProjectCheck(t)
-	RequireEnvVars(t, "GOOGLE_CREDENTIALS")
+	RequireEnvVars(t, "GOOGLE_CREDENTIALS", "GCP_PROJECT_ID")
 }
 
 func ValueAndCheck(t *testing.T, key string) (string, func()) {
@@ -62,4 +56,9 @@ func ValueAndCheck(t *testing.T, key string) (string, func()) {
 func AWSBYOCValueAndCheck(t *testing.T) (string, func()) {
 	t.Helper()
 	return ValueAndCheck(t, "AWS_TEST_CLOUD_ACCOUNT_NAME")
+}
+
+func GCPProjectValueAndCheck(t *testing.T) (string, func()) {
+	t.Helper()
+	return ValueAndCheck(t, "GCP_PROJECT_ID")
 }

--- a/provider/pro/rediscloud_pro_subscription_cmk_test.go
+++ b/provider/pro/rediscloud_pro_subscription_cmk_test.go
@@ -21,9 +21,6 @@ import (
 // TestAccRedisCloudProSubscription_CMK is a fully automated CMK test that uses the GCP provider
 // to create KMS keys and grant IAM permissions automatically.
 func TestAccRedisCloudProSubscription_CMK(t *testing.T) {
-
-	envchecks.RequireEnvVars(t, "GCP_PROJECT_ID", "GOOGLE_CREDENTIALS")
-
 	name := utils.RandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	gcpProjectId := os.Getenv("GCP_PROJECT_ID")
@@ -45,7 +42,7 @@ func TestAccRedisCloudProSubscription_CMK(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:     func() { envchecks.RedisCloudCheck(t); envchecks.GCPProviderCheck(t) },
 		CheckDestroy: checkProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/provider/pro/rediscloud_pro_subscription_datasource_resource_tags_test.go
+++ b/provider/pro/rediscloud_pro_subscription_datasource_resource_tags_test.go
@@ -1,7 +1,6 @@
 package pro_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -17,20 +16,20 @@ import (
 // source's cloud_provider.0.resource_tags attribute. It requires a BYOC cloud
 // account because the API only accepts tags for BYOC subscriptions.
 func TestAccDataSourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
-	byocCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	name := acctest.RandomWithPrefix("tf-test") + "-ds-resource-tags"
 	const dataSourceName = "data.rediscloud_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				ConfigFile: config.StaticFile("testdata/pro_subscription_datasource_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags": config.MapVariable(map[string]config.Variable{
 						"environment": config.StringVariable("staging"),

--- a/provider/pro/rediscloud_pro_subscription_resource_tags_test.go
+++ b/provider/pro/rediscloud_pro_subscription_resource_tags_test.go
@@ -1,7 +1,6 @@
 package pro_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -15,13 +14,13 @@ import (
 
 func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 
-	byocCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	name := acctest.RandomWithPrefix("tf-test") + "-resource-tags"
 	const resourceName = "rediscloud_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             checkProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -29,7 +28,7 @@ func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 				// Step 1: Create with resource tags
 				ConfigFile: config.StaticFile("testdata/pro_subscription_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags": config.MapVariable(map[string]config.Variable{
 						"environment": config.StringVariable("staging"),
@@ -46,7 +45,7 @@ func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 				// Step 2: Update tags (change value, add key)
 				ConfigFile: config.StaticFile("testdata/pro_subscription_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags": config.MapVariable(map[string]config.Variable{
 						"environment": config.StringVariable("production"),
@@ -70,7 +69,7 @@ func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 				// Step 4: Remove all tags
 				ConfigFile: config.StaticFile("testdata/pro_subscription_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags":      config.MapVariable(map[string]config.Variable{}),
 				},
@@ -83,7 +82,7 @@ func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 				// Re-apply tags first so there's something to verify.
 				ConfigFile: config.StaticFile("testdata/pro_subscription_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags": config.MapVariable(map[string]config.Variable{
 						"environment": config.StringVariable("staging"),
@@ -93,7 +92,7 @@ func TestAccResourceRedisCloudProSubscription_ResourceTags(t *testing.T) {
 			{
 				ConfigFile: config.StaticFile("testdata/pro_subscription_resource_tags.tf"),
 				ConfigVariables: config.Variables{
-					"cloud_account_name": config.StringVariable(byocCloudAccountName),
+					"cloud_account_name": config.StringVariable(cloudAccountName),
 					"subscription_name":  config.StringVariable(name),
 					"resource_tags": config.MapVariable(map[string]config.Variable{
 						"environment": config.StringVariable("staging"),

--- a/provider/rediscloud_acl_role_test.go
+++ b/provider/rediscloud_acl_role_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -21,7 +20,7 @@ import (
 func TestAccResourceRedisCloudAclRole_CRUDI(t *testing.T) {
 
 	prefix := testRandomWithPrefix()
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	exampleSubscriptionName := prefix + "-subscription"
 	exampleDatabasePassword := prefix + "aA.1"
 	exampleRuleName := prefix + "-rule"
@@ -30,7 +29,7 @@ func TestAccResourceRedisCloudAclRole_CRUDI(t *testing.T) {
 	testRoleNameUpdated := testRoleName + "-updated"
 
 	proSubBoilerPlate := utils.GetTestConfig(t, "./pro/testdata/pro_subscription_boilerplate.tf")
-	proSubBoilerPlateFormatted := fmt.Sprintf(proSubBoilerPlate, exampleCloudAccountName, exampleSubscriptionName, exampleDatabasePassword)
+	proSubBoilerPlateFormatted := fmt.Sprintf(proSubBoilerPlate, cloudAccountName, exampleSubscriptionName, exampleDatabasePassword)
 
 	testCreateTerraform := proSubBoilerPlateFormatted + testAccResourceRedisCloudProDatabaseAcl +
 		fmt.Sprintf(referencableRule, exampleRuleName) +
@@ -44,7 +43,7 @@ func TestAccResourceRedisCloudAclRole_CRUDI(t *testing.T) {
 	const testAclRoleData = "data.rediscloud_acl_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		// Sometimes after deletion, the entity 'flickers'
 		CheckDestroy: nil,

--- a/provider/rediscloud_acl_user_test.go
+++ b/provider/rediscloud_acl_user_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -20,7 +19,7 @@ import (
 func TestAccResourceRedisCloudAclUser_CRUDI(t *testing.T) {
 
 	prefix := testRandomWithPrefix()
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	exampleSubscriptionName := prefix + "-subscription"
 	exampleDatabasePassword := prefix + "aA.1"
 
@@ -32,20 +31,20 @@ func TestAccResourceRedisCloudAclUser_CRUDI(t *testing.T) {
 	testUserPassword := prefix + "aA.1"
 	testUserPasswordUpdated := testUserPassword + "-updated"
 
-	testCreateTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, exampleCloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
+	testCreateTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, cloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
 		fmt.Sprintf(referencableRole, exampleRoleName) +
 		fmt.Sprintf(testUser, testUserName, testUserPassword)
 
 	// The User will be updated because the Role's name will have changed
-	testUpdateTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, exampleCloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
+	testUpdateTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, cloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
 		fmt.Sprintf(referencableRole, exampleRoleNameUpdated) +
 		fmt.Sprintf(testUser, testUserName, testUserPassword)
 
-	testNewNameTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, exampleCloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
+	testNewNameTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, cloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
 		fmt.Sprintf(referencableRole, exampleRoleNameUpdated) +
 		fmt.Sprintf(testUser, testUserNameUpdated, testUserPassword)
 
-	testNewPasswordTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, exampleCloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
+	testNewPasswordTerraform := fmt.Sprintf(testAccResourceRedisCloudProDatabaseAcl, cloudAccountName, exampleSubscriptionName, exampleDatabasePassword) +
 		fmt.Sprintf(referencableRole, exampleRoleNameUpdated) +
 		fmt.Sprintf(testUser, testUserNameUpdated, testUserPasswordUpdated)
 
@@ -55,7 +54,7 @@ func TestAccResourceRedisCloudAclUser_CRUDI(t *testing.T) {
 	const AclUserTestData = "data.rediscloud_acl_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckAclUserDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_active_active_database_block_public_endpoints_test.go
+++ b/provider/rediscloud_active_active_database_block_public_endpoints_test.go
@@ -31,7 +31,7 @@ func TestAccActiveActiveSubscriptionDatabase_DefaultSourceIPs_PrivateAccess(t *t
 	configDisabled := fmt.Sprintf(contentDisabled, subscriptionName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccActiveActiveSubscriptionDatabase_DefaultSourceIPs_PublicAccess(t *te
 	configEnabled := fmt.Sprintf(contentEnabled, subscriptionName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccActiveActiveSubscriptionDatabase_BlockPublicEndpoints(t *testing.T) 
 	configEnabled := fmt.Sprintf(contentEnabled, subscriptionName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_active_active_database_enable_default_user_test.go
+++ b/provider/rediscloud_active_active_database_enable_default_user_test.go
@@ -43,7 +43,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUserInheritance(
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +84,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUser(t *testing.
 	var initialDbId string
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_active_active_private_link_test.go
+++ b/provider/rediscloud_active_active_private_link_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -32,12 +31,13 @@ func TestAccResourceRedisCloudActiveActivePrivateLink_CRUDI(t *testing.T) {
 	subName := testRandomWithPrefix() + "-aa-private-link"
 	shareName := testRandomWithPrefix() + "-privatelink-aa"
 	password := acctest.RandString(20)
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
-	terraformConfig := getRedisActiveActivePrivateLinkConfigWithNames(t, subName, shareName, password)
-	terraformConfigWithoutPrivateLink := getRedisActiveActivePrivateLinkConfigWithoutPrivateLink(t, subName, password)
+	terraformConfig := getRedisActiveActivePrivateLinkConfigWithNames(t, subName, cloudAccountName, shareName, password)
+	terraformConfigWithoutPrivateLink := getRedisActiveActivePrivateLinkConfigWithoutPrivateLink(t, subName, cloudAccountName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -85,16 +85,14 @@ func TestAccResourceRedisCloudActiveActivePrivateLink_CRUDI(t *testing.T) {
 	})
 }
 
-func getRedisActiveActivePrivateLinkConfigWithNames(t *testing.T, subName, shareName, password string) string {
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+func getRedisActiveActivePrivateLinkConfigWithNames(t *testing.T, subName, cloudAccountName, shareName, password string) string {
 	content := utils.GetTestConfig(t, testActiveActivePrivateLinkConfigFile)
-	return fmt.Sprintf(content, subName, exampleCloudAccountName, shareName, password)
+	return fmt.Sprintf(content, subName, cloudAccountName, shareName, password)
 }
 
-func getRedisActiveActivePrivateLinkConfigWithoutPrivateLink(t *testing.T, subName, password string) string {
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+func getRedisActiveActivePrivateLinkConfigWithoutPrivateLink(t *testing.T, subName, cloudAccountName, password string) string {
 	content := utils.GetTestConfig(t, testActiveActivePrivateLinkConfigWithoutPrivateLinkFile)
-	return fmt.Sprintf(content, subName, exampleCloudAccountName, password)
+	return fmt.Sprintf(content, subName, cloudAccountName, password)
 }
 
 func testAccCheckActiveActivePrivateLinkDeleted(subscriptionResourceName, regionsDataSourceName string) resource.TestCheckFunc {

--- a/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_active_active_private_service_connect_endpoint_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -18,12 +17,12 @@ func TestAccResourceRedisCloudActiveActivePrivateServiceConnectEndpoint_CRUDI(t 
 
 	const resourceName = "rediscloud_active_active_private_service_connect_endpoint.psce"
 	const datasourceName = "data.rediscloud_active_active_private_service_connect_endpoints.psce"
-	gcpProjectId := os.Getenv("GCP_PROJECT_ID")
+	gcpProjectId, gcpProjectCheck := envchecks.GCPProjectValueAndCheck(t)
 	gcpVPCName := fmt.Sprintf("%s-network", baseName)
 	gcpVPCSubnetName := fmt.Sprintf("%s-subnet", baseName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.GCPProjectCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); gcpProjectCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_active_active_subscription_test.go
+++ b/provider/rediscloud_active_active_subscription_test.go
@@ -533,7 +533,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateContractPayme
 	const resourceName = "rediscloud_active_active_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -571,7 +571,7 @@ func TestAccResourceRedisCloudActiveActiveSubscription_createUpdateMarketplacePa
 	const resourceName = "rediscloud_active_active_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_private_link_test.go
+++ b/provider/rediscloud_private_link_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -25,8 +24,6 @@ const testPrivateLinkConfigWithoutPrivateLinkFile = "./privatelink/testdata/pro_
 
 func TestAccResourceRedisCloudPrivateLink_CRUDI(t *testing.T) {
 
-	envchecks.AWSBYOCloudAccountCheck(t)
-
 	const resourceName = "rediscloud_private_link.pro_private_link"
 	const subscriptionResourceName = "rediscloud_subscription.pro_subscription"
 	const datasourceName = "data.rediscloud_private_link.pro_private_link"
@@ -35,12 +32,13 @@ func TestAccResourceRedisCloudPrivateLink_CRUDI(t *testing.T) {
 	subName := testRandomWithPrefix() + "-pro-private-link"
 	shareName := testRandomWithPrefix() + "-privatelink"
 	password := acctest.RandString(20)
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
-	terraformConfig := getRedisPrivateLinkConfigWithNames(t, subName, shareName, password)
-	terraformConfigWithoutPrivateLink := getRedisPrivateLinkConfigWithoutPrivateLink(t, subName, password)
+	terraformConfig := getRedisPrivateLinkConfigWithNames(t, subName, cloudAccountName, shareName, password)
+	terraformConfigWithoutPrivateLink := getRedisPrivateLinkConfigWithoutPrivateLink(t, subName, cloudAccountName, password)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -86,25 +84,22 @@ func TestAccResourceRedisCloudPrivateLink_CRUDI(t *testing.T) {
 	})
 }
 
-func getRedisPrivateLinkConfig(t *testing.T, shareName string) string {
+func getRedisPrivateLinkConfig(t *testing.T, cloudAccountName, shareName string) string {
 	subName := testRandomWithPrefix() + "-pro-private-link"
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
 
 	password := acctest.RandString(20)
 	content := utils.GetTestConfig(t, testPrivateLinkConfigFile)
-	return fmt.Sprintf(content, subName, exampleCloudAccountName, shareName, password)
+	return fmt.Sprintf(content, subName, cloudAccountName, shareName, password)
 }
 
-func getRedisPrivateLinkConfigWithNames(t *testing.T, subName, shareName, password string) string {
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+func getRedisPrivateLinkConfigWithNames(t *testing.T, subName, cloudAccountName, shareName, password string) string {
 	content := utils.GetTestConfig(t, testPrivateLinkConfigFile)
-	return fmt.Sprintf(content, subName, exampleCloudAccountName, shareName, password)
+	return fmt.Sprintf(content, subName, cloudAccountName, shareName, password)
 }
 
-func getRedisPrivateLinkConfigWithoutPrivateLink(t *testing.T, subName, password string) string {
-	exampleCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+func getRedisPrivateLinkConfigWithoutPrivateLink(t *testing.T, subName, cloudAccountName, password string) string {
 	content := utils.GetTestConfig(t, testPrivateLinkConfigWithoutPrivateLinkFile)
-	return fmt.Sprintf(content, subName, exampleCloudAccountName, password)
+	return fmt.Sprintf(content, subName, cloudAccountName, password)
 }
 
 func testAccCheckPrivateLinkDeleted(subscriptionResourceName string) resource.TestCheckFunc {
@@ -143,16 +138,16 @@ func testAccCheckPrivateLinkDeleted(subscriptionResourceName string) resource.Te
 // This test was added to catch a bug where the private link API returns a different port
 // than what's shown in the database's private_endpoint for Pro subscriptions.
 func TestAccResourceRedisCloudPrivateLink_PortConsistency(t *testing.T) {
-	envchecks.AWSBYOCloudAccountCheck(t)
 
 	const databaseResourceName = "rediscloud_subscription_database.pro_database"
 	const privateLinkResourceName = "rediscloud_private_link.pro_private_link"
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	shareName := testRandomWithPrefix() + "-port-test"
-	terraformConfig := getRedisPrivateLinkConfig(t, shareName)
+	terraformConfig := getRedisPrivateLinkConfig(t, cloudAccountName, shareName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/rediscloud_private_service_connect_endpoint_test.go
+++ b/provider/rediscloud_private_service_connect_endpoint_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -18,12 +17,12 @@ func TestAccResourceRedisCloudPrivateServiceConnectEndpoint_CRUDI(t *testing.T) 
 
 	const resourceName = "rediscloud_private_service_connect_endpoint.psce"
 	const datasourceName = "data.rediscloud_private_service_connect_endpoints.psce"
-	gcpProjectId := os.Getenv("GCP_PROJECT_ID")
+	gcpProjectId, gcpProjectCheck := envchecks.GCPProjectValueAndCheck(t)
 	gcpVPCName := fmt.Sprintf("%s-network", baseName)
 	gcpVPCSubnetName := fmt.Sprintf("%s-subnet", baseName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.GCPProjectCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); gcpProjectCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -124,7 +124,6 @@ func TestAccResourceRedisCloudActiveActiveSubscription_CMK_AWS(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
-			envchecks.AWSBYOCloudAccountCheck(t)
 			envchecks.AWSProviderCheck(t)
 		},
 		CheckDestroy: testAccCheckActiveActiveSubscriptionDestroy,

--- a/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -68,16 +67,17 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_aws(t *testing.T) 
 func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_gcp(t *testing.T) {
 
 	name := testRandomWithPrefix()
-
+	gcpVPCProject, gcpVPCProjectCheck := envchecks.ValueAndCheck(t, "GCP_VPC_PROJECT")
+	gcpVPCId, gcpVPCIdCheck := envchecks.ValueAndCheck(t, "GCP_VPC_ID")
 	tf := fmt.Sprintf(testAccResourceRedisCloudActiveActiveSubscriptionPeeringGCP,
 		name,
-		os.Getenv("GCP_VPC_PROJECT"),
-		os.Getenv("GCP_VPC_ID"),
+		gcpVPCProject,
+		gcpVPCId,
 	)
 	const resourceName = "rediscloud_active_active_subscription_peering.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); gcpVPCProjectCheck(); gcpVPCIdCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/resource_rediscloud_pro_database_qpf_test.go
+++ b/provider/resource_rediscloud_pro_database_qpf_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -97,9 +96,9 @@ resource "rediscloud_subscription_database" "example" {
 }
 
 // Generic test helper for error cases
-func testErrorCase(t *testing.T, config string, expectedError *regexp.Regexp) {
+func testErrorCase(t *testing.T, config string, cloudAccountCheck func(), expectedError *regexp.Regexp) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -114,15 +113,15 @@ func testErrorCase(t *testing.T, config string, expectedError *regexp.Regexp) {
 func TestAccResourceRedisCloudProDatabase_qpf(t *testing.T) {
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: formatDatabaseConfig(name, testCloudAccountName, password, "4x", ""),
+				Config: formatDatabaseConfig(name, cloudAccountName, password, "4x", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("rediscloud_subscription_database.example", "name", "example"),
 					resource.TestCheckResourceAttr("rediscloud_subscription_database.example", "protocol", "redis"),
@@ -135,7 +134,7 @@ func TestAccResourceRedisCloudProDatabase_qpf(t *testing.T) {
 
 			// Test that query_performance_factor can be updated without forcing replacement
 			{
-				Config: formatDatabaseConfig(name, testCloudAccountName, password, "2x", ""),
+				Config: formatDatabaseConfig(name, cloudAccountName, password, "2x", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("rediscloud_subscription_database.example", "name", "example"),
 					resource.TestCheckResourceAttr("rediscloud_subscription_database.example", "query_performance_factor", "2x"),
@@ -148,20 +147,20 @@ func TestAccResourceRedisCloudProDatabase_qpf(t *testing.T) {
 func TestAccResourceRedisCloudProDatabase_qpf_missingModule(t *testing.T) {
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
-	config := formatDatabaseConfig(name, testCloudAccountName, password, "4x", `redis_version = "7.4"`)
+	config := formatDatabaseConfig(name, cloudAccountName, password, "4x", `redis_version = "7.4"`)
 
-	testErrorCase(t, config, regexp.MustCompile("DATABASE_QUERY_PERFORMANCE_FACTOR_SEARCH_IS_REQUIRED.*RediSearch.*required"))
+	testErrorCase(t, config, cloudAccountCheck, regexp.MustCompile("DATABASE_QUERY_PERFORMANCE_FACTOR_SEARCH_IS_REQUIRED.*RediSearch.*required"))
 }
 
 func TestAccResourceRedisCloudProDatabase_qpf_missingRediSearchModule(t *testing.T) {
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
-	config := formatDatabaseConfig(name, testCloudAccountName, password, "4x", `modules = [{ name = "RediBloom" }]
+	config := formatDatabaseConfig(name, cloudAccountName, password, "4x", `modules = [{ name = "RediBloom" }]
     redis_version = "7.4"`)
 
-	testErrorCase(t, config, regexp.MustCompile("DATABASE_QUERY_PERFORMANCE_FACTOR_SEARCH_IS_REQUIRED.*RediSearch.*required"))
+	testErrorCase(t, config, cloudAccountCheck, regexp.MustCompile("DATABASE_QUERY_PERFORMANCE_FACTOR_SEARCH_IS_REQUIRED.*RediSearch.*required"))
 }

--- a/provider/resource_rediscloud_pro_database_redis_8_test.go
+++ b/provider/resource_rediscloud_pro_database_redis_8_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -26,17 +25,17 @@ func TestAccResourceRedisCloudProDatabase_Redis8(t *testing.T) {
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getRedis8DatabaseConfig(t, testCloudAccountName, name, password),
+				Config: getRedis8DatabaseConfig(t, cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -106,18 +105,18 @@ func TestAccResourceRedisCloudProDatabase_Redis8_RamAndFlash_CRUDI(t *testing.T)
 	const subscriptionResourceName = "rediscloud_subscription.example"
 	const replicaResourceName = "rediscloud_subscription_database.example_replica"
 
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Test database and replica database creation
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_with_replica.tf"), testCloudAccountName, name, password),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_with_replica.tf"), cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -184,7 +183,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_RamAndFlash_CRUDI(t *testing.T)
 			},
 			// Test database is updated successfully
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_update.tf"), testCloudAccountName, name),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_update.tf"), cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example-updated"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -211,14 +210,14 @@ func TestAccResourceRedisCloudProDatabase_Redis8_RamAndFlash_CRUDI(t *testing.T)
 			},
 			// Test that alerts are deleted
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_update_destroy_alerts.tf"), testCloudAccountName, name, password),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_update_destroy_alerts.tf"), cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "alert.#", "0"),
 				),
 			},
 			// Test that a 32-character password is generated when no password is provided
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_no_password.tf"), testCloudAccountName, name),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_ram_and_flash_database_redis_8_no_password.tf"), cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("rediscloud_subscription_database.no_password_database", "ram_percentage", "20"),
 					func(s *terraform.State) error {
@@ -248,18 +247,18 @@ func TestAccResourceRedisCloudProDatabase_Redis8_Upgrade(t *testing.T) {
 	password := acctest.RandString(20)
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Test database and replica database creation with Redis 7.2
 			{
-				Config: getRedis7DatabaseConfig(t, testCloudAccountName, name, password),
+				Config: getRedis7DatabaseConfig(t, cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -319,7 +318,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_Upgrade(t *testing.T) {
 			},
 			// Test database is updated successfully to Redis 8.0
 			{
-				Config: getRedis8DatabaseConfig(t, testCloudAccountName, name, password),
+				Config: getRedis8DatabaseConfig(t, cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.2"),
 				),
@@ -333,15 +332,15 @@ func TestAccResourceRedisCloudProDatabase_Redis8_ModulesBlocked(t *testing.T) {
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      getRedis8WithModulesConfig(t, testCloudAccountName, name, password),
+				Config:      getRedis8WithModulesConfig(t, cloudAccountName, name, password),
 				ExpectError: regexp.MustCompile(`"modules" cannot be explicitly set for Redis version 8\.0 as modules are bundled by default`),
 			},
 		},

--- a/provider/resource_rediscloud_pro_database_test.go
+++ b/provider/resource_rediscloud_pro_database_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -28,18 +27,18 @@ func TestAccResourceRedisCloudProDatabase_CRUDI(t *testing.T) {
 	const resourceName = "rediscloud_subscription_database.example"
 	const subscriptionResourceName = "rediscloud_subscription.example"
 	const replicaResourceName = "rediscloud_subscription_database.example_replica"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			// Test database and replica database creation
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_with_replica.tf"), testCloudAccountName, name, password),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_with_replica.tf"), cloudAccountName, name, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -107,7 +106,7 @@ func TestAccResourceRedisCloudProDatabase_CRUDI(t *testing.T) {
 			},
 			// Test database is updated successfully
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_update.tf"), testCloudAccountName, name),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_update.tf"), cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "example-updated"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "redis"),
@@ -137,14 +136,14 @@ func TestAccResourceRedisCloudProDatabase_CRUDI(t *testing.T) {
 			},
 			// Test that alerts are deleted
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_update_destroy_alerts.tf"), testCloudAccountName, name),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_update_destroy_alerts.tf"), cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "alert.#", "0"),
 				),
 			},
 			// Test that a 32-character password is generated when no password is provided
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_no_password.tf"), testCloudAccountName, name),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_no_password.tf"), cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						is := s.RootModule().Resources["rediscloud_subscription_database.no_password_database"].Primary
@@ -170,18 +169,18 @@ func TestAccResourceRedisCloudProDatabase_optionalAttributes(t *testing.T) {
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	portNumber := 10101
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_optional_attributes.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"port_number":                  config.IntegerVariable(portNumber),
 				},
@@ -197,15 +196,15 @@ func TestAccResourceRedisCloudProDatabase_optionalAttributes(t *testing.T) {
 func TestAccResourceRedisCloudProDatabase_timeUtcRequiresValidInterval(t *testing.T) {
 
 	name := testRandomWithPrefix()
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_invalid_time_utc.tf"), testCloudAccountName, name),
+				Config:      fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_invalid_time_utc.tf"), cloudAccountName, name),
 				ExpectError: regexp.MustCompile("unexpected value at remote_backup\\.0\\.time_utc - time_utc can only be set when interval is either every-24-hours or every-12-hours"),
 			},
 		},
@@ -218,15 +217,15 @@ func TestAccResourceRedisCloudProDatabase_MultiModules(t *testing.T) {
 	name := testRandomWithPrefix()
 	dbName := "db-multi-modules"
 	const resourceName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_multi_modules.tf"), testCloudAccountName, name, dbName),
+				Config: fmt.Sprintf(utils.GetTestConfig(t, "./pro/testdata/pro_database_multi_modules.tf"), cloudAccountName, name, dbName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttr(resourceName, "modules.#", "2"),
@@ -248,18 +247,18 @@ func TestAccResourceRedisCloudProDatabase_respversion(t *testing.T) {
 	// Test that attributes can be optional, either by setting them or not having them set when compared to CRUDI test
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	portNumber := 10101
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_resp_versions.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"port_number":                  config.IntegerVariable(portNumber),
 					"resp_version":                 config.StringVariable("resp2"),
@@ -271,7 +270,7 @@ func TestAccResourceRedisCloudProDatabase_respversion(t *testing.T) {
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_resp_versions.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"port_number":                  config.IntegerVariable(portNumber),
 					"resp_version":                 config.StringVariable("resp3"),
@@ -283,7 +282,7 @@ func TestAccResourceRedisCloudProDatabase_respversion(t *testing.T) {
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_resp_versions.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"port_number":                  config.IntegerVariable(portNumber),
 					"resp_version":                 config.StringVariable("best_resp_100"),
@@ -299,10 +298,10 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 	name := testRandomWithPrefix()
 	databaseName := testRandomWithPrefix() + "-database"
 	const resourceName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -310,7 +309,7 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_auto_minor_version_upgrade.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"rediscloud_database_name":     config.StringVariable(databaseName),
 					"auto_minor_version_upgrade":   config.BoolVariable(false),
@@ -327,7 +326,7 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_auto_minor_version_upgrade.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"rediscloud_database_name":     config.StringVariable(databaseName),
 					"auto_minor_version_upgrade":   config.BoolVariable(true),
@@ -346,7 +345,7 @@ func TestAccResourceRedisCloudProDatabase_autoMinorVersionUpgrade(t *testing.T) 
 			{
 				ConfigFile: config.StaticFile("./pro/testdata/pro_database_auto_minor_version_upgrade.tf"),
 				ConfigVariables: config.Variables{
-					"rediscloud_cloud_account":     config.StringVariable(testCloudAccountName),
+					"rediscloud_cloud_account":     config.StringVariable(cloudAccountName),
 					"rediscloud_subscription_name": config.StringVariable(name),
 					"rediscloud_database_name":     config.StringVariable(databaseName),
 					"auto_minor_version_upgrade":   config.BoolVariable(true),

--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -1,7 +1,6 @@
 package provider_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -17,14 +16,12 @@ import (
 // TODO: integrate the GCP provider and set up these permissions automatically
 func TestAccResourceRedisCloudProSubscription_CMK(t *testing.T) {
 
-	envchecks.RequireEnvVars(t, "GCP_CMK_RESOURCE_NAME")
-
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
-	gcpCmkResourceName := os.Getenv("GCP_CMK_RESOURCE_NAME")
+	gcpCmkResourceName, gcpCmkResourceNameCheck := envchecks.ValueAndCheck(t, "GCP_CMK_RESOURCE_NAME")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); gcpCmkResourceNameCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -24,7 +24,7 @@ func TestAccResourceRedisCloudProSubscription_CMK(t *testing.T) {
 	gcpCmkResourceName := os.Getenv("GCP_CMK_RESOURCE_NAME")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +84,6 @@ func TestAccResourceRedisCloudProSubscription_CMK_AWS(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
-			envchecks.AWSBYOCloudAccountCheck(t)
 			envchecks.AWSProviderCheck(t)
 		},
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),

--- a/provider/resource_rediscloud_pro_subscription_qpf_test.go
+++ b/provider/resource_rediscloud_pro_subscription_qpf_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -62,16 +61,16 @@ resource "rediscloud_subscription" "example" {
 
 func TestAccResourceRedisCloudProSubscription_qpf(t *testing.T) {
 	name := testRandomWithPrefix()
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 	const resourceName = "rediscloud_subscription.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: formatSubscriptionConfig(name, testCloudAccountName, "2x", `modules = ["RediSearch"]`),
+				Config: formatSubscriptionConfig(name, cloudAccountName, "2x", `modules = ["RediSearch"]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),

--- a/provider/resource_rediscloud_pro_subscription_test.go
+++ b/provider/resource_rediscloud_pro_subscription_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -33,17 +32,17 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis7(t *testing.T) {
 
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceRedisCloudProSubscriptionRedis7(t, testCloudAccountName, name),
+				Config: testAccResourceRedisCloudProSubscriptionRedis7(t, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -92,7 +91,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis7(t *testing.T) {
 			},
 			{
 				// Checks if the changes in the creation plan are ignored.
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, testCloudAccountName, name, "ram"),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, cloudAccountName, name, "ram"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.average_item_size_in_bytes", "0"),
@@ -106,7 +105,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis7(t *testing.T) {
 			},
 			{
 				// Checks if the changes to the payment_method are ignored.
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionChangedPaymentMethod, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionChangedPaymentMethod, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
 				),
@@ -129,7 +128,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis7(t *testing.T) {
 			},
 			{
 				// Checks if an error is raised when a ForceNew attribute is changed and the creation_plan block is not defined.
-				Config:       fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, testCloudAccountName, name, "ram-and-flash"),
+				Config:       fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, cloudAccountName, name, "ram-and-flash"),
 				ResourceName: resourceName,
 				ExpectError:  regexp.MustCompile(`Error: the "creation_plan" block is required`),
 			},
@@ -142,17 +141,17 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis8(t *testing.T) {
 
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceRedisCloudProSubscriptionRedis8(t, testCloudAccountName, name),
+				Config: testAccResourceRedisCloudProSubscriptionRedis8(t, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
@@ -198,7 +197,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis8(t *testing.T) {
 			},
 			{
 				// Checks if the changes in the creation plan are ignored.
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, testCloudAccountName, name, "ram"),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, cloudAccountName, name, "ram"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "creation_plan.0.average_item_size_in_bytes", "0"),
@@ -212,7 +211,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis8(t *testing.T) {
 			},
 			{
 				// Checks if the changes to the payment_method are ignored.
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionChangedPaymentMethod, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionChangedPaymentMethod, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "payment_method", "credit-card"),
 				),
@@ -235,7 +234,7 @@ func TestAccResourceRedisCloudProSubscription_CRUDI_Redis8(t *testing.T) {
 			},
 			{
 				// Checks if an error is raised when a ForceNew attribute is changed and the creation_plan block is not defined.
-				Config:       fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, testCloudAccountName, name, "ram-and-flash"),
+				Config:       fmt.Sprintf(testAccResourceRedisCloudProSubscriptionNoCreationPlan, cloudAccountName, name, "ram-and-flash"),
 				ResourceName: resourceName,
 				ExpectError:  regexp.MustCompile(`Error: the "creation_plan" block is required`),
 			},
@@ -247,15 +246,15 @@ func TestAccResourceRedisCloudProSubscription_preferredAZsModulesOptional(t *tes
 
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPreferredAZsModulesOptional, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPreferredAZsModulesOptional, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.region.0.preferred_availability_zones.#", "1"),
@@ -274,15 +273,15 @@ func TestAccResourceRedisCloudProSubscription_createUpdateContractPayment(t *tes
 	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionContractPayment, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionContractPayment, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
@@ -292,7 +291,7 @@ func TestAccResourceRedisCloudProSubscription_createUpdateContractPayment(t *tes
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionContractPayment, testCloudAccountName, updatedName),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionContractPayment, cloudAccountName, updatedName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "payment_method_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
@@ -311,15 +310,15 @@ func TestAccResourceRedisCloudProSubscription_createUpdateMarketplacePayment(t *
 	name := testRandomWithPrefix()
 	updatedName := fmt.Sprintf("%v-updatedName", name)
 	const resourceName = "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionMarketplacePayment, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionMarketplacePayment, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider.0.provider", "AWS"),
@@ -328,7 +327,7 @@ func TestAccResourceRedisCloudProSubscription_createUpdateMarketplacePayment(t *
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionMarketplacePayment, testCloudAccountName, updatedName),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionMarketplacePayment, cloudAccountName, updatedName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 				),
@@ -340,17 +339,17 @@ func TestAccResourceRedisCloudProSubscription_createUpdateMarketplacePayment(t *
 func TestAccResourceRedisCloudProSubscription_RedisVersion(t *testing.T) {
 
 	name := testRandomWithPrefix()
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	identifier := ""
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionWithRedisVersion, testCloudAccountName, name, ""),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionWithRedisVersion, cloudAccountName, name, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Take a snapshot of the ID
 					func(s *terraform.State) error {
@@ -361,7 +360,7 @@ func TestAccResourceRedisCloudProSubscription_RedisVersion(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionWithRedisVersion, testCloudAccountName, name, "redis_version = \"latest\""),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionWithRedisVersion, cloudAccountName, name, "redis_version = \"latest\""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Take a snapshot of the ID
 					func(s *terraform.State) error {
@@ -388,7 +387,7 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 	name := testRandomWithPrefix() + "-mw"
 	resourceName := "rediscloud_subscription.example"
 	datasourceName := "data.rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	const defaultMW = ""
 	const autoMw = `maintenance_windows {
@@ -430,12 +429,12 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 	}`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, defaultMW),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, defaultMW),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "automatic"),
@@ -447,7 +446,7 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, autoMw),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, autoMw),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "automatic"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "0"),
@@ -457,7 +456,7 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, manualMw),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, manualMw),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "1"),
@@ -477,15 +476,15 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, errorManualMw),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, errorManualMw),
 				ExpectError: regexp.MustCompile("Must provide at least one maintenance window with manual maintenance mode"),
 			},
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, errorAutoMw),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, errorAutoMw),
 				ExpectError: regexp.MustCompile("Automatic mode cannot be set with a manual maintenance window"),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, multipleManualMw),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, multipleManualMw),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "manual"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "2"),
@@ -521,7 +520,7 @@ func TestAccResourceRedisCloudProSubscription_MaintenanceWindows(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, testCloudAccountName, name, autoMw),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionMaintenanceWindows, cloudAccountName, name, autoMw),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.mode", "automatic"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_windows.0.window.#", "0"),
@@ -538,22 +537,22 @@ func TestAccResourceRedisCloudProSubscription_PublicEndpointAccess(t *testing.T)
 
 	name := testRandomWithPrefix()
 	resourceName := "rediscloud_subscription.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPublicEndpointDisabled, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPublicEndpointDisabled, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint_access", "false"),
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPublicEndpointEnabled, testCloudAccountName, name),
+				Config: fmt.Sprintf(testAccResourceRedisCloudProSubscriptionPublicEndpointEnabled, cloudAccountName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint_access", "true"),

--- a/provider/resource_rediscloud_pro_tls_test.go
+++ b/provider/resource_rediscloud_pro_tls_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -27,17 +26,17 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, sslCertificate),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, cloudAccountName, name, 1, password, sslCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(subscriptionName, "name", name),
 					resource.TestCheckResourceAttr(subscriptionName, "cloud_provider.0.provider", "AWS"),
@@ -86,7 +85,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 			},
 			// Ensure that SSL users can upgrade to TLS
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndTlsCert, testCloudAccountName, name, 1, password, sslCertificate),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndTlsCert, cloudAccountName, name, 1, password, sslCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(subscriptionName, "name", name),
 					resource.TestCheckResourceAttr(subscriptionName, "cloud_provider.0.provider", "AWS"),
@@ -100,7 +99,7 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 			},
 			// And that mTLS can be switched off altogether
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndNoCert, testCloudAccountName, name, 1, password),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndNoCert, cloudAccountName, name, 1, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(subscriptionName, "name", name),
 					resource.TestCheckResourceAttr(subscriptionName, "cloud_provider.0.provider", "AWS"),
@@ -129,17 +128,17 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndWithoutCert, testCloudAccountName, name, 1, password),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndWithoutCert, cloudAccountName, name, 1, password),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(subscriptionName, "name", name),
 					resource.TestCheckResourceAttr(subscriptionName, "cloud_provider.0.provider", "AWS"),
@@ -204,15 +203,15 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, testCloudAccountName, name, 1, password, invalidSslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndCert, cloudAccountName, name, 1, password, invalidSslCertificate),
 				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
 			},
 		},
@@ -224,15 +223,15 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseAndDisabledTlsAn
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithoutEnableTlsAndWithCert, testCloudAccountName, name, 1, password, invalidSslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithoutEnableTlsAndWithCert, cloudAccountName, name, 1, password, invalidSslCertificate),
 				ExpectError: regexp.MustCompile("Error: 400 BAD_REQUEST - DATABASE_INVALID_CERT: Database certificate is invalid"),
 			},
 		},
@@ -244,15 +243,15 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithoutEnableTlsAndTlsCert(t
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccResourceRedisCloudWithoutEnableTlsAndWithTlsCert, testCloudAccountName, name, 1, password, sslCertificate),
+				Config:      fmt.Sprintf(testAccResourceRedisCloudWithoutEnableTlsAndWithTlsCert, cloudAccountName, name, 1, password, sslCertificate),
 				ExpectError: regexp.MustCompile("TLS certificates may not be provided while enable_tls is false"),
 			},
 		},
@@ -263,15 +262,15 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithSslCertAndTlsCert(t *tes
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(bothSslAndTls, testCloudAccountName, name, 1, password, sslCertificate, sslCertificate),
+				Config:      fmt.Sprintf(bothSslAndTls, cloudAccountName, name, 1, password, sslCertificate, sslCertificate),
 				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
 			},
 		},
@@ -285,17 +284,17 @@ func TestAccResourceRedisCloudSubscriptionTls_createWithDatabaseWithEnabledTlsAn
 	password := acctest.RandString(20)
 	const subscriptionName = "rediscloud_subscription.example"
 	const databaseName = "rediscloud_subscription_database.example"
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	var subId int
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t); envchecks.AWSBYOCloudAccountCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); cloudAccountCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndTlsCert, testCloudAccountName, name, 1, password, sslCertificate),
+				Config: fmt.Sprintf(testAccResourceRedisCloudSubscriptionOneDbWithEnableTlsAndTlsCert, cloudAccountName, name, 1, password, sslCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(subscriptionName, "name", name),
 					resource.TestCheckResourceAttr(subscriptionName, "cloud_provider.0.provider", "AWS"),

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -17,7 +17,7 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 
 	name := testRandomWithPrefix()
 
-	testCloudAccountName := os.Getenv("AWS_TEST_CLOUD_ACCOUNT_NAME")
+	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
 
 	cidrRange := os.Getenv("AWS_VPC_CIDR")
 	// Chose a CIDR range for the subscription that's unlikely to overlap with any VPC CIDR
@@ -41,7 +41,7 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 	matchesRegex(t, vpcId, "^vpc-[a-z\\d]+$")
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudSubscriptionPeeringAWS,
-		testCloudAccountName,
+		cloudAccountName,
 		name,
 		subCidrRange,
 		peeringRegion,
@@ -55,7 +55,7 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
 			envchecks.AwsPeeringCheck(t)
-			envchecks.AWSBYOCloudAccountCheck(t)
+			cloudAccountCheck()
 		},
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"fmt"
 	"net"
-	"os"
 	"regexp"
 	"testing"
 
@@ -18,43 +17,40 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 	name := testRandomWithPrefix()
 
 	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck(t)
+	awsPeering, awsPeeringCheck := envchecks.AwsPeeringValueAndCheck(t)
 
-	cidrRange := os.Getenv("AWS_VPC_CIDR")
 	// Chose a CIDR range for the subscription that's unlikely to overlap with any VPC CIDR
 	subCidrRange := "10.0.0.0/24"
 
-	overlap, err := cidrRangesOverlap(subCidrRange, cidrRange)
+	overlap, err := cidrRangesOverlap(subCidrRange, awsPeering.VpcCidr)
 	if err != nil {
-		t.Fatalf("AWS_VPC_CIDR is not a valid CIDR range %s: %s", cidrRange, err)
+		t.Fatalf("AWS_VPC_CIDR is not a valid CIDR range %s: %s", awsPeering.VpcCidr, err)
 	}
 	if overlap {
 		subCidrRange = "172.16.0.0/24"
 	}
 
-	peeringRegion := os.Getenv("AWS_PEERING_REGION")
-	matchesRegex(t, peeringRegion, "^[a-z]+-[a-z]+-\\d+$")
+	matchesRegex(t, awsPeering.Region, "^[a-z]+-[a-z]+-\\d+$")
 
-	accountId := os.Getenv("AWS_ACCOUNT_ID")
-	matchesRegex(t, accountId, "^\\d+$")
+	matchesRegex(t, awsPeering.AccountId, "^\\d+$")
 
-	vpcId := os.Getenv("AWS_VPC_ID")
-	matchesRegex(t, vpcId, "^vpc-[a-z\\d]+$")
+	matchesRegex(t, awsPeering.VpcId, "^vpc-[a-z\\d]+$")
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudSubscriptionPeeringAWS,
 		cloudAccountName,
 		name,
 		subCidrRange,
-		peeringRegion,
-		accountId,
-		vpcId,
-		cidrRange,
+		awsPeering.Region,
+		awsPeering.AccountId,
+		awsPeering.VpcId,
+		awsPeering.VpcCidr,
 	)
 	const resourceName = "rediscloud_subscription_peering.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			envchecks.RedisCloudCheck(t)
-			envchecks.AwsPeeringCheck(t)
+			awsPeeringCheck()
 			cloudAccountCheck()
 		},
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
@@ -68,9 +64,9 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_account_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", cidrRange),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", awsPeering.VpcCidr),
 					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.0", cidrRange),
+					resource.TestCheckResourceAttr(resourceName, "vpc_cidrs.0", awsPeering.VpcCidr),
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_peering_id"),
 				),
@@ -82,16 +78,18 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 func TestAccResourceRedisCloudSubscriptionPeering_gcp(t *testing.T) {
 
 	name := testRandomWithPrefix()
+	gcpVpcProject, gcpVpcProjectCheck := envchecks.ValueAndCheck(t, "GCP_VPC_PROJECT")
+	gcpVpcId, gcpVpcIdCheck := envchecks.ValueAndCheck(t, "GCP_VPC_ID")
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudSubscriptionPeeringGCP,
 		name,
-		os.Getenv("GCP_VPC_PROJECT"),
-		os.Getenv("GCP_VPC_ID"),
+		gcpVpcProject,
+		gcpVpcId,
 	)
 	const resourceName = "rediscloud_subscription_peering.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { envchecks.RedisCloudCheck(t) },
+		PreCheck:                 func() { envchecks.RedisCloudCheck(t); gcpVpcProjectCheck(); gcpVpcIdCheck() },
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
- adds `ValueAndCheck` function to return a value for env var, and a check to be added to test `PreCheck` function
- adds common `*ValueAndCheck` functions (AWS BYOC cloud account, GCP project ID and AWS peering)
- cleans up other `os.Getenv` cases replacing them with `ValueAndCheck`