### PR TITLE
security: Bump gotoolchain to v1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/terraform-provider-rediscloud
 
 go 1.25.8
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/RedisLabs/rediscloud-go-api v0.52.1


### PR DESCRIPTION
Addresses the standard-library vulnerabilities reported by govulncheck by updating the Go toolchain from v1.26.5 to v1.26.6.

The update resolves:

- GO-2026-6218 in net/url
- GO-2026-6090 in crypto/tls
- GO-2026-5972 in encoding/asn1
- GO-2026-5026 through net/http

## Verification

- nix develop --command make ci
- govulncheck reports zero reachable vulnerabilities