### PR TITLE
tests: Run all tests without TFACC=1

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ TEST_PARALLELISM?=6
         build clean install-local \
         fmt fmt-golangci fmt-terraform \
         lint lint-golangci lint-terraform lint-tfproviderlint lint-docs lint-goreleaser lint-markdown \
-        ci govulncheck go-mod-tidy go-build go-build-tests go-unit-test terraform-providers-schema \
+        ci govulncheck go-mod-tidy go-build go-test terraform-providers-schema \
         testacc testacc-essentials testacc-check \
         sweep \
         release-notes release
@@ -76,7 +76,7 @@ lint-markdown:
 	@echo "Linting Markdown"
 	markdownlint-cli2
 
-ci: govulncheck go-mod-tidy lint go-build go-build-tests go-unit-test terraform-providers-schema
+ci: govulncheck go-mod-tidy lint go-build go-test terraform-providers-schema
 	@echo "All local CI checks passed"
 
 govulncheck:
@@ -92,13 +92,9 @@ go-build: bin
 	mkdir -p $(CI_PLUGIN_DIR)/$(PLUGINS_PROVIDER_PATH)
 	go build -o $(CI_PLUGIN_DIR)/$(PLUGINS_PROVIDER_PATH)/terraform-provider-rediscloud .
 
-go-build-tests:
-	@echo "Building test packages"
-	go test ./... -run="^$$"
-
-go-unit-test:
-	@echo "Running unit tests"
-	go test ./... -run="^TestUnit"
+go-test:
+	@echo "Running tests"
+	go test ./...
 
 terraform-providers-schema: go-build
 	@echo "Generating provider schema"

--- a/provider/peering/testdata/active_active_peering_aws.tf
+++ b/provider/peering/testdata/active_active_peering_aws.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 variable "subscription_name" {
   type = string
 }

--- a/provider/pro/testdata/cmk_aws_step1.tf
+++ b/provider/pro/testdata/cmk_aws_step1.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }

--- a/provider/pro/testdata/cmk_aws_step2.tf
+++ b/provider/pro/testdata/cmk_aws_step2.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 variable "name" {
   type = string
 }

--- a/provider/resource_rediscloud_active_active_subscription_peering_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering_test.go
@@ -26,18 +26,12 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_aws(t *testing.T) 
 	const resourceName = "rediscloud_active_active_subscription_peering.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, envchecks.AWSProviderCheck),
-		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {
-				Source:            "hashicorp/aws",
-				VersionConstraint: "~> 5.0",
-			},
-		},
+		PreCheck:     envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, envchecks.AWSProviderCheck),
 		CheckDestroy: testAccCheckActiveActiveSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				ConfigFile: config.StaticFile("./peering/testdata/active_active_peering_aws.tf"),
+				ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+				ConfigFile:               config.StaticFile("./peering/testdata/active_active_peering_aws.tf"),
 				ConfigVariables: config.Variables{
 					"subscription_name": config.StringVariable(name),
 					"aws_region":        config.StringVariable(awsRegion),
@@ -57,9 +51,10 @@ func TestAccResourceRedisCloudActiveActiveSubscriptionPeering_aws(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
 			},
 		},
 	})

--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -81,13 +81,7 @@ func TestAccResourceRedisCloudProSubscription_CMK_AWS(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, envchecks.AWSProviderCheck),
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {
-				Source:            "hashicorp/aws",
-				VersionConstraint: "~> 5.0",
-			},
-		},
-		CheckDestroy: testAccCheckProSubscriptionDestroy,
+		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Step 1: subscription enters encryption_key_pending; KMS key policy

--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -79,16 +79,16 @@ func TestAccResourceRedisCloudProSubscription_CMK_AWS(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, envchecks.AWSProviderCheck),
-		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
-		CheckDestroy:             testAccCheckProSubscriptionDestroy,
+		PreCheck:     envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, envchecks.AWSProviderCheck),
+		CheckDestroy: testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Step 1: subscription enters encryption_key_pending; KMS key policy
 				// references the role ARN returned by the subscription.
-				ConfigFile:         config.StaticFile("./pro/testdata/cmk_aws_step1.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+				ConfigFile:               config.StaticFile("./pro/testdata/cmk_aws_step1.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),
@@ -103,9 +103,10 @@ func TestAccResourceRedisCloudProSubscription_CMK_AWS(t *testing.T) {
 			},
 			{
 				// Step 2: subscription supplies the KMS key ARN and transitions to active.
-				ConfigFile:         config.StaticFile("./pro/testdata/cmk_aws_step2.tf"),
-				ConfigVariables:    configVars,
-				ExpectNonEmptyPlan: true,
+				ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
+				ConfigFile:               config.StaticFile("./pro/testdata/cmk_aws_step2.tf"),
+				ConfigVariables:          configVars,
+				ExpectNonEmptyPlan:       true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_managed_key_aws_role_arn"),

--- a/provider/resource_rediscloud_subscription_peering_test.go
+++ b/provider/resource_rediscloud_subscription_peering_test.go
@@ -19,22 +19,13 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 	cloudAccountName, cloudAccountCheck := envchecks.AWSBYOCValueAndCheck()
 	awsPeering, awsPeeringCheck := envchecks.AwsPeeringValueAndCheck()
 
-	// Chose a CIDR range for the subscription that's unlikely to overlap with any VPC CIDR
+	// Chose a CIDR range for the subscription that's unlikely to overlap with the peer VPC.
+	// Env format is validated in PreCheck; offline the env is empty and the test skips at the
+	// TF_ACC gate, so tolerate an empty/invalid AWS_VPC_CIDR here rather than failing early.
 	subCidrRange := "10.0.0.0/24"
-
-	overlap, err := cidrRangesOverlap(subCidrRange, awsPeering.VpcCidr)
-	if err != nil {
-		t.Fatalf("AWS_VPC_CIDR is not a valid CIDR range %s: %s", awsPeering.VpcCidr, err)
-	}
-	if overlap {
+	if overlap, err := cidrRangesOverlap(subCidrRange, awsPeering.VpcCidr); err == nil && overlap {
 		subCidrRange = "172.16.0.0/24"
 	}
-
-	matchesRegex(t, awsPeering.Region, "^[a-z]+-[a-z]+-\\d+$")
-
-	matchesRegex(t, awsPeering.AccountId, "^\\d+$")
-
-	matchesRegex(t, awsPeering.VpcId, "^vpc-[a-z\\d]+$")
 
 	tf := fmt.Sprintf(testAccResourceRedisCloudSubscriptionPeeringAWS,
 		cloudAccountName,
@@ -48,7 +39,23 @@ func TestAccResourceRedisCloudSubscriptionPeering_aws(t *testing.T) {
 	const resourceName = "rediscloud_subscription_peering.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, awsPeeringCheck, cloudAccountCheck),
+		PreCheck: envchecks.ComposePreChecks(t,
+			envchecks.RedisCloudCheck,
+			awsPeeringCheck,
+			cloudAccountCheck,
+			// Validate env-var formats here (after the TF_ACC gate) so the test skips
+			// cleanly offline instead of t.Fatal-ing in the test body.
+			func(t *testing.T) bool {
+				if _, err := cidrRangesOverlap("10.0.0.0/24", awsPeering.VpcCidr); err != nil {
+					t.Errorf("AWS_VPC_CIDR is not a valid CIDR range %q: %s", awsPeering.VpcCidr, err)
+					return false
+				}
+				matchesRegex(t, awsPeering.Region, "^[a-z]+-[a-z]+-\\d+$")
+				matchesRegex(t, awsPeering.AccountId, "^\\d+$")
+				matchesRegex(t, awsPeering.VpcId, "^vpc-[a-z\\d]+$")
+				return true
+			},
+		),
 		ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories(),
 		CheckDestroy:             testAccCheckProSubscriptionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
This way it's hard to miss tests that should be unit tests. Also, TF validation runs without the actual test steps (`TF_ACC` is not set).