### PR TITLE
tests: Add Active-Active Database unit tests with fully mocked backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.52.1
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/provider/activeactive/active_active_database_unit_test.go
+++ b/provider/activeactive/active_active_database_unit_test.go
@@ -1,0 +1,414 @@
+package activeactive_test
+
+// This file exercises redis_version / redis_version_actual end-to-end through Terraform's plan/apply
+// pipeline, WITHOUT provisioning any real infrastructure.
+//
+// It drives the REAL resource — activeactive.NewActiveActiveDatabaseResource — against the stateful
+// in-memory API in ./mock_aa_api_test.go, so production createDatabase/readDatabase/updateDatabase,
+// the schema's plan modifiers and the nil-state guards all execute. resource.UnitTest runs real
+// Terraform against it, catching plan idempotency and plan/apply consistency behaviour that direct
+// PlanModifyString calls cannot.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/activeactive"
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
+)
+
+const aaResourceName = "test_active_active_subscription_database.aa_db"
+
+type planCheckFunc func(context.Context, plancheck.CheckPlanRequest, *plancheck.CheckPlanResponse)
+
+func (f planCheckFunc) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	f(ctx, req, resp)
+}
+
+// newAAFixture returns a fixture with one subscription registered, the provider factories wired to it,
+// and that subscription's id for use in configs.
+func newAAFixture(t *testing.T) (*mockAAAPI, map[string]func() (tfprotov5.ProviderServer, error), int) {
+	t.Helper()
+
+	api := newMockAAAPI()
+	subID := api.addSubscription()
+
+	apiClient, err := testhelpers.MockAPIClient(api.buildMock())
+	require.NoError(t, err)
+
+	return api, testhelpers.FrameworkProviderFactoriesWithData(
+		apiClient,
+		activeactive.NewActiveActiveDatabaseResource,
+	), subID
+}
+
+// Configs set global_password even though no test asserts anything about it — see
+// BEHAVIOUR(global_password) at the bottom of this file. Without it, every step that plans an update
+// also plans that attribute as unknown, which defeats any empty-plan assertion this file wants to make.
+func newAADatabaseConfig(subID int, redisVersion string) string {
+	return fmt.Sprintf(`resource "test_active_active_subscription_database" "aa_db" {
+  subscription_id    = %d
+  name               = "aa-db"
+  dataset_size_in_gb = 1
+  global_password    = "test-password"
+  redis_version      = %q
+}`, subID, redisVersion)
+}
+
+func newAADatabaseConfigNoVersion(subID int) string {
+	return fmt.Sprintf(`resource "test_active_active_subscription_database" "aa_db" {
+  subscription_id    = %d
+  name               = "aa-db"
+  dataset_size_in_gb = 1
+  global_password    = "test-password"
+}`, subID)
+}
+
+// newAADatabaseConfigNoPassword leaves global_password out — the default configuration, where the API
+// generates it. Only the test exercising BEHAVIOUR(global_password) uses this; every other config sets
+// it, for the reason described there.
+func newAADatabaseConfigNoPassword(subID int, name string) string {
+	return fmt.Sprintf(`resource "test_active_active_subscription_database" "aa_db" {
+  subscription_id    = %d
+  name               = %q
+  dataset_size_in_gb = 1
+  redis_version      = "8.2"
+}`, subID, name)
+}
+
+func newAADatabaseConfigNamed(subID int, name, redisVersion string) string {
+	return fmt.Sprintf(`resource "test_active_active_subscription_database" "aa_db" {
+  subscription_id    = %d
+  name               = %q
+  dataset_size_in_gb = 1
+  global_password    = "test-password"
+  redis_version      = %q
+}`, subID, name, redisVersion)
+}
+
+func TestUnitActiveActiveDatabaseVersion_DefaultsWhenOmitted(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfigNoVersion(subID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", defaultRedisVersion),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", defaultRedisVersion),
+				),
+			},
+			{
+				Config: newAADatabaseConfigNoVersion(subID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply:             []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+
+	// The version a database is created at goes to the create API, never to the upgrade endpoint, and
+	// the second step is a no-op — so nothing here should reach UpgradeRedisVersion.
+	assert.Empty(t, api.requestedUpgrades())
+}
+
+func TestUnitActiveActiveDatabaseVersion_SatisfiedRequestIsNoOp(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig(subID, "8.4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.4"),
+				),
+			},
+			{
+				Config: newAADatabaseConfig(subID, "8.2"), // lower than the running 8.4 -> satisfied
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					// redis_version is Optional+Computed and set in config, so the config value lands in
+					// state — this is a real update, not a suppressed one.
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// State records what the user asked for; redis_version_actual still reports what the
+					// database is running.
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.4"),
+				),
+			},
+		},
+	})
+
+	// BUG: state follows config, but the provider ALSO asks the API to move a database running 8.4 down
+	// to 8.2. updateDatabase's version guard compares plan.RedisVersion against state's redis_version and
+	// redis_version_actual with exact string inequality, so a request below the running version clears it
+	// just as readily as an upgrade. Nothing on that path compares versions.
+	//
+	// State stays coherent only because the API ignores a target it has already passed — which is an
+	// assumption this fixture encodes, not something verified. The correct value here is an empty slice.
+	assert.Equal(t, []string{"8.2"}, api.requestedUpgrades())
+}
+
+// BUG(redis_version_actual): a genuine upgrade cannot be applied at all.
+//
+// redis_version_actual is Computed and carries only stringplanmodifier.UseStateForUnknown, so the
+// planned value is pinned to the PRIOR running version. Apply then performs the upgrade and
+// readDatabase writes the new running version, contradicting the plan, and Terraform rejects that as a
+// provider bug. This step encodes the failure so it is pinned rather than latent.
+//
+// To fix: give redis_version_actual a plan modifier that leaves the value unknown when the planned
+// redis_version is a genuine upgrade, then drop ExpectError and assert instead that the step plans an
+// update, converges to an empty plan, and leaves both attributes at 8.4.
+func TestUnitActiveActiveDatabaseVersion_GenuineUpgrade(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig(subID, "8.2"),
+				Check:  resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.2"),
+			},
+			{
+				Config: newAADatabaseConfig(subID, "8.4"), // higher than the running 8.2 -> genuine upgrade
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					// No PostApply checks: apply fails, so they would never run.
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ExpectError: regexp.MustCompile(`(?s)Provider produced inconsistent result after apply.*` +
+					`\.redis_version_actual: was cty\.StringVal\("8\.2"\),\s+but\s+now cty\.StringVal\("8\.4"\)`),
+			},
+		},
+	})
+
+	// The one path that SHOULD reach the upgrade endpoint: exactly one request, for the version config
+	// asked for — not skipped, not repeated.
+	assert.Equal(t, []string{"8.4"}, api.requestedUpgrades())
+}
+
+// A background auto-upgrade moves the running version past the requested one; a subsequent config
+// change to a still-lower version must be a no-op, never an in-place downgrade.
+func TestUnitActiveActiveDatabaseVersion_BackgroundUpgradeThenLowerRequestIsNoOp(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig(subID, "8.2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.2"),
+				),
+			},
+			{
+				PreConfig: func() {
+					api.setRunningVersion("8.6") // simulate a background auto minor upgrade
+				},
+				Config: newAADatabaseConfig(subID, "8.4"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					// The config change from 8.2 to 8.4 is a real update: redis_version is Optional+Computed
+					// and set, so state follows config even though the running 8.6 already satisfies it.
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// State records the requested 8.4; redis_version_actual keeps the 8.6 the background
+					// upgrade moved it to. Crucially the database is NOT moved back down to 8.4.
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.6"),
+				),
+			},
+		},
+	})
+
+	// BUG: same exact-string guard as SatisfiedRequestIsNoOp, in the scenario this resource most needs to
+	// get right. A background auto minor upgrade took the database to 8.6, the customer asked for 8.4,
+	// and the provider responds by requesting 8.4 — an in-place downgrade. redis_version_actual stays 8.6
+	// only because the fixture models the API refusing it. The correct value here is an empty slice.
+	assert.Equal(t, []string{"8.4"}, api.requestedUpgrades())
+}
+
+// Changing an attribute other than redis_version must not touch the version endpoint. The guard's
+// first half (planned redis_version differs from prior state) is what prevents it, and this is the
+// only test that exercises a non-version update at all.
+func TestUnitActiveActiveDatabaseVersion_UnrelatedChangeDoesNotUpgrade(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfigNamed(subID, "aa-db", "8.2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.2"),
+				),
+			},
+			{
+				// Rename only — redis_version is untouched.
+				Config: newAADatabaseConfigNamed(subID, "aa-db-renamed", "8.2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+						// Asserted on the PLAN, not just on state after apply: the point is that neither
+						// version attribute goes unknown ("known after apply") on an update that has nothing
+						// to do with versions. A post-apply state check cannot see that — the state value is
+						// 8.2 either way — so without these two checks, removing the plan modifier from
+						// redis_version_actual would only be caught by GenuineUpgrade.
+						plancheck.ExpectKnownValue(aaResourceName, tfjsonpath.New("redis_version"), knownvalue.StringExact("8.2")),
+						plancheck.ExpectKnownValue(aaResourceName, tfjsonpath.New("redis_version_actual"), knownvalue.StringExact("8.2")),
+					},
+					PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "name", "aa-db-renamed"),
+					// Both version attributes stay put.
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.2"),
+				),
+			},
+		},
+	})
+
+	assert.Empty(t, api.requestedUpgrades())
+}
+
+// A background auto-upgrade can land after Terraform has saved the plan but before apply. Since
+// redis_version_actual is pinned to its prior value for an unrelated update, the read after apply
+// contradicts that plan. A PreApply plan check provides the exact boundary needed to reproduce the
+// race: the saved plan contains 8.2, then the fixture starts reporting 8.4 before apply begins.
+func TestUnitActiveActiveDatabaseVersion_BackgroundUpgradeAfterPlanIsInconsistent(t *testing.T) {
+	api, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfigNamed(subID, "aa-db", "8.2"),
+				Check:  resource.TestCheckResourceAttr(aaResourceName, "redis_version_actual", "8.2"),
+			},
+			{
+				Config: newAADatabaseConfigNamed(subID, "aa-db-renamed", "8.2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+						planCheckFunc(func(_ context.Context, _ plancheck.CheckPlanRequest, _ *plancheck.CheckPlanResponse) {
+							api.setRunningVersion("8.4")
+						}),
+					},
+				},
+				ExpectError: regexp.MustCompile(`(?s)Provider produced inconsistent result after apply.*redis_version_actual.*8\.2.*8\.4`),
+			},
+		},
+	})
+
+	assert.Empty(t, api.requestedUpgrades())
+}
+
+// BEHAVIOUR(global_password): in the DEFAULT configuration — no global_password in config and not
+// passwordless, so the API generates one — any plan that changes another attribute also plans
+// global_password as unknown ("known after apply"). Exercised by
+// TestUnitActiveActiveDatabase_GlobalPasswordLeftToAPIIsPlannedUnknown.
+//
+// Whether this is a defect is genuinely unclear, which is why it is recorded rather than judged:
+//   - Arguably correct. The attribute is Optional+Computed and null in config, so Terraform cannot know
+//     what the API will return — it could rotate the password. Marking it unknown is conservative, and it
+//     settles: the plan straight after apply is clean, so this is not drift or a perpetual diff.
+//   - Arguably broken. ModifyPlan (resource_active_active_database.go:597-606) exists specifically to
+//     prevent it, and demonstrably does not. Either that code is unnecessary and should go, or it is
+//     necessary and something is defeating it.
+//
+// What the attribute looks like: Optional+Computed, Sensitive, with no Default and no attribute-level
+// plan modifier — the only such attribute on this resource. The absence is deliberate; the comment on
+// ModifyPlan records that UseStateForUnknown caused "inconsistent values for sensitive attribute" errors
+// on passwordless transitions, so preservation was moved into ModifyPlan by hand.
+//
+// Ruled out by instrumentation and a TF_LOG=trace run, so nobody repeats it:
+//   - state DOES hold the password, and the fixture returns it on every read
+//   - ModifyPlan's preservation branch runs on every invocation with prior state; SetAttribute returns
+//     zero diagnostics; the raw value the provider returns is tftypes.String<"..."> — known, not unknown
+//   - the framework's ordering is correct: MarkComputedNilsAsUnknown, attribute modifiers, ModifyPlan,
+//     then resp.PlannedState = the modified plan, with nothing after it touching the value
+//   - Sensitive: true is NOT the cause — removing it changes nothing
+//   - the "Value switched to prior value due to semantic equality logic" lines in the trace are a red
+//     herring: that message fires whenever newValue equals priorValue (value_semantic_equality.go:90),
+//     and only during ReadResource, not PlanResourceChange
+//
+// So the provider returns a known value and Terraform records after_unknown: true. If this is worth
+// chasing, the next step is a minimal resource with one Optional+Computed Sensitive attribute and a
+// ModifyPlan that preserves it, to establish whether the gap is in terraform-plugin-go's proto conversion
+// or in Terraform core — rather than adding a third workaround here.
+//
+// Practical consequence either way: a test cannot assert a genuinely empty plan for a no-op config change
+// unless global_password is set in config, which is why every config here except
+// newAADatabaseConfigNoPassword sets it.
+//
+// NOT verified against the real API. One thing could differ there: if the API returns the password only
+// on create, readDatabase writes null to state on refresh, which would be a separate and worse problem
+// this fixture cannot reproduce.
+
+// Exercises BEHAVIOUR(global_password) below. In the default configuration — no global_password in config, not
+// passwordless, so the API generates one — any plan that changes another attribute ALSO shows
+// global_password as "known after apply", because the framework marks computed attributes unknown
+// whenever config leaves them null. Here the change is a rename: nothing to do with versions.
+//
+// Scope, verified rather than assumed: this is confined to the plan of a step that changes something.
+// The plan straight after apply is CLEAN — asserted below — so it is not drift or a perpetual diff.
+func TestUnitActiveActiveDatabase_GlobalPasswordLeftToAPIIsPlannedUnknown(t *testing.T) {
+	_, factories, subID := newAAFixture(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfigNoPassword(subID, "aa-db"),
+				// The generated password IS persisted, so a missing state value is not the cause.
+				Check: resource.TestCheckResourceAttrSet(aaResourceName, "global_password"),
+			},
+			{
+				Config: newAADatabaseConfigNoPassword(subID, "aa-db-renamed"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(aaResourceName, plancheck.ResourceActionUpdate),
+						// The bug: nothing in config or state justifies this being unknown.
+						plancheck.ExpectUnknownValue(aaResourceName, tfjsonpath.New("global_password")),
+					},
+					// And it settles: once there is nothing else to change, the plan is clean.
+					PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(aaResourceName, "name", "aa-db-renamed"),
+					resource.TestCheckResourceAttrSet(aaResourceName, "global_password"),
+				),
+			},
+		},
+	})
+}

--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -297,11 +297,12 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 // waitForDatabaseToBeDeleted waits for the database to be deleted using retry.StateChangeConf.
 func waitForDatabaseToBeDeleted(ctx context.Context, subId, dbId int, api *client.ApiClient) error {
 	wait := &retry.StateChangeConf{
-		Delay:        30 * time.Second,
+		// 30s, not the 10s the other waiters use — deletion is slower to settle.
+		Delay:        api.WaitDelay(30 * time.Second),
 		Pending:      []string{"pending"},
 		Target:       []string{"deleted"},
 		Timeout:      10 * time.Minute,
-		PollInterval: 30 * time.Second,
+		PollInterval: api.WaitPollInterval(30 * time.Second),
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for database %d to be deleted", dbId)

--- a/provider/activeactive/mock_aa_api_test.go
+++ b/provider/activeactive/mock_aa_api_test.go
@@ -1,0 +1,288 @@
+package activeactive_test
+
+// A stateful in-memory Redis Cloud API for Active-Active databases, wired to the real resource via
+// testhelpers.MockAPI. Tests drive activeactive.NewActiveActiveDatabaseResource against it, so
+// production Create/Read/Update/Delete, plan modifiers and guards all execute for real.
+//
+// A fixture holds ONE subscription and ONE database, because a Terraform test drives one resource of a
+// given type. Ids come from a counter rather than being hardcoded, so they are obviously synthetic in
+// failure output and two fixtures in the same run never collide.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
+)
+
+const (
+	// defaultRedisVersion is the version the API picks when a create request omits redisVersion.
+	defaultRedisVersion = "8.0"
+)
+
+type mockDatabase struct {
+	id   int
+	name string
+	// globalPassword is whatever the last create/update request supplied, or a generated value when the
+	// create request omitted one. Echoed back on read: returning some other value would contradict the
+	// plan, since the provider planned the password it sent — "inconsistent values for sensitive
+	// attribute".
+	globalPassword string
+	// redisVersion is the version the database is actually RUNNING — the value the API reports back,
+	// which redis_version_actual reflects. Tests mutate it directly to simulate a background auto minor
+	// upgrade moving it out from under Terraform.
+	redisVersion string
+}
+
+// mockAAAPI holds the fixture's state.
+//
+// No mutex of its own: testhelpers.MockAPI serialises handler invocation, so handlers may touch this
+// freely. The two methods a test calls from its own goroutine go through MockAPI.Locked.
+type mockAAAPI struct {
+	mock *testhelpers.MockAPI
+
+	nextID int
+	subID  int
+	// database is nil before create and after delete. Nil is what lets deleteDatabase's wait terminate:
+	// it polls until the API 404s, so a fixture that kept answering 200 would spin until the wait's
+	// timeout.
+	database *mockDatabase
+
+	// upgradeRequests records every target passed to the version-upgrade endpoint, in order, whether or
+	// not the API honoured it. A rejected downgrade is indistinguishable from a request never sent if
+	// you only look at resulting state, so this is what lets a test prove the provider asked for
+	// something it should not have.
+	upgradeRequests []string
+}
+
+func newMockAAAPI() *mockAAAPI {
+	// Start high enough that ids are never mistaken for array indices or for the small numbers that
+	// appear in fixtures.
+	return &mockAAAPI{mock: testhelpers.NewMockAPI(), nextID: 1000}
+}
+
+func (a *mockAAAPI) allocID() int {
+	a.nextID++
+	return a.nextID
+}
+
+// addSubscription registers the fixture's subscription and returns its id, for use in a config.
+func (a *mockAAAPI) addSubscription() int {
+	a.mock.Locked(func() { a.subID = a.allocID() })
+	return a.subID
+}
+
+// setRunningVersion simulates the running version changing out from under Terraform, e.g. a background
+// auto minor upgrade.
+func (a *mockAAAPI) setRunningVersion(redisVersion string) {
+	a.mock.Locked(func() { a.database.redisVersion = redisVersion })
+}
+
+func (a *mockAAAPI) requestedUpgrades() (targets []string) {
+	a.mock.Locked(func() { targets = a.upgradeRequests })
+	return targets
+}
+
+// requestedDatabase returns the fixture's database if the request addresses it, or NotFound. The id check
+// is what would catch the provider addressing the wrong resource — a parseResourceId bug, say — rather
+// than silently operating on the only database there is.
+func (a *mockAAAPI) requestedDatabase(r *http.Request) (*mockDatabase, error) {
+	if a.database == nil || pathInt(r, "dbID") != a.database.id {
+		return nil, testhelpers.NotFound()
+	}
+	return a.database, nil
+}
+
+// mock builds the MockAPI serving this fixture's state.
+func (a *mockAAAPI) buildMock() *testhelpers.MockAPI {
+	mock := a.mock
+
+	// Subscription status, polled by WaitForSubscriptionToBeActive.
+	mock.Handle("GET /subscriptions/{subID}", func(r *http.Request) (any, error) {
+
+		if pathInt(r, "subID") != a.subID {
+			return nil, testhelpers.NotFound()
+		}
+		return map[string]any{"id": a.subID, "status": "active"}, nil
+	})
+
+	// Regions, listed during createDatabase to build localThroughputMeasurement.
+	mock.Handle("GET /subscriptions/{subID}/regions", func(r *http.Request) (any, error) {
+		return map[string]any{
+			"subscriptionId": pathInt(r, "subID"),
+			"regions": []map[string]any{
+				{"region": "us-east-1", "networking": []map[string]any{}},
+			},
+		}, nil
+	})
+
+	mock.Handle("POST /subscriptions/{subID}/databases", func(r *http.Request) (any, error) {
+		var body struct {
+			Name         string  `json:"name"`
+			RedisVersion string  `json:"redisVersion"`
+			Password     *string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			return nil, fmt.Errorf("decoding create request: %w", err)
+		}
+
+		// Mirror the real create API: when redisVersion is omitted the database is created at a
+		// server-chosen default rather than failing.
+		running := body.RedisVersion
+		if running == "" {
+			running = defaultRedisVersion
+		}
+
+		id := a.allocID()
+
+		// A supplied password is honoured verbatim, including an empty one — createDatabase sends "" to
+		// mean passwordless. Only an absent field means "generate me one", mirroring the real API's "if
+		// left empty, the password will be generated automatically". The generated value is the fixture's
+		// own business: it is per-database, non-empty (an empty password reads back as passwordless), and
+		// no test asserts it.
+		password := fmt.Sprintf("generated-password-%d", id)
+		if body.Password != nil {
+			password = *body.Password
+		}
+
+		a.database = &mockDatabase{
+			id:             id,
+			name:           body.Name,
+			globalPassword: password,
+			redisVersion:   running,
+		}
+
+		return mock.NewTask("databaseCreateRequest", id), nil
+	})
+
+	// Active-Active updates go to the per-database regions endpoint, not the database itself.
+	mock.Handle("PUT /subscriptions/{subID}/databases/{dbID}/regions", func(r *http.Request) (any, error) {
+		var body struct {
+			Name           *string `json:"name"`
+			GlobalPassword *string `json:"globalPassword"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		db, err := a.requestedDatabase(r)
+		if err != nil {
+			return nil, err
+		}
+		// Apply what the request actually asked for. Ignoring it would make the subsequent read report
+		// the old name, contradicting the plan — "Provider produced inconsistent result after apply".
+		if body.Name != nil {
+			db.name = *body.Name
+		}
+		if body.GlobalPassword != nil {
+			db.globalPassword = *body.GlobalPassword
+		}
+		return mock.NewTask("databaseUpdateRequest", db.id), nil
+	})
+
+	// The version-upgrade endpoint. Records every request, then honours it only when it really is an
+	// upgrade: no API moves a live database to a lower version in place.
+	mock.Handle("POST /subscriptions/{subID}/databases/{dbID}/upgrade", func(r *http.Request) (any, error) {
+		var body struct {
+			TargetRedisVersion string `json:"targetRedisVersion"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			return nil, fmt.Errorf("decoding upgrade request: %w", err)
+		}
+
+		db, err := a.requestedDatabase(r)
+		if err != nil {
+			return nil, err
+		}
+
+		a.upgradeRequests = append(a.upgradeRequests, body.TargetRedisVersion)
+
+		if higherVersion(body.TargetRedisVersion, db.redisVersion) {
+			db.redisVersion = body.TargetRedisVersion
+		}
+
+		return mock.NewTask("databaseUpgradeRequest", db.id), nil
+	})
+
+	mock.Handle("PUT /subscriptions/{subID}/databases/{dbID}/tags", func(_ *http.Request) (any, error) {
+		return map[string]any{"tags": []map[string]any{}}, nil
+	})
+
+	mock.Handle("GET /subscriptions/{subID}/databases/{dbID}/tags", func(_ *http.Request) (any, error) {
+		return map[string]any{"tags": []map[string]any{}}, nil
+	})
+
+	mock.Handle("DELETE /subscriptions/{subID}/databases/{dbID}", func(r *http.Request) (any, error) {
+
+		db, err := a.requestedDatabase(r)
+		if err != nil {
+			return nil, err
+		}
+		a.database = nil
+
+		return mock.NewTask("databaseDeleteRequest", db.id), nil
+	})
+
+	// The database, read by GetActiveActive and polled by WaitForDatabaseToBeActive. Every field the
+	// real API always returns has to be present: readDatabase leaves Optional+Computed attributes
+	// unknown if the response omits them, and the framework rejects unknowns after apply.
+	mock.Handle("GET /subscriptions/{subID}/databases/{dbID}", func(r *http.Request) (any, error) {
+
+		db, err := a.requestedDatabase(r)
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]any{
+			"databaseId":                          db.id,
+			"name":                                db.name,
+			"status":                              "active",
+			"redisVersion":                        db.redisVersion,
+			"memoryLimitInGb":                     1,
+			"datasetSizeInGb":                     1,
+			"globalPassword":                      db.globalPassword,
+			"dataEvictionPolicy":                  "volatile-lru",
+			"supportOSSClusterApi":                false,
+			"useExternalEndpointForOSSClusterApi": false,
+			"crdbDatabases": []map[string]any{
+				{
+					"provider":               "AWS",
+					"region":                 "us-east-1",
+					"redisVersionCompliance": db.redisVersion,
+					"publicEndpoint":         "pub.example.com:12000",
+					"privateEndpoint":        "priv.example.com:12000",
+					"dataPersistence":        "none",
+					"security": map[string]any{
+						"enableDefaultUser": true,
+						"sourceIps":         []string{"0.0.0.0/0"},
+					},
+					"alerts": []map[string]any{},
+				},
+			},
+		}, nil
+	})
+
+	return mock
+}
+
+// pathInt reads a {named} path wildcard as an int. Path values are always strings, so numeric ids need
+// converting before they go anywhere near a JSON response.
+func pathInt(r *http.Request, name string) int {
+	var v int
+	_, _ = fmt.Sscanf(r.PathValue(name), "%d", &v)
+	return v
+}
+
+// higherVersion reports whether target is a genuinely higher version than current.
+func higherVersion(target, current string) bool {
+	t, err := version.NewVersion(target)
+	if err != nil {
+		return false
+	}
+	c, err := version.NewVersion(current)
+	if err != nil {
+		return false
+	}
+	return t.GreaterThan(c)
+}

--- a/provider/client/client.go
+++ b/provider/client/client.go
@@ -4,12 +4,47 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	rediscloudApi "github.com/RedisLabs/rediscloud-go-api"
 )
 
 type ApiClient struct {
 	Client *rediscloudApi.Client
+
+	// WaitDelayOverride and WaitPollIntervalOverride replace the corresponding resource-state waiter
+	// timing when non-zero. Production leaves both zero, so each waiter keeps the literal timing at its
+	// own call site — those timings differ per waiter and are not interchangeable, so there is
+	// deliberately no shared default here to flatten them.
+	//
+	// Tests driving an in-memory API set them to something tiny: the fixture answers on the first poll,
+	// so retry.StateChangeConf.Delay — an unconditional sleep before that first poll — is pure dead time.
+	// Carried on the client rather than in package-level state so each test owns its own values, which
+	// keeps parallel tests race-free.
+	//
+	// Zero means "not overridden", so a literal zero cannot be requested. That is not a gap worth
+	// closing with a pointer: use a millisecond. Zero would be marginally faster still — it drops the
+	// pre-poll sleep and puts retry on its exponential backoff rather than a fixed interval — but the
+	// delay is paid once per waiter and the fixture responds immediately, so the difference is
+	// unmeasurable.
+	WaitDelayOverride        time.Duration
+	WaitPollIntervalOverride time.Duration
+}
+
+// WaitDelay returns def, unless a test has overridden the waiter delay.
+func (c *ApiClient) WaitDelay(def time.Duration) time.Duration {
+	if c.WaitDelayOverride > 0 {
+		return c.WaitDelayOverride
+	}
+	return def
+}
+
+// WaitPollInterval returns def, unless a test has overridden the waiter poll interval.
+func (c *ApiClient) WaitPollInterval(def time.Duration) time.Duration {
+	if c.WaitPollIntervalOverride > 0 {
+		return c.WaitPollIntervalOverride
+	}
+	return def
 }
 
 var (

--- a/provider/testhelpers/framework_test_provider.go
+++ b/provider/testhelpers/framework_test_provider.go
@@ -1,0 +1,68 @@
+package testhelpers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+// FrameworkTestProviderTypeName is the provider type name for the throwaway plugin-framework
+// provider built by FrameworkProviderFactories. Resources it serves therefore use type names
+// like "test_<suffix>" (set in their Metadata via req.ProviderTypeName).
+const FrameworkTestProviderTypeName = "test"
+
+type frameworkTestProvider struct {
+	resources    []func() resource.Resource
+	providerData any
+}
+
+var _ provider.Provider = &frameworkTestProvider{}
+
+func (p *frameworkTestProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = FrameworkTestProviderTypeName
+}
+
+func (p *frameworkTestProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{}
+}
+
+func (p *frameworkTestProvider) Configure(_ context.Context, _ provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// Real resources pull their API client out of ProviderData in Configure, so handing them one here
+	// is what lets a test drive the real implementation. Left nil by FrameworkProviderFactories, for
+	// resources that need no client.
+	resp.ResourceData = p.providerData
+	resp.DataSourceData = p.providerData
+}
+
+func (p *frameworkTestProvider) Resources(_ context.Context) []func() resource.Resource {
+	return p.resources
+}
+
+func (p *frameworkTestProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+// FrameworkProviderFactories builds a ProtoV5ProviderFactories map serving a throwaway
+// plugin-framework provider (type name "test") that exposes only the given resources. Use it to
+// unit-test resource/schema behaviour — e.g. plan modifiers — via resource.UnitTest, with no real
+// provider wiring or backend. A fresh map is returned each call to avoid cross-test mutation.
+func FrameworkProviderFactories(resources ...func() resource.Resource) map[string]func() (tfprotov5.ProviderServer, error) {
+	return FrameworkProviderFactoriesWithData(nil, resources...)
+}
+
+// FrameworkProviderFactoriesWithData is FrameworkProviderFactories with providerData supplied to each
+// resource's Configure. Pass a *client.ApiClient built by MockAPIClient to drive real resources
+// against an in-memory API.
+func FrameworkProviderFactoriesWithData(providerData any, resources ...func() resource.Resource) map[string]func() (tfprotov5.ProviderServer, error) {
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		FrameworkTestProviderTypeName: providerserver.NewProtocol5WithError(&frameworkTestProvider{
+			resources:    resources,
+			providerData: providerData,
+		}),
+	}
+}

--- a/provider/testhelpers/mock_api.go
+++ b/provider/testhelpers/mock_api.go
@@ -1,0 +1,252 @@
+package testhelpers
+
+// MockAPI is an in-memory stand-in for the Redis Cloud REST API, injected via the SDK's
+// rediscloudApi.Transporter option. It exists so tests can drive the REAL resource implementations —
+// their Create/Read/Update/Delete, their plan modifiers, their guards — rather than a hand-written
+// test resource that mirrors them and can silently drift.
+//
+// The mock sits at the http.RoundTripper boundary because that is the only seam the SDK offers:
+// rediscloudApi.Client exposes its services as concrete *databases.API, *subscriptions.API and so on,
+// so there is nothing to substitute at the Go level. Nothing listens on a socket — routing runs
+// in-process through an http.ServeMux, whose Go 1.22 patterns give method matching, {named} path
+// wildcards and specificity-based precedence for free.
+//
+// Unmatched requests fail loudly with the method and path, so a test that reaches an unstubbed
+// endpoint tells you exactly which handler to add instead of failing obscurely.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+
+	rediscloudApi "github.com/RedisLabs/rediscloud-go-api"
+	"github.com/google/uuid"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
+)
+
+// MockAPIClient builds a real rediscloud SDK client whose transport is the given MockAPI, wrapped in
+// the *client.ApiClient that resources expect from ProviderData. The SDK's request handling, task
+// polling and model decoding all run for real, against in-memory responses.
+func MockAPIClient(mock *MockAPI) (*client.ApiClient, error) {
+	api, err := rediscloudApi.NewClient(
+		rediscloudApi.Auth("mock-key", "mock-secret"),
+		rediscloudApi.Transporter(mock),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &client.ApiClient{
+		Client: api,
+		// The fixture answers on the first poll, so every waiter's pre-poll delay is dead time and the
+		// interval is never reached.
+		WaitDelayOverride:        time.Millisecond,
+		WaitPollIntervalOverride: time.Millisecond,
+	}, nil
+}
+
+// Handler returns the value to encode as the JSON response body. Read path wildcards with
+// req.PathValue("name"), and the request body from req.Body. Returning an error fails the round trip;
+// returning a StatusError responds with that HTTP status instead.
+type Handler func(req *http.Request) (any, error)
+
+// StatusError makes a handler respond with a non-200 status. Return NotFound() to drive the SDK's
+// 404 handling — which is how the provider detects a deleted resource.
+type StatusError struct {
+	Code int
+	Body any
+}
+
+func (e StatusError) Error() string { return fmt.Sprintf("mock api: HTTP %d", e.Code) }
+
+// NotFound returns a StatusError the SDK maps to its NotFound error types.
+func NotFound() error {
+	return StatusError{Code: http.StatusNotFound, Body: map[string]any{"description": "not found"}}
+}
+
+// MockAPI serves requests registered by ServeMux pattern.
+//
+// Handlers run on goroutines owned by Terraform and the plugin framework — the gRPC server's per-RPC
+// goroutine, and retry.StateChangeConf's separate Refresh goroutine — so nothing about their ordering is
+// the fixture's to control. Terraform's default parallelism is 10, and a config with two resources would
+// genuinely overlap.
+//
+// Two mutexes, never held together:
+//
+//   - handlerMu serialises handler invocation, so a fixture's own state needs no locking of its own.
+//   - mu guards this type's fields below.
+//
+// The one ordering that occurs is handlerMu then mu, because NewTask and the task-poll handler run under
+// handlerMu and take mu inside. RoundTrip releases mu before dispatching, so it never holds both — do not
+// change that to hold mu across dispatch, which would invert the order and deadlock.
+type MockAPI struct {
+	mux *http.ServeMux
+
+	// handlerMu serialises handler invocation. Held only around the handler call.
+	handlerMu sync.Mutex
+
+	// mu guards requests and taskResource.
+	mu sync.Mutex
+	// requests records every request the provider made, in order, as "METHOD /path".
+	requests []string
+	// taskResource maps a task id to the resource id that task resolves to.
+	taskResource map[string]int
+}
+
+func NewMockAPI() *MockAPI {
+	m := &MockAPI{mux: http.NewServeMux(), taskResource: map[string]int{}}
+
+	// Every Redis Cloud mutation is asynchronous: it returns a task id and the SDK polls this endpoint
+	// until the task completes, then reads the resource id out of the response. Registered here rather
+	// than per-fixture because it is protocol, not resource behaviour — see NewTask.
+	m.Handle("GET /tasks/{taskID}", func(r *http.Request) (any, error) {
+		taskID := r.PathValue("taskID")
+
+		// sm-cloud-api types task ids as UUID throughout (RedisRepository.saveTask,
+		// getLatestTaskStatus) and rejects ids that will not parse, so a fixture that accepted other
+		// shapes could let a bug through.
+		if _, err := uuid.Parse(taskID); err != nil {
+			return nil, fmt.Errorf("task id %q is not a UUID: the API types these as UUIDs, so whatever "+
+				"NewTask returned must be round-tripped unchanged: %w", taskID, err)
+		}
+
+		m.mu.Lock()
+		resourceID, ok := m.taskResource[taskID]
+		m.mu.Unlock()
+
+		if !ok {
+			return nil, fmt.Errorf("unknown task %q — tasks must be created with MockAPI.NewTask", taskID)
+		}
+
+		return map[string]any{
+			"taskId":   taskID,
+			"status":   "processing-completed",
+			"response": map[string]any{"resourceId": resourceID},
+		}, nil
+	})
+
+	// Least specific pattern, so it only runs when nothing else matched. 500 rather than 404: a 404 is
+	// meaningful to the SDK (deleted resource), and silently returning one would turn a missing handler
+	// into confusing provider behaviour rather than an obvious test failure.
+	m.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, fmt.Sprintf(
+			"mock api: no handler for %s %s — register one with Handle(%q, ...)",
+			r.Method, r.URL.Path, r.Method+" "+r.URL.Path,
+		), http.StatusInternalServerError)
+	})
+
+	return m
+}
+
+// Handle registers a handler for a ServeMux pattern, e.g.
+// "GET /subscriptions/{subID}/databases/{dbID}". Method matching, {named} wildcards and precedence
+// (most specific pattern wins, regardless of registration order) come from ServeMux; conflicting
+// patterns panic at registration.
+func (m *MockAPI) Handle(pattern string, handler Handler) *MockAPI {
+	m.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		status := http.StatusOK
+
+		m.handlerMu.Lock()
+		payload, err := handler(r)
+		m.handlerMu.Unlock()
+
+		if err != nil {
+			var statusErr StatusError
+			if !errors.As(err, &statusErr) {
+				http.Error(w, fmt.Sprintf("mock api: handler for %s: %v", pattern, err), http.StatusInternalServerError)
+				return
+			}
+			status, payload = statusErr.Code, statusErr.Body
+		}
+
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("mock api: encoding response for %s: %v", pattern, err), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(encoded)
+	})
+	return m
+}
+
+// NewTask registers an asynchronous task resolving to resourceID and returns the body a mutation
+// endpoint should respond with. The SDK then polls GET /tasks/{taskID}, which NewMockAPI already serves,
+// so a fixture only has to return this from its create/update/delete handlers.
+//
+// The id is a UUID, as the real API's is. commandType is echoed back purely for realism; nothing depends on it.
+//
+// Tasks complete immediately: the poll endpoint returns processing-completed on the first call. Neither
+// processing-error nor the API's brief 404-before-the-task-is-known window (internal/service.go:145) is
+// modelled, so no test here exercises task-failure handling or that retry path.
+func (m *MockAPI) NewTask(commandType string, resourceID int) map[string]any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	id := uuid.New().String()
+	m.taskResource[id] = resourceID
+
+	return map[string]any{
+		"taskId":      id,
+		"commandType": commandType,
+		"status":      "received",
+		"description": "Task request received and is being queued for processing.",
+	}
+}
+
+// Locked runs fn with handler invocation suspended. Use it for fixture state that a test mutates or
+// reads from the test goroutine rather than from inside a handler.
+func (m *MockAPI) Locked(fn func()) {
+	m.handlerMu.Lock()
+	defer m.handlerMu.Unlock()
+
+	fn()
+}
+
+// Requests returns every request made so far, in order, as "METHOD /path".
+func (m *MockAPI) Requests() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]string(nil), m.requests...)
+}
+
+// Calls counts requests whose "METHOD /path" equals the given string. Use it to assert that the
+// provider did — or did not — call an endpoint.
+func (m *MockAPI) Calls(methodAndPath string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := 0
+	for _, r := range m.requests {
+		if r == methodAndPath {
+			count++
+		}
+	}
+	return count
+}
+
+func (m *MockAPI) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Strip the SDK base URL's /v1 prefix so patterns don't have to repeat it. Clone rather than mutate:
+	// the request belongs to the caller.
+	routed := req.Clone(req.Context())
+	routed.URL.Path = strings.TrimPrefix(req.URL.Path, "/v1")
+
+	m.mu.Lock()
+	m.requests = append(m.requests, routed.Method+" "+routed.URL.Path)
+	m.mu.Unlock()
+
+	rec := httptest.NewRecorder()
+	m.mux.ServeHTTP(rec, routed)
+
+	resp := rec.Result()
+	resp.Request = req
+	return resp, nil
+}

--- a/provider/utils/wait.go
+++ b/provider/utils/wait.go
@@ -21,8 +21,8 @@ func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiC
 		Pending:      []string{subscriptions.SubscriptionStatusPending},
 		Target:       []string{subscriptions.SubscriptionStatusActive},
 		Timeout:      SafetyTimeout,
-		Delay:        10 * time.Second,
-		PollInterval: 30 * time.Second,
+		Delay:        api.WaitDelay(10 * time.Second),
+		PollInterval: api.WaitPollInterval(30 * time.Second),
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for subscription %d to be %s", id, subscriptions.SubscriptionStatusActive)
@@ -94,8 +94,8 @@ func WaitForDatabaseToBeActive(ctx context.Context, subId, id int, api *client.A
 		},
 		Target:       []string{databases.StatusActive},
 		Timeout:      SafetyTimeout,
-		Delay:        10 * time.Second,
-		PollInterval: 30 * time.Second,
+		Delay:        api.WaitDelay(10 * time.Second),
+		PollInterval: api.WaitPollInterval(30 * time.Second),
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for database %d to be active", id)


### PR DESCRIPTION
## What

  Unit tests for Active-Active `redis_version` / `redis_version_actual` that run real Terraform plan/apply cycles against an in-memory API — no infrastructure, no credentials, ~7s.

  They encode **current** behaviour, including three defects. The fix is a follow-up PR, so it lands as a test diff rather than an indistinguishable refactor.

  ## How

  The tests drive the real resource, so production CRUD, plan modifiers and nil-state guards all execute — not a double that mirrors them and drifts. `testhelpers.MockAPI` sits at the
  `http.RoundTripper` boundary via the SDK's `Transporter` option, the only seam the SDK offers (its services are concrete types). In-process `ServeMux`; nothing on a socket. The async task
  protocol lives in the shared helper, being protocol rather than resource behaviour.

  `86c358c2` is the only production change and a no-op in production: waiters read `api.WaitDelay(30 * time.Second)` instead of a bare literal, zero meaning "not overridden", so tests can
  drop 30s sleeps to 1ms.

  ## Defects encoded

  1. **A genuine upgrade can't be applied at all** — `redis_version_actual` carries only `UseStateForUnknown`, so the plan pins the prior version and apply contradicts it. Shipped in
  v2.18.0/v2.18.1.
  2. **The version guard issues in-place downgrades** — exact string inequality, so a request *below* the running version clears it. Worst case: an auto minor upgrade takes the database to
  8.6, the customer asks for 8.4, the provider requests 8.4.
  3. **Same inconsistency via a plan/apply race**, when a background upgrade lands between saved plan and apply.

  Tests assert on `requestedUpgrades()`, not just state — a rejected downgrade looks identical to a request never sent if you only check state.

  ## Also

  `BEHAVIOUR(global_password)` records why any plan that changes an attribute also plans `global_password` unknown, and what was ruled out. Not judged as a defect: it settles, and the plan
  after apply is clean. Consequence: test configs pin it so plan assertions stay about their subject.

  ## Verification

  `make ci` passes; seven tests pass under `-race`. They're `resource.UnitTest`, so they run under plain `go test ./...` with no `TF_ACC`.

  The v2.18.0/v2.18.1 claim comes from git log archaeology on f8277f1e — worth checking before reviewers see it.