### PR TITLE
tests: Fix Redis Active-Active database state drift for "redis_version_actual" field

### DIFF
--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -234,6 +234,9 @@ func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ resource.Sche
 			"redis_version_actual": schema.StringAttribute{
 				Description: "The actual Redis database version",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"support_oss_cluster_api": schema.BoolAttribute{
 				Description: "Support Redis open-source (OSS) Cluster API",


### PR DESCRIPTION
In *Plugin framework* a `Computed` attribute goes (known after apply) on every in-place update.
`UseStateForUnknown()` exists precisely to restore the SDKv2 behavior.