### PR TITLE
tests: Skip Redis 8 modules blocked test

### DIFF
--- a/provider/resource_rediscloud_pro_database_redis_8_test.go
+++ b/provider/resource_rediscloud_pro_database_redis_8_test.go
@@ -330,6 +330,7 @@ func TestAccResourceRedisCloudProDatabase_Redis8_Upgrade(t *testing.T) {
 
 // Test that modules cannot be set on Redis 8.x
 func TestAccResourceRedisCloudProDatabase_Redis8_ModulesBlocked(t *testing.T) {
+	t.Skip("modules + Redis 8.0+ currently emits a warning, not a hard error; revive when block behaviour is implemented")
 
 	name := testRandomWithPrefix()
 	password := acctest.RandString(20)


### PR DESCRIPTION
Redis 8 shows a warning, exercised here: https://github.com/RedisLabs/terraform-provider-rediscloud/blob/main/provider/pro/resource_rediscloud_pro_database_validation_test.go