### PR TITLE
ci: Remove unused env vars from PR/Main GitHub workflows

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -6,26 +6,6 @@ on:
       - main
       - develop
   workflow_dispatch:
-env:
-  REDISCLOUD_URL: ${{ secrets.REDISCLOUD_URL_STAGING }}
-  AWS_TEST_CLOUD_ACCOUNT_NAME: "${{ secrets.AWS_TEST_CLOUD_ACCOUNT_NAME_STAGING }}"
-  AWS_PEERING_REGION: ${{ secrets.AWS_PEERING_REGION }}
-  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-  AWS_VPC_CIDR: ${{ secrets.AWS_VPC_CIDR }}
-  AWS_VPC_ID: ${{ secrets.AWS_VPC_ID }}
-  AWS_TEST_TGW_ID: ${{ secrets.AWS_TEST_TGW_ID_STAGING }}
-  TF_ACC: true
-  TF_LOG: info
-  AWS_ACCESS_KEY_ID: ${{ secrets.CLOUD_ACCOUNT_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUD_ACCOUNT_SECRET }}
-  AWS_CONSOLE_USERNAME: ${{ secrets.CLOUD_ACCOUNT_USERNAME }}
-  AWS_CONSOLE_PASSWORD: ${{ secrets.CLOUD_ACCOUNT_PASS }}
-  AWS_SIGNIN_URL: ${{ secrets.CLOUD_ACCOUNT_URL }}
-  GCP_VPC_PROJECT: ${{ secrets.GCP_VPC_PROJECT }}
-  GCP_VPC_ID: ${{ secrets.GCP_VPC_ID }}
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-  TEST_RESOURCE_PREFIX: "tf-ci-main-${{ github.run_number }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -6,26 +6,6 @@ on:
       - main
       - develop
       - 'release/*'
-env:
-  REDISCLOUD_URL: ${{ secrets.REDISCLOUD_URL_STAGING }}
-  AWS_TEST_CLOUD_ACCOUNT_NAME: "${{ secrets.AWS_TEST_CLOUD_ACCOUNT_NAME_STAGING }}"
-  AWS_PEERING_REGION: ${{ secrets.AWS_PEERING_REGION }}
-  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-  AWS_VPC_CIDR: ${{ secrets.AWS_VPC_CIDR }}
-  AWS_VPC_ID: ${{ secrets.AWS_VPC_ID }}
-  AWS_TEST_TGW_ID: ${{ secrets.AWS_TEST_TGW_ID_STAGING }}
-  TF_ACC: true
-  TF_LOG: info
-  AWS_ACCESS_KEY_ID: ${{ secrets.CLOUD_ACCOUNT_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUD_ACCOUNT_SECRET }}
-  AWS_CONSOLE_USERNAME: ${{ secrets.CLOUD_ACCOUNT_USERNAME }}
-  AWS_CONSOLE_PASSWORD: ${{ secrets.CLOUD_ACCOUNT_PASS }}
-  AWS_SIGNIN_URL: ${{ secrets.CLOUD_ACCOUNT_URL }}
-  GCP_VPC_PROJECT: ${{ secrets.GCP_VPC_PROJECT }}
-  GCP_VPC_ID: ${{ secrets.GCP_VPC_ID }}
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-  TEST_RESOURCE_PREFIX: "tf-ci-pr${{ github.event.pull_request.number }}-${{ github.run_number }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Everything is run in the `testacc.yml` workflow, so these environment variables are no longer in use. The `CI` step doesn't care about any of them and there is no pre/post sweep as part of the _WHOLE_ `PR` workflow.