### PR TITLE
tests: Skip GCP CMK tests

### DIFF
--- a/provider/pro/rediscloud_pro_subscription_cmk_test.go
+++ b/provider/pro/rediscloud_pro_subscription_cmk_test.go
@@ -21,6 +21,8 @@ import (
 // TestAccRedisCloudProSubscription_CMK is a fully automated CMK test that uses the GCP provider
 // to create KMS keys and grant IAM permissions automatically.
 func TestAccRedisCloudProSubscription_CMK(t *testing.T) {
+	t.Skip("developer-only: GCP CMK is not supported in CI. The CI service account behind GOOGLE_CREDENTIALS lacks `cloudkms.keyRings.create` on the test project, so the in-fixture key ring cannot be created. Run locally with credentials holding roles/cloudkms.admin.")
+
 	name := utils.RandomWithPrefix()
 	const resourceName = "rediscloud_subscription.example"
 	gcpProjectId := os.Getenv("GCP_PROJECT_ID")

--- a/provider/resource_rediscloud_active_active_subscription_cmk_test.go
+++ b/provider/resource_rediscloud_active_active_subscription_cmk_test.go
@@ -21,6 +21,7 @@ import (
 // TestAccResourceRedisCloudActiveActiveSubscription_CMK is a fully automated CMK test
 // that uses the GCP provider to create KMS keys and grant IAM permissions automatically.
 func TestAccResourceRedisCloudActiveActiveSubscription_CMK(t *testing.T) {
+	t.Skip("developer-only: GCP CMK is not supported in CI. The CI service account behind GOOGLE_CREDENTIALS lacks `cloudkms.keyRings.create` on the test project, so the in-fixture key ring cannot be created. Run locally with credentials holding roles/cloudkms.admin.")
 
 	name := testRandomWithPrefix()
 	const resourceName = "rediscloud_active_active_subscription.example"


### PR DESCRIPTION
The provided credentials don't have the required permissions to create keys in GCP.