### PR TITLE
chore: refactor cloud_account datasource filters into named constructors

### DIFF
--- a/provider/cloudaccount/datasource_cloud_account_read.go
+++ b/provider/cloudaccount/datasource_cloud_account_read.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+type caFilterFunc func(account *cloud_accounts.CloudAccount) bool
+
 // Read refreshes the Terraform state with the latest data.
 func (d *cloudAccountDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	// Defensive nil check for client
@@ -39,23 +41,17 @@ func (d *cloudAccountDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	// Build filters based on configuration
-	var filters []func(cloudAccount *cloud_accounts.CloudAccount) bool
+	var filters []caFilterFunc
 
 	// Handle exclude_internal_account filter - default to false if not set
 	if !config.ExcludeInternalAccount.IsNull() && config.ExcludeInternalAccount.ValueBool() {
-		filters = append(filters, func(cloudAccount *cloud_accounts.CloudAccount) bool {
-			return redis.IntValue(cloudAccount.ID) != 1
-		})
+		filters = append(filters, excludeInternalAccountFilter())
 	}
 	if !config.ProviderType.IsNull() && config.ProviderType.ValueString() != "" {
-		filters = append(filters, func(cloudAccount *cloud_accounts.CloudAccount) bool {
-			return redis.StringValue(cloudAccount.Provider) == config.ProviderType.ValueString()
-		})
+		filters = append(filters, providerTypeFilter(config.ProviderType.ValueString()))
 	}
 	if !config.Name.IsNull() && config.Name.ValueString() != "" {
-		filters = append(filters, func(cloudAccount *cloud_accounts.CloudAccount) bool {
-			return redis.StringValue(cloudAccount.Name) == config.Name.ValueString()
-		})
+		filters = append(filters, nameFilter(config.Name.ValueString()))
 	}
 
 	// Apply filters
@@ -91,7 +87,7 @@ func (d *cloudAccountDataSource) Read(ctx context.Context, req datasource.ReadRe
 	resp.Diagnostics.Append(diags...)
 }
 
-func filterCloudAccounts(accounts []*cloud_accounts.CloudAccount, filters []func(account *cloud_accounts.CloudAccount) bool) []*cloud_accounts.CloudAccount {
+func filterCloudAccounts(accounts []*cloud_accounts.CloudAccount, filters []caFilterFunc) []*cloud_accounts.CloudAccount {
 	var filtered []*cloud_accounts.CloudAccount
 	for _, cloudAccount := range accounts {
 		if cloudAccount == nil {
@@ -105,11 +101,33 @@ func filterCloudAccounts(accounts []*cloud_accounts.CloudAccount, filters []func
 	return filtered
 }
 
-func filterCloudAccount(account *cloud_accounts.CloudAccount, filters []func(account *cloud_accounts.CloudAccount) bool) bool {
+func filterCloudAccount(account *cloud_accounts.CloudAccount, filters []caFilterFunc) bool {
 	for _, f := range filters {
 		if !f(account) {
 			return false
 		}
 	}
 	return true
+}
+
+// excludeInternalAccountFilter matches every cloud account except the Redis Labs
+// internal account (id 1).
+func excludeInternalAccountFilter() caFilterFunc {
+	return func(account *cloud_accounts.CloudAccount) bool {
+		return redis.IntValue(account.ID) != 1
+	}
+}
+
+// providerTypeFilter matches cloud accounts with the given provider (e.g. AWS, GCP).
+func providerTypeFilter(providerType string) caFilterFunc {
+	return func(account *cloud_accounts.CloudAccount) bool {
+		return redis.StringValue(account.Provider) == providerType
+	}
+}
+
+// nameFilter matches cloud accounts with the given name.
+func nameFilter(name string) caFilterFunc {
+	return func(account *cloud_accounts.CloudAccount) bool {
+		return redis.StringValue(account.Name) == name
+	}
 }

--- a/provider/cloudaccount/filter_test.go
+++ b/provider/cloudaccount/filter_test.go
@@ -1,0 +1,70 @@
+package cloudaccount
+
+import (
+	"testing"
+
+	"github.com/RedisLabs/rediscloud-go-api/redis"
+	"github.com/RedisLabs/rediscloud-go-api/service/cloud_accounts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterCloudAccounts(t *testing.T) {
+	internal := &cloud_accounts.CloudAccount{ID: redis.Int(1), Name: redis.String("internal"), Provider: redis.String("AWS")}
+	awsProd := &cloud_accounts.CloudAccount{ID: redis.Int(2), Name: redis.String("prod"), Provider: redis.String("AWS")}
+	gcpProd := &cloud_accounts.CloudAccount{ID: redis.Int(3), Name: redis.String("prod"), Provider: redis.String("GCP")}
+	awsDev := &cloud_accounts.CloudAccount{ID: redis.Int(4), Name: redis.String("dev"), Provider: redis.String("AWS")}
+
+	tests := []struct {
+		name    string
+		input   []*cloud_accounts.CloudAccount
+		filters []caFilterFunc
+		want    []*cloud_accounts.CloudAccount
+	}{
+		{
+			name:  "no filters returns all non-nil accounts",
+			input: []*cloud_accounts.CloudAccount{internal, awsProd, gcpProd},
+			want:  []*cloud_accounts.CloudAccount{internal, awsProd, gcpProd},
+		},
+		{
+			name:  "nil accounts are skipped",
+			input: []*cloud_accounts.CloudAccount{nil, awsProd, nil},
+			want:  []*cloud_accounts.CloudAccount{awsProd},
+		},
+		{
+			name:    "exclude internal account (id 1)",
+			input:   []*cloud_accounts.CloudAccount{internal, awsProd, gcpProd},
+			filters: []caFilterFunc{excludeInternalAccountFilter()},
+			want:    []*cloud_accounts.CloudAccount{awsProd, gcpProd},
+		},
+		{
+			name:    "single provider filter",
+			input:   []*cloud_accounts.CloudAccount{awsProd, gcpProd, awsDev},
+			filters: []caFilterFunc{providerTypeFilter("AWS")},
+			want:    []*cloud_accounts.CloudAccount{awsProd, awsDev},
+		},
+		{
+			name:    "multiple filters are ANDed (provider and name)",
+			input:   []*cloud_accounts.CloudAccount{awsProd, gcpProd, awsDev},
+			filters: []caFilterFunc{providerTypeFilter("AWS"), nameFilter("prod")},
+			want:    []*cloud_accounts.CloudAccount{awsProd},
+		},
+		{
+			name:    "no matches returns empty",
+			input:   []*cloud_accounts.CloudAccount{awsProd, gcpProd},
+			filters: []caFilterFunc{providerTypeFilter("Azure")},
+			want:    nil,
+		},
+		{
+			name:  "empty input returns empty",
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterCloudAccounts(tt.input, tt.filters)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- Extracts the filter func type to a `caFilterFunc` to avoid repetition throughout the codebase
- Extracts the `exclude_internal_account` / `provider_type` / `name` filter predicates into named `caFilterFunc` constructors
- Adds a table-driven unit test for `filterCloudAccounts` that uses the actual filter constructors