### PR TITLE
tests: Skip GCP CMK acceptance test

### DIFF
--- a/provider/resource_rediscloud_pro_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_pro_subscription_cmk_test.go
@@ -13,8 +13,9 @@ import (
 
 // TestAccResourceRedisCloudProSubscription_CMK is a semi-automated test that requires the user to pause midway through
 // to give the CMK the necessary permissions.
-// TODO: integrate the GCP provider and set up these permissions automatically
+// TODO(tests): integrate the GCP provider and set up these permissions automatically
 func TestAccResourceRedisCloudProSubscription_CMK(t *testing.T) {
+	t.Skip("developer-only: GCP_CMK_RESOURCE_NAME is not provided by CI (nor set anywhere in the repo) and the test needs a manual mid-run pause to grant CMK permissions; run locally with that var set. TODO: automate via the GCP provider (see above)")
 
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"


### PR DESCRIPTION
`GCP_CMK_RESOURCE_NAME` is not setup in GitHub Actions secrets.