### PR TITLE
tests: Fix fmt.Sprinf string interpolation for Redis Pro database data source test

### DIFF
--- a/provider/datasource_rediscloud_pro_subscription_test.go
+++ b/provider/datasource_rediscloud_pro_subscription_test.go
@@ -84,7 +84,7 @@ func TestAccDataSourceRedisCloudProSubscription_ignoresAA(t *testing.T) {
 	password := acctest.RandString(20)
 
 	config := utils.GetTestConfig(t, AADatabaseProDatasourceConfigPath)
-	config = fmt.Sprintf(config, name+"-subscription", name+"-database", password)
+	config = fmt.Sprintf(config, name+"-subscription", password)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck),


### PR DESCRIPTION
Only 2 `%s` in the respective file: https://github.com/RedisLabs/terraform-provider-rediscloud/blob/release/2.19.0/provider/pro/testdata/active_active_database_with_pro_data_source.tf