### PR TITLE
ci: Automate release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
-        name: Run GoReleaser
-        run: nix develop --command goreleaser release --clean
+        name: Release
+        run: nix develop --command make release
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ terraform.tfplan
 terraform.tfstate
 bin/
 dist/
+release-notes.md
 terraform-plugin-dir/
 .envrc
 modules-dev/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,6 +12,7 @@ PLUGINS_PROVIDER_PATH=$(PROVIDER_HOSTNAME)/$(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE
 BIN=$(CURDIR)/bin
 CI_PLUGIN_DIR = $(BIN)/terraform-plugin-dir
 CI_SCHEMA_DIR = $(BIN)/providers-schema
+RELEASE_NOTES_FILE = release-notes.md
 
 # Use a parallelism of 3 by default for tests, overriding whatever GOMAXPROCS is set to.
 TEST_PARALLELISM?=6
@@ -20,7 +21,7 @@ TESTARGS?=-short
 .PHONY: build clean fmt fmt-golangci fmt-terraform lint lint-golangci lint-terraform lint-tfproviderlint tfproviderlint \
         testacc testacc-essentials install-local sweep sweep-prefix \
         lint-docs lint-goreleaser ci go-mod-tidy govulncheck go-unit-test go-build go-build-tests \
-        terraform-providers-schema lint-markdown
+        terraform-providers-schema lint-markdown release-notes release
 
 bin:
 	mkdir -p $(BIN)
@@ -126,3 +127,13 @@ ifndef TEST_RESOURCE_PREFIX
 endif
 	@echo "WARNING: This will destroy infrastructure matching prefix '$(TEST_RESOURCE_PREFIX)'. Use only in development accounts."
 	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) SWEEP_AGE_THRESHOLD=0s go test ./provider -v -sweep=ALL $(SWEEPARGS) -timeout 30m
+
+release-notes:
+	@echo "Generating release notes"
+	./scripts/release-notes.sh > $(RELEASE_NOTES_FILE)
+	@echo "===== release notes ====="
+	@cat $(RELEASE_NOTES_FILE)
+	@echo "================================="
+
+release: release-notes
+	goreleaser release --clean --release-notes=$(RELEASE_NOTES_FILE)

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,14 @@
 
               pkgs.gnumake
               pkgs.markdownlint-cli2
+              pkgs.mdq
+
+              # GNU userland so shell tooling (e.g. scripts/release-notes.sh)
+              # behaves identically on macOS (BSD by default) and Linux CI.
+              pkgs.coreutils
+              pkgs.gawk
+              pkgs.gnugrep
+              pkgs.gnused
 
               pkgs.go_1_25
               pkgs.golangci-lint

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Emit the release notes for the latest CHANGELOG.md entry on stdout.
+#
+# The changelog lists releases as level-2 headings ("## 2.18.1 (...)") with the
+# newest first, under a "# Changelog" title. We select every version block
+# (headings that start with a digit, which excludes the title), keep only the
+# first one's body, and drop its own version heading so the notes start at the
+# content. The result is suitable for `goreleaser release --release-notes`.
+set -euo pipefail
+
+# mdq's heading selector is depth-agnostic and matches on text: "# /^[0-9]/"
+# picks every version heading (title "Changelog" is excluded) and renders it at
+# its original level (## for versions, ### for sections). awk then keeps only
+# the first block's body: it counts the rendered "## <digit>" version headings
+# (so a "## foo" section or code line is not mistaken for a boundary) and prints
+# lines while inside the first one. sed trims the leading blank line left by the
+# stripped heading.
+mdq --no-br '# /^[0-9]/' CHANGELOG.md \
+  | awk '/^## [0-9]/{ c++; next } c==1' \
+  | sed -e '/./,$!d'


### PR DESCRIPTION
Run `make release-notes` locally to see the output.