### PR TITLE
ci: Stagger ephemeral account creation in PR/main GitHub workflows

### DIFF
--- a/.github/workflows/terraform_provider_main.yml
+++ b/.github/workflows/terraform_provider_main.yml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Database_.*
+      create_account_sleep_seconds: 0
     secrets: inherit
 
   testacc-subscriptions:
@@ -36,6 +37,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloud(Essentials|Pro|ActiveActive)Subscription_.*
+      create_account_sleep_seconds: 30
     secrets: inherit
 
   testacc-subscriptions-tls:
@@ -44,6 +46,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloudSubscriptionTls_.*
+      create_account_sleep_seconds: 60
     secrets: inherit
 
   testacc-essentials-plan:
@@ -52,6 +55,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloudEssentialsPlan_.*
+      create_account_sleep_seconds: 90
     secrets: inherit
 
   testacc-persistence-modules-regions-acl:
@@ -60,6 +64,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloud(DataPersistence|DatabaseModules|Regions|Acl).*
+      create_account_sleep_seconds: 120
     secrets: inherit
 
   testacc-cloud-account:
@@ -68,6 +73,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloud(CloudAccount).*
+      create_account_sleep_seconds: 150
     secrets: inherit
 
   testacc-transit-payment:
@@ -76,4 +82,5 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(DataSource|Resource)RedisCloud(TransitGatewayAttachment|PaymentMethod).*
+      create_account_sleep_seconds: 180
     secrets: inherit

--- a/.github/workflows/terraform_provider_pr.yml
+++ b/.github/workflows/terraform_provider_pr.yml
@@ -63,6 +63,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudActiveActiveSubscription_CRUDI
+      create_account_sleep_seconds: 0
     secrets: inherit
 
   testacc-smoke-aa-db:
@@ -71,6 +72,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudActiveActiveDatabase_CRUDI
+      create_account_sleep_seconds: 30
     secrets: inherit
 
   testacc-smoke-aa-regions:
@@ -79,6 +81,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudActiveActiveSubscriptionRegions_CRUDI
+      create_account_sleep_seconds: 60
     secrets: inherit
 
   testacc-smoke-aa-enable-default-user:
@@ -87,6 +90,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudActiveActiveDatabase_enableDefaultUser
+      create_account_sleep_seconds: 90
     secrets: inherit
 
   testacc-smoke-pro-sub:
@@ -95,6 +99,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudProSubscription_CRUDI
+      create_account_sleep_seconds: 120
     secrets: inherit
 
   testacc-smoke-pro-db:
@@ -103,6 +108,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudProDatabase_CRUDI
+      create_account_sleep_seconds: 150
     secrets: inherit
 
   testacc-smoke-essentials-sub:
@@ -111,6 +117,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudEssentialsSubscription
+      create_account_sleep_seconds: 180
     secrets: inherit
 
 
@@ -120,6 +127,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudEssentialsDatabase_CRUDI
+      create_account_sleep_seconds: 210
     secrets: inherit
 
   testacc-smoke-misc:
@@ -128,6 +136,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloud(PrivateServiceConnect_CRUDI|AclRule_CRUDI)
+      create_account_sleep_seconds: 240
     secrets: inherit
 
   testacc-pro-db-upgrade:
@@ -136,6 +145,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAccResourceRedisCloudProDatabase_Redis8_Upgrade
+      create_account_sleep_seconds: 270
     secrets: inherit
 
   testacc-block-public-endpoints:
@@ -144,6 +154,7 @@ jobs:
     uses: ./.github/workflows/testacc.yml
     with:
       test_pattern: TestAcc(RedisCloudProDatabase_BlockPublicEndpoints|ActiveActiveSubscriptionDatabase_BlockPublicEndpoints)
+      create_account_sleep_seconds: 300
     secrets: inherit
 
   status:

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -18,6 +18,10 @@ on:
         description: 'Test pattern passed to the -run flag'
         required: true
         type: string
+      create_account_sleep_seconds:
+        description: 'Seconds to sleep (stagger) ephemeral account creation'
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -94,6 +98,12 @@ jobs:
           age-keygen -o "$RUNNER_TEMP/age-key.txt"
           public_key=$(age-keygen -y "$RUNNER_TEMP/age-key.txt")
           echo "public_key=$public_key" >> "$GITHUB_OUTPUT"
+
+      - name: Stagger ephemeral account creation
+        shell: bash
+        env:
+          OFFSET_SECONDS: ${{ inputs.create_account_sleep_seconds }}
+        run: sleep "$OFFSET_SECONDS"
 
       # Ask the private repo to provision an account and encrypt its credentials
       # with our public key. Waits for the run and exposes its runId.


### PR DESCRIPTION
Some intermittent errors occur when creating multiple account creations concurrently.

Playing around with batch size of 4 with 65 seconds in between.