### PR TITLE
chore: Add AGENTS.md and migration skill

### DIFF
--- a/.agents/skills/migrate-to-plugin-framework/SKILL.md
+++ b/.agents/skills/migrate-to-plugin-framework/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: migrate-to-plugin-framework
+description: >-
+  Migrate Redis Cloud Terraform provider data sources and resources from
+  terraform-plugin-sdk/v2 to terraform-plugin-framework while preserving the
+  protocol-v5 schema and existing behaviour. Use for SDKv2-to-Framework
+  migrations, new Framework resources or data sources, mux registration,
+  Framework schemas and models, CRUD or state conversion, API-to-Framework
+  mapping helpers including legacy flatten helpers, provider custom types,
+  migration acceptance tests, and manual
+  migration verification.
+---
+
+# Migrate to the Plugin Framework
+
+Treat a migration as a compatibility change. Move ownership from the SDKv2
+provider to the Framework provider without changing the public Terraform shape
+or the values users already have in state.
+
+Read `AGENTS.md` first for repository commands, branch policy, service ownership,
+and manual-provider setup.
+
+## Establish the baseline
+
+1. Read the complete SDKv2 implementation, its tests, and every helper it calls.
+   Use them as the behavioural specification rather than relying on the migration
+   ticket.
+2. Compare the schema field by field. Record names, types, collection kinds,
+   cardinality, validators, defaults, conflicts, and Required, Optional, and
+   Computed combinations.
+3. Search the provider for sibling consumers of every nested shape and shared
+   helper. A data source may expose a computed copy of a block that users
+   configure on its resource.
+4. Verify that files expected from a parent migration branch are present. Base a
+   stacked migration on that parent rather than recreating its helpers.
+5. Ask before deliberately changing observable behaviour. Fixing an apparent
+   SDKv2 bug is separate from faithfully migrating it, even when the proposed fix
+   is non-breaking.
+
+## Preserve the protocol-v5 schema
+
+The provider mux speaks protocol v5. Translate SDKv2 collection shapes according
+to what they represent:
+
+- Convert `TypeList` or `TypeSet` with `Elem: &schema.Resource{}` to
+  `schema.ListNestedBlock` or `schema.SetNestedBlock`.
+- Do not use Framework nested attributes for those object collections. Nested
+  attributes require protocol v6 and can panic when served through this mux.
+- Convert primitive lists and sets to `schema.ListAttribute` and
+  `schema.SetAttribute` with an `ElementType`.
+- Convert primitive maps to `schema.MapAttribute`.
+
+Preserve the public block and attribute names, nesting, collection kind, and
+configuration semantics exactly. Similar subscription types do not necessarily
+give a field the same Required, Optional, or Computed flags, so verify each
+schema independently.
+
+Keep descriptions meaningful in code you touch. Update generated or published
+documentation only when the schema or its wording actually changes.
+
+## Place and register the implementation
+
+Put a migrated implementation in its resource-family package. Use a focused file
+layout unless the package already has an established equivalent:
+
+- `datasource_<name>.go`, `datasource_<name>_model.go`, and
+  `datasource_<name>_read.go` for a data source.
+- `resource_<name>.go`, `resource_<name>_model.go`, and
+  `resource_<name>_crud.go` for a resource.
+
+Add compile-time assertions for every Framework interface the implementation
+supports. Configure the API client through `Configure`, and derive the Terraform
+type name from `req.ProviderTypeName` plus the public suffix.
+
+Register the constructor in `provider/framework_provider.go`. Remove the SDKv2
+registration from `provider/sdk_provider.go` and leave its existing Framework
+ownership marker. Delete the old SDKv2 implementation only after searching for
+remaining callers of its helpers.
+
+Framework resources and data sources do not receive an implicit `id` attribute.
+For a migrated implementation, declare a computed string `id` as the SDKv2
+implementation exposed one implicitly; existing configurations and state may reference it.
+For a new implementation with no SDKv2 predecessor, add `id` only when the value
+has a useful domain meaning.
+
+## Map values without changing state semantics
+
+Match the value written by the SDKv2 code, including its treatment of missing API
+fields:
+
+- Preserve empty strings when SDKv2 wrote `""`. Do not replace them with null
+  simply because pointer-based Framework constructors make that convenient.
+- Use a pointer constructor only when SDKv2 genuinely left the attribute absent.
+- Preserve zero values for integer fields when that was the previous behaviour.
+- Keep existing special defaults, such as a boolean that defaults to true when
+  the API omits it.
+- Prefer constants from `rediscloud-go-api` to duplicated status or enum strings.
+
+Acceptance checks alone do not prove empty-string compatibility. Terraform's
+testing helpers can treat an absent value as equivalent to `""` in common
+resource-attribute checks. Inspect the SDKv2 assignment and use a state check
+that distinguishes known empty strings from null when the distinction matters.
+
+Use the project marker `//TODO(TF3.0) make <field> nullable` for all fields kept
+as an empty string solely for backward compatibility and expected to become null
+in the next major version.
+
+When a resource field is supplied by configuration but never returned by the
+API, leave its existing model value untouched during reads. Assigning a null
+value erases configuration that SDKv2 previously retained in state.
+
+## Name mapping helpers by result and direction
+
+Rename an SDKv2-style `flattenX` helper when a migration moves, replaces, or
+otherwise changes it. Do not introduce new `flatten` names in Framework code.
+
+Name an API-to-Framework collection mapper
+`<Domain><TerraformShape>FromAPI`. Include `List`, `Set`, `Map`, or `Object` in
+the name so the result is clear at the call site. For example, use
+`PricingListFromAPI` and `ResourceTagsMapFromAPI`.
+
+Keep `NewX` for a real constructor that returns the named custom type or value it
+creates. `NewMaintenanceList`, for example, constructs a
+`MaintenanceListValue`; it is not an ordinary mapper returning `types.List`.
+
+Update callers, comments, and test names with the helper. Limit the rename to
+helpers touched by the migration rather than sweeping unrelated legacy code.
+
+## Choose a strategy for nested collections
+
+Make the decision from every resource and data source that uses the shape, not
+only from the schema currently being migrated.
+
+### Configurable shapes
+
+Create a reusable Framework custom collection type when the nested shape is user configurable somewhere. Required, Optional, or Optional-and-Computed blocks fall
+into this category. Maintenance windows are the representative subscription
+shape: a data source reads them as computed data, while subscription resources
+accept them as configuration.
+
+Apply this decision recursively to nested object collections. If a configurable
+custom block contains another configurable list or set of objects, give the
+nested collection its own custom type so the parent model exposes a typed value
+with its own `AsModels`. Keep primitive collections as ordinary Framework values
+unless they need additional domain behaviour.
+
+Introduce the custom type in whichever migration reaches the shared shape first.
+Prefer introducing it with the data-source migration when possible. The later
+resource migration can then consume the same typed value and avoids carrying the
+type implementation in its own already-large diff.
+
+Use a custom list type when callers need the whole list as a domain value:
+
+1. Define `XListType` and `XListValue` by embedding `basetypes.ListType` and
+   `basetypes.ListValue`.
+2. Implement the Framework conversion, equality, and type methods required by
+   `basetypes.ListTypable` and `basetypes.ListValuable`. Add compile-time
+   interface assertions.
+3. Attach the type to `schema.ListNestedBlock.CustomType` and use `XListValue` in
+   the containing `tfsdk` model.
+4. Represent element data with `tfsdk`-tagged model structs. Construct the
+   collection from those models as described in the shared rules below.
+5. Add `AsModels(ctx) ([]XModel, diag.Diagnostics)` to the list value and decode
+   through the embedded `ElementsAs` method.
+
+Do not override `Elements()`. Its signature belongs to the Framework value
+interface and must continue to return `[]attr.Value`. Do not add a custom element
+type merely to avoid casts in provider code. `AsModels` supplies typed access to
+the complete collection while ordinary object elements retain standard Framework
+behaviour. Callers that need one element can index the returned model slice.
+
+Require callers to check `IsNull()` and `IsUnknown()` before using `AsModels`, and
+propagate its diagnostics. Constructors must preserve null and unknown states
+rather than converting them to empty known lists.
+
+### Strictly computed shapes
+
+Keep ordinary Framework collection values when a nested shape is computed in
+every resource and data source. Pricing is the representative subscription
+shape. It is returned by the API and is never user configuration, so a provider
+custom type adds no useful configuration or CRUD boundary.
+
+Still give the element a `tfsdk`-tagged model such as `PricingModel`. Derive the
+element attribute map with `customtypes.AttrTypesOf(PricingModel{})`. This keeps
+the model as the source of attribute names and types so mapping code does not
+repeat hardcoded string keys. Store the result in a normal `types.List` or
+`types.Set` model field.
+
+`AttrTypesOf` expects model fields that implement `attr.Value`. A zero
+`types.String`, `types.Int64`, or similar scalar can report its type directly. A
+list or set field must be seeded with its element type because an uninitialised
+collection cannot describe that element type.
+
+### Rules shared by both strategies
+
+- Map API values into a non-nil model slice such as
+  `make([]PricingModel, 0, len(apiValues))`, then convert the complete slice with
+  the matching whole-collection function, such as `types.ListValueFrom` or
+  `types.SetValueFrom`. Prefer this to converting each model with
+  `types.ObjectValueFrom` and manually assembling `[]attr.Value`. The
+  whole-collection function centralises conversion diagnostics, and the non-nil
+  empty slice preserves a known empty Terraform collection when the API returns
+  no values. Use per-element conversion only when an element needs custom logic
+  or element-specific diagnostic handling.
+- Sort API results before creating a Terraform list when the API does not
+  guarantee order. Use a composite key containing every field needed to produce
+  a stable result.
+- Preserve null, unknown, empty, and known states deliberately.
+- Keep the schema's nested object attributes and the model-derived type map in
+  sync. This consistency is checked at runtime, so cover it with tests.
+- Return diagnostics from Framework conversion functions immediately when they
+  contain errors.
+
+For a custom collection, test type equality, Terraform conversion, null and
+unknown handling, API-to-value construction, and `AsModels`. For a computed-only
+collection, test model decoding, empty and nil responses, value compatibility,
+and deterministic ordering.
+
+## Share and retire helpers carefully
+
+Put Framework helpers used by more than one package in `provider/utils`, and put
+reusable Framework custom types in `provider/customtypes`. Reuse an existing
+helper only after confirming that its null handling, ordering, and element shape
+match the migration.
+
+Search the entire provider before removing an SDKv2 helper or constant. Other
+SDKv2 resources may still require its map-based return value even when Framework
+code has moved to `attr.Value`. If a remaining caller can use an identical shared
+helper, repoint that caller and then remove the duplicate. Otherwise leave the
+SDKv2 helper in place until its final caller migrates and just add a reminder
+comment for that.
+
+## Preserve Framework resource lifecycle behaviour
+
+Framework request and response types prevent `Create` or `Update` from directly
+delegating to `Read`. Factor shared API-to-model logic into an internal helper
+that all three operations can call.
+
+Apply these resource rules:
+
+- Treat NotFound during `Read` as a missing resource and remove it from state.
+- Continue to propagate NotFound from `Delete` unless the existing resource
+  deliberately does otherwise. These resources assume Terraform owns their
+  lifecycle.
+- Continue using `terraform-plugin-sdk/v2/helper/retry` for state polling. There
+  is no need to replace a working `retry.StateChangeConf` merely because the
+  resource itself uses the Framework.
+- If creation or update produces a remote object and a later readiness wait
+  fails, write its identifier and last observed status to state before returning
+  the error. Otherwise Terraform loses ownership of an object it created.
+
+For imports, implement `ResourceWithImportState` and verify any configuration-only
+secret fields through the same ignore behaviour used by the existing acceptance
+test.
+
+## Update tests with the migration
+
+Add table-driven unit tests for pure filters, mapping helpers, sort keys, custom
+types, and model conversions. Keep those tests independent of Terraform and live
+API credentials where possible.
+
+Acceptance tests use `terraform-plugin-testing` and run against a real account
+only with `TF_ACC=1`. Keep these common pieces unless the existing test requires
+more:
+
+- `testhelpers.ProtoV5ProviderFactories()` for provider factories.
+- `client.GetTestClient()` for destroy checks and sweepers.
+- `utils.RandomWithPrefix()` or the package equivalent for test names.
+- `envchecks.ComposePreChecks` with `envchecks.RedisCloudCheck` and every
+  additional provider or environment check the scenario needs.
+
+Drive HCL through `config.StaticFile` or `config.StaticDirectory`. Put the HCL in
+`testdata/*.tf` and declare variables there. Pass values with
+`config.Variables`; do not interpolate a Go string with `fmt.Sprintf`.
+
+For every acceptance test touched by a migration, define `ConfigVariables`
+inline in each `resource.TestStep`:
+
+```go
+{
+    ConfigFile: config.StaticFile("testdata/example.tf"),
+    ConfigVariables: config.Variables{
+        "name": config.StringVariable(name),
+    },
+}
+```
+
+Do not assign the variables map before `Steps`, and do not hide it behind a
+helper. Repeat the literal when two steps pass the same values. A reader should
+see the configuration inputs beside the exact step that consumes them.
+
+Treat a testdata file as a reusable configuration shape rather than a single
+scenario. Reuse one parameterised file when only values differ; create another
+file when the HCL structure differs.
+
+Give every migrated data source its own acceptance test case in the new
+Framework package. When the SDKv2 test combined resource and data-source
+coverage for convenience or speed, split that coverage during the migration.
+The data-source test may provision the resource it needs, but make assertions
+only about the data source. This keeps each scenario focused and lighter, while
+parallel test execution removes the speed advantage of combining them.
+
+## Verify the migration
+
+Run checks in increasing order of cost:
+
+1. Format changed Go files and run `git diff --check`.
+2. Run unit tests for the migrated package and every shared helper or custom-type
+   package changed by the migration.
+3. Run `go build ./...`, `go vet ./...`, and `make fmtcheck`.
+4. Compare the resulting protocol-v5 schema with the SDKv2 schema, especially
+   nested block kinds and Required, Optional, and Computed flags.
+5. Run the relevant acceptance tests when credentials and a live test account
+   are available. Report missing credentials as a skipped verification rather
+   than treating them as a passing test.
+
+For manual checks, build the provider and use the development override described
+in `AGENTS.md`. Keep resource and data-source configurations in separate
+`playground/` directories. Apply the resource first, then plan the data source so
+its values are known during planning rather than deferred until apply.
+
+Before handing off, inspect the complete branch diff against its actual parent.
+Confirm that registration moved exactly once, no SDKv2 callers were stranded,
+and unrelated schema or documentation changes did not enter the migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,375 +1,124 @@
-# Agent guide — terraform-provider-rediscloud
+# Repository guide
 
-> **Status: living guide.** Working notes for agents on this repo — general dev
-> workflow plus task-specific playbooks. It lives in the repo; improve it as you
-> learn more (see [Maintaining this document](#maintaining-this-document)),
-> ideally in the same PR as the work that taught you the thing.
+Use this file for conventions that apply across the repository. Put procedures
+for a particular kind of work in a skill under `.agents/skills/` so they are
+loaded only when they are relevant.
 
----
+## What this repository contains
 
-## Project basics
+`terraform-provider-rediscloud` is a Go Terraform provider. The provider is
+being moved incrementally from `terraform-plugin-sdk/v2` to
+`terraform-plugin-framework`. Until that migration finishes, the SDK and
+Framework providers run together behind a protocol-v5 mux.
 
-`terraform-provider-rediscloud` is a Terraform provider written in Go. It is
-mid-migration from the legacy `terraform-plugin-sdk/v2` to
-`terraform-plugin-framework`, with both running side by side behind a
-**protocol-v5 mux** — so most changes must "keep existing acceptance tests
-green".
+The main directories are:
 
-- **Build / format:** `make build` (compiles into `bin/` and writes
-  `bin/developer_overrides.tfrc` for local runs) · `make fmtcheck` (goimports
-  `-local github.com/RedisLabs/...`) · `go build ./...` · `go vet ./...`.
-- **Test:** `go test ./...` for unit tests; `make testacc` (`TF_ACC=1`, real API
-  creds — can't run without a live account) for acceptance tests. Current test
-  patterns live in the migration playbook (§7–§8).
-- **Run locally:** after `make build`, `export
-  TF_CLI_CONFIG_FILE=$PWD/bin/developer_overrides.tfrc` so Terraform uses your
-  built provider; put scratch configs in `playground/` (it's gitignored).
-- **Key directories:** `provider/` (all provider code — one package per
-  resource/data source), `docs/` (**published to the Terraform Registry** — no
-  internal notes here), `playground/` (gitignored manual harnesses), `scripts/`,
-  `bin/`.
-- **Sandbox:** `make build`, `go build`/`vet`/`test`, and
-  terraform-with-dev-overrides often need the sandbox disabled; the first time
-  you hit it, confirm the user's per-session preference.
+- `provider/` contains provider code and tests. Framework implementations are
+  normally grouped by resource family.
+- `docs/` contains Terraform Registry documentation. Do not put internal
+  engineering notes there.
+- `playground/` is the gitignored location for manual Terraform configurations.
+- `scripts/` contains repository automation.
+- `bin/` receives local build output and the Terraform development override.
 
----
+## Build and test commands
 
-## Branching & PRs
+- Run `make build` to compile the provider and create
+  `bin/developer_overrides.tfrc`.
+- Run `make fmtcheck` to check formatting with the repository's goimports
+  settings.
+- Run `go build ./...` and `go vet ./...` for repository-wide compilation and
+  static checks.
+- Run `go test ./...` for unit tests.
+- Run `make testacc` only with a configured Redis Cloud test account. Acceptance
+  tests set `TF_ACC=1` and make real API calls.
 
-**Default: branch from — and open PRs against — the latest release branch, not
-`main`.** Release branches are named `release/<x.y.z>` (e.g. `release/2.19.0`).
-Only release branches get merged into `main`, with very few exceptions.
+If the default Go build cache is not writable, point `GOCACHE` at a writable
+directory under `/tmp`. Terraform-based tests may also need to run outside a
+restricted command sandbox because they start a provider process and communicate
+with it over a local socket.
 
-Why: each release is assembled as a stable, predictable set of features. Nothing
-half-baked reaches `main` ahead of a release, and what's on the release branch is
-exactly what ships.
+For manual testing, build the provider and then export:
 
-- **Find the latest release branch; never assume one.** `git fetch` then
-  `git branch -r --list 'origin/release/*'` and take the highest version — don't
-  reuse a release branch name you saw in an earlier session or in this document,
-  it goes stale every release. If which one is current is ambiguous (two open, or
-  the newest looks already-released), ask rather than guess: a wrong base makes
-  the whole diff wrong.
-- **Work that won't be in the next release may be based on `main`** — but it's
-  parked, not done. Once the next release branch opens, put it in the right place:
-  rebase onto that newer release branch and merge there.
-- **Stacked work bases on its parent branch**, which is itself based on the
-  release branch — see the stacked-migrations bullet in the playbook (§0).
-- Anchor: `.github/workflows/terraform_provider_pr.yml` runs the PR checks for
-  PRs targeting `main`, `develop`, and `release/*`. Note that
-  `RELEASE_PROCESS.md` step 1 ("open a PR to `main`") describes the
-  release-branch → `main` PR — it is not licence for a feature branch to target
-  `main`.
+```sh
+export TF_CLI_CONFIG_FILE="$PWD/bin/developer_overrides.tfrc"
+```
 
----
+Terraform will then use the local provider binary for configurations under
+`playground/`.
 
-## Migration playbook (SDKv2 → Plugin Framework)
+## Branches and pull requests
 
-The provider is migrated one data source / resource at a time. Most rules below
-fall out of the protocol-v5 mux and out of "keep existing acceptance tests
-green".
+Base ordinary work on the newest active `release/<x.y.z>` branch and target the
+same branch with the pull request. Do not assume that a release branch remembered
+from an earlier task is still current. Fetch first, list `origin/release/*`, and
+compare their semantic versions. Ask when multiple branches appear active or the
+newest branch already looks released.
 
-**Reading guide:** §2 is split by kind and each subsection is self-contained —
-read only the one you're migrating. Everything else applies to **both** kinds;
-the few kind-specific bullets are tagged _(data sources)_ / _(resources)_.
+Work may be parked on `main` before its release branch exists. Move that work to
+the appropriate release branch once the branch is created. Feature branches do
+not normally target `main`; the release branch itself is what later merges into
+`main`.
 
-### 0. Before you start
+For stacked work, base each child branch and pull request on its immediate parent
+branch. Verify that helpers or packages expected from the parent are actually
+present before starting the child migration.
 
-- **The old SDKv2 source is the baseline spec — but not bug-free.** Tickets are
-  templated and vague; the behavioural spec is the existing SDKv2 code, so
-  replicate what it did by default. Treat it as fallible, though: some quirks
-  are genuine bugs, and the migration is a fair time to fix or improve things
-  **as long as the change is non-breaking** (schema and observable behaviour
-  stay backwards-compatible; see §4). When you spot a likely bug or a worthwhile
-  improvement, **stop and confirm with the user** before deviating — don't
-  silently "fix" it, and don't silently carry a known bug forward.
-- **Migrations are often stacked.** A task may depend on helpers/files added on
-  an earlier migration branch that **haven't landed on the release branch** yet
-  (e.g. `provider/pro/flatten.go`). Verify prerequisites exist on your base
-  before writing code (`git show HEAD:<path>`). If stacked, the **PR base should
-  be the parent migration branch** — not the release branch, not `main` — so the
-  diff stays scoped. Unstacked work follows the default in
-  [Branching & PRs](#branching--prs).
+`.github/workflows/terraform_provider_pr.yml` defines the branches for which pull
+request checks run. `RELEASE_PROCESS.md` describes the separate process of
+merging a completed release branch into `main`.
 
-### 1. Schema type translation (non-negotiable mux v5 rules)
+## System ownership
 
-- **Nested structures are BLOCKS, never nested attributes.**
-  `TypeList`/`TypeSet` \+ `Elem: &schema.Resource{}` becomes
-  `schema.ListNestedBlock` / `schema.SetNestedBlock` — **not** the
-  `*NestedAttribute` variants. Nested attributes require protocol v6 and will
-  **panic at runtime** under the v5 mux. `TypeSet` → `SetNestedBlock`;
-  `TypeList` → `ListNestedBlock`. See the comment in
-  `provider/regions/datasource_regions.go`.
-- **Primitive collections are ATTRIBUTES.** `TypeList`/`TypeSet` +
-  `Elem: &schema.Schema{}` (list/set of primitives, e.g. strings) →
-  `schema.ListAttribute`/`SetAttribute` with `ElementType`; `TypeMap` →
-  `schema.MapAttribute`. Only list/set **of objects** are blocks.
+The provider calls the public Redis Cloud API through
+`github.com/RedisLabs/rediscloud-go-api`. Several services participate behind
+that API, and their ownership matters when behaviour differs between the public
+API and the console:
 
-### 2. Package & file layout
+- Subscription Manager, also called SM or Garantia, owns the primary data and
+  the core account, subscription, database, and cluster behaviour.
+- `sm-cloud-api`, commonly called CAPI, is the public API gateway. It reads from
+  an SM database replica and sends asynchronous writes to SM.
+- `sm-das` provides a separate GraphQL read interface over SM-owned data for
+  internal tooling.
+- RCP provisions dedicated clusters in customer cloud accounts and synchronises
+  their state with SM.
+- `cloud-ui` is the web console and calls SM's session-authenticated API rather
+  than CAPI.
+- `rediscloud-go-api` is the Go client used by this provider to reach CAPI.
 
-Each migrated data source / resource gets its own package dir, unless it belongs
-to an existing grouping (e.g. `provider/activeactive`, `provider/pro`). After
-migrating, delete the old SDKv2 implementation.
+The console and this provider therefore exercise different read paths. Do not
+infer public API behaviour solely from the console. In particular, API list
+responses can arrive in an unspecified order even when the console's backend
+sorts the same data. Terraform code that stores an ordered collection must impose
+a stable order itself.
 
-#### 2.1 Data sources
+When investigating backend behaviour, first look for an existing local checkout
+of the owning service and verify claims against its code. If a required checkout
+cannot be found, ask the user for its location or for the missing repository to
+be made available. Do not clone a service repository solely for the current work
+session. Architecture prose can lag behind deployed behaviour.
 
-Blueprint: `provider/essentialsplan` (`rediscloud_essentials_plan`) — read it
-with its PR/commit history. Three files:
+## Task skills
 
-- `datasource_<x>.go` — interface asserts (`var _ datasource.DataSource = ...`,
-  `...WithConfigure`), `New<X>DataSource`, `Metadata`, `Configure`, `Schema`.
-- `datasource_<x>_model.go` — the `tfsdk`-tagged model struct.
-- `datasource_<x>_read.go` — `Read` + any flatten helpers.
+Recurring workflows live as Agent Skills:
 
-#### 2.2 Resources
+| Skill | Use it for |
+| --- | --- |
+| `migrate-to-plugin-framework` | Migrating an SDKv2 resource or data source, or adding a new Framework implementation. |
 
-Blueprint: `provider/cloudaccount` (`rediscloud_cloud_account`) — read it with
-its PR/commit history. Three files:
+Skills are stored at `.agents/skills/<skill-name>/SKILL.md`. When adding or
+changing a skill, validate it with the available Agent Skills validator.
 
-- `resource_<x>.go` — interface asserts (`resource.Resource`,
-  `...WithConfigure`, `...WithImportState`), `New<X>Resource`, `Metadata`,
-  `Configure`, `Schema`.
-- `resource_<x>_model.go` — the `tfsdk`-tagged model struct.
-- `resource_<x>_crud.go` — `Create`/`Read`/`Update`/`Delete`/`ImportState` +
-  wait helpers.
+## Maintaining repository guidance
 
-**Resource CRUD gotchas** (not obvious from the framework docs):
-
-- **Create/Update can't delegate to Read** the way SDKv2 did
-  (`return ...Read(...)`) — the framework request/response signatures differ.
-  Factor a `read<X>IntoModel(...) (notFound bool)` helper and call it from all
-  three; on not-found, `resp.State.RemoveResource(ctx)` (the framework's
-  `d.SetId("")`).
-- **Fields the API never returns must be left UNTOUCHED by that helper** (e.g.
-  secret key, console user/pass, sign-in URL). Assigning
-  `StringPointerValue(nil)` silently wipes them to null — SDKv2 just never
-  `d.Set` them, preserving the config/state value. Tests skip them via
-  `ImportStateVerifyIgnore`.
-- **State-change waiters stay on SDKv2.** A framework resource still imports
-  `terraform-plugin-sdk/v2/helper/retry` (`retry.StateChangeConf` /
-  `WaitForStateContext`) — there's no framework-native poller, so this is
-  expected, not a leftover to "fix".
-- **A resource that polls for a ready state must not orphan the remote object on
-  poll failure.** When Create (or Update) provisions the object then waits for
-  it to become active/ready, a timed-out or failed wait must still write the
-  object to state before returning the error — persist the `id` and the last
-  observed status via `resp.State.Set` — otherwise the created object leaks
-  (untracked, unrecoverable, and the next apply makes a duplicate). SDKv2 got
-  this for free (`d.SetId()` before the wait is persisted even on error); the
-  framework does not, so do it explicitly. Have the poll helper _return_ the
-  last observed status so you can record it without a second read (fall back to
-  a null status if the first poll never landed). Precedent:
-  `provider/cloudaccount` resource `Create`.
-- **Delete is not idempotent, by design.** Redis TF resources assume their infra
-  is managed **only** by Terraform, so `Delete` propagates the API error rather
-  than swallowing a NotFound. If the object was removed out-of-band,
-  `terraform destroy` **fails** — that's expected, not a bug to "fix" (don't add
-  NotFound-tolerance to `Delete`). Contrast the first gotcha: `Read` _does_
-  treat NotFound as "gone" and drops the resource from state; `Delete` does not.
-
-### 3. Registration
-
-- Add the constructor to `provider/framework_provider.go` (`DataSources()` /
-  `Resources()`) and import the package.
-- Remove the old entry from `provider/sdk_provider.go`, leaving a marker:
-  `// Note: <public_name> is served by the Plugin Framework provider`.
-- `Metadata` TypeName = `req.ProviderTypeName + "_<suffix>"`. **Watch
-  public-name vs file-name mismatches**: `rediscloud_subscription` is the
-  pro/flexible subscription but its package/type is "pro" — suffix is
-  `_subscription`, not `_pro_subscription`.
-- **The Framework has no implicit `id`.** SDKv2 had a mandatory implicit `id`;
-  the Framework treats `id` as an ordinary attribute — nothing in the framework,
-  the mux, or `terraform-plugin-testing` requires one. So whether to add an `id`
-  depends on _why_ it would exist:
-  - _Migrating from SDKv2:_ **add** an explicit `Computed` `id` `StringAttribute`
-    (e.g. `strconv.Itoa(subId)`). The SDKv2 version always exposed an `id`, so
-    keeping it is backward compatibility — existing configs/state/tests reference
-    `.id`. This is the only reason the rule reads "always add an id" for migrations.
-  - _Brand-new (no SDKv2 predecessor):_ add an `id` **only if it's functionally
-    meaningful** (e.g. it's the object's real identifier and is useful to
-    reference downstream); **skip it otherwise**. There's no compatibility
-    constraint, so don't invent a placeholder id just to have one — an absent
-    attribute is more honest than a sentinel that implies meaning it lacks.
-  - Precedent: the net-new plural `rediscloud_subscriptions` data source
-    (`provider/pro`) **omits** a top-level `id` — a list has no meaningful single
-    identifier, and each element already carries its own `id`. Contrast the older
-    SDKv2 aggregate data sources (`rediscloud_database_modules`,
-    `rediscloud_subscription_peerings`), which set `id = "ALL"` as a sentinel
-    purely because SDKv2 _required_ a non-empty id.
-
-### 4. Schema & docs fidelity
-
-- Preserve the schema **exactly**: attribute names, types,
-  computed/optional/required, block nesting — otherwise acceptance tests break.
-  Diff against the old schema; note per-field differences between siblings (e.g.
-  pro-sub `name` is `Computed`+`Optional`, AA `name` is `Required`).
-- Replace placeholder descriptions (`"Self-explanatory"`) with short, meaningful
-  ones in the files you touch. Keep the schema description, the sibling
-  resource/data source, and the `docs/` markdown consistently worded.
-- Only touch `docs/` markdown if the schema actually changes — a faithful
-  migration keeps it identical (exception: placeholder cleanup, when asked).
-
-### 5. Value mapping (scalars)
-
-- **null-for-nil** (see blueprint): `StringPointerValue` / `Float64PointerValue`
-  / `BoolPointerValue` (nil → null); ints →
-  `Int64Value(int64(redis.IntValue(...)))` (0 for nil).
-- Fields the old code always stringifies (e.g. an int id) →
-  `types.StringValue(strconv.Itoa(redis.IntValue(...)))` (always present, never
-  null).
-- Match SDKv2 special-case defaults, e.g. `public_endpoint_access` defaults to
-  `true` when the API returns nil.
-- **Empty-string vs null — testing gotcha.** `terraform-plugin-testing` treats
-  an **absent** attribute as equal to `""`. A framework `types.StringNull()`
-  renders as _absent_ in the test flatmap, satisfying **both**
-  `TestCheckResourceAttr(k, "")` **and** `TestCheckNoResourceAttr(k)`. So
-  null-for-nil is safe even when a test asserts `== ""`; you rarely need
-  `StringValue("")`.
-- **Prefer `rediscloud-go-api` constants over hardcoded literals.** Wherever the
-  SDK exposes a value you'd otherwise hardcode — status strings, provider/enum
-  values, etc. — reference the constant (`cloud_accounts.StatusActive`,
-  `cloud_accounts.StatusDeleted`, `cloud_accounts.ProviderValues()`, …) rather
-  than a magic string. It's a non-breaking readability/robustness win — the value
-  tracks the SDK — that fits the migration, so make the swap when you spot one.
-  Precedent: the status constants in `provider/cloudaccount`'s wait helpers and
-  the `provider_type` `OneOf(cloud_accounts.ProviderValues()...)` validator.
-
-### 6. Helpers
-
-Two concerns: building framework values from API data (6.1), and reusing or
-retiring the shared helper set (6.2).
-
-#### 6.1 Flatten helpers (collections)
-
-- Build nested collections with attr-type maps + `types.ObjectValue` +
-  `types.ListValue`/`SetValue`; primitive collections via `types.ListValueFrom`
-  / `MapValueFrom`. This is the `provider/pro` style (`FlattenMaintenance`,
-  `FlattenPricing`).
-- Alternative **typed-struct** style: `tfsdk`-tagged nested structs +
-  `types.ObjectValueFrom` / `ListValueFrom` (the `provider/regions` style).
-  Cleaner and type-checked, but mixes idioms if the file also uses the
-  hand-rolled style.
-- **Model fields stay `types.List` / `types.Set`.** The framework has no generic
-  typed list value and the shared `pro.Flatten*` helpers return `types.List`,
-  so receiving fields must match. Do **not** convert model fields to `[]struct`:
-  you lose null/unknown fidelity, can't assign shared-helper output, and diverge
-  from precedent.
-- A flatten's behavioural spec is the **old SDKv2 flatten** — replicate its
-  quirks (e.g. the pro cloud-details `isResource=false` path leaves region-level
-  `networking_vpc_id` unset and always returns a non-nil `resource_tags` map).
-- **Deterministic ordering.** The API can return nondeterministically-ordered
-  lists (e.g. pricing) → sort by a composite key inside the flatten to kill a
-  perpetual plan diff. Shared helpers already do this — inherit it, don't change
-  it.
-
-#### 6.2 Shared helpers & old-helper cleanup
-
-- Shared subscription helpers live in the `provider/pro` package —
-  `FilterSubscriptions` (in `datasource_rediscloud_pro_subscription.go`),
-  `FlattenMaintenance` / `FlattenPricing` (in `flatten.go`), and the
-  `CMK_ENABLED_STRING` constant. Reuse; don't duplicate.
-- Filter-helper naming stays `filter<Singular>` (`pro.FilterSubscriptions` +
-  `filterSubscription` predicate) — consistent with ~14 other data sources.
-- **Grep the WHOLE provider for remaining callers before deleting any old
-  helper.** SDKv2 code often still needs the map-based `Flatten*` helpers and
-  constants (e.g. `CMK_ENABLED_STRING`); only remove what's now unused. Grep on
-  the **correct (stacked) base** — a prior migration may already have removed
-  callers.
-- If a duplicated helper's only remaining caller is another SDKv2 file that can
-  use the migrated equivalent (identical signature), **repoint it and delete the
-  duplicate** rather than leaving a near-empty file. (We repointed the SDKv2
-  AA-regions data source to the shared `pro.FilterSubscriptions` and deleted the
-  duplicate helper.)
-- **Leave a removal note on SDKv2-only helpers.** A helper kept alive only
-  because SDKv2 code still calls it is migration debt — mark it in place so a
-  later session deletes it instead of guessing, e.g.
-  `// SDKv2-only: remove once the remaining callers (X, Y) are migrated to the framework.`
-  Use a plain comment, not a godoc `// Deprecated:` marker (which would flag
-  every caller in linters). When the grep above shows no SDKv2 callers remain,
-  delete the helper and its note.
-
-### 7. Tests
-
-- Keep tests schema-compatible so they pass unchanged.
-- **Unit-test the pure helpers you introduce/migrate.** Standalone helpers
-  (filters, `Flatten*`, sort keys) get table-driven tests in
-  `package <pkg>_test` with testify — decoupled from TF/mux, no acceptance
-  creds. This is the cheap regression net the migration otherwise lacks (e.g. it
-  pins the pricing deterministic sort). Exercise unexported helpers through
-  their exported callers. Example: `provider/pro/flatten_test.go`.
-- **Acceptance tests** need real API creds and can't run locally; the
-  `terraform-plugin-testing` framework runs them only when `TF_ACC=1` (set by
-  `make testacc`). There is no `EXECUTE_TESTS` or `testing.Short()` gate.
-- **Prechecks go through the `envchecks` package.** Set
-  `PreCheck: envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, <more>...)`
-  — it runs every check and fails **once** with the full list of missing env
-  vars (the old per-package `BasicPreCheck` and the `utils.AccRequiresEnvVar`
-  **skip** are gone; there's no skip-vs-fail split any more — everything fails).
-  Ready-made checks: `RedisCloudCheck` (URL + access/secret key),
-  `AWSProviderCheck`, `GCPProviderCheck`, or `RequireEnvVars(t, ...)` for ad-hoc
-  vars. When a test needs a var's **value**, use a value+check pair so the same
-  var is read _and_ gated — `name, check := envchecks.AWSBYOCValueAndCheck()`
-  (also `ValueAndCheck(key)`, `GCPProjectValueAndCheck`,
-  `AwsPeeringValueAndCheck`) — and pass `check` into `ComposePreChecks`.
-- **Unchanged wiring:**
-  `ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories()`; get an API
-  client for `CheckDestroy` / sweepers via `client.GetTestClient()`; name
-  resources with `utils.RandomWithPrefix()` (honours `TEST_RESOURCE_PREFIX`).
-- **A `testdata/*.tf` file maps to a config _form_, not a scenario.** Scenarios
-  that share structure and differ only in values reuse **one** parameterised
-  file via per-step `ConfigVariables`. Add a separate `.tf` only when the
-  _structure_ differs (e.g. a GCP cloud account taking different arguments than
-  AWS) — don't fork just to hardcode different values.
-- _(Data sources)_ Relocate a data-source test only if it's a **standalone**
-  test file → move it into the package as `package <pkg>_test`. If the
-  assertions are **embedded** in a combined resource+datasource test, leave them
-  (AA precedent). The essentialsplan blueprint relocated its standalone test.
-
-### 8. Verify
-
-- `go build ./...` · `go vet ./...` · `make fmtcheck` (goimports
-  `-local github.com/RedisLabs/...`).
-- Run unit tests for the package + `provider/utils`.
-- A pre-existing acceptance test that hard-fails on a missing env var is
-  probably **environmental and not your regression** — confirm it fails
-  identically on the base.
-- Prepare testing .tf files for the user to perform manual testing
-  - drive the freshly-built provider from `playground/` (gitignored; split into
-    `datasource/` and `resource/` if needed)
-  - **The shared test env is wiped daily**. This applies both to resources and
-    data sources, but has more impact on data sources, because usually have no
-    object to read. In that case first `apply` a resource in
-    `playground/resource/` to create one, then point the data-source config in
-    `playground/datasource/` at it and `plan`.
-  - **Setup:** `make build`, then export
-    `TF_CLI_CONFIG_FILE=$PWD/bin/developer_overrides.tfrc` and
-    `REDISCLOUD_ACCESS_KEY` / `REDISCLOUD_SECRET_KEY` (+ any vars the resource
-    needs); dev-overrides let you skip `terraform init`.
-  - _(Data sources)_ - Keep the data-source `.tf` in its own dir, separate from
-    any resource `.tf`.\*\* A data source relies on infra that already exists,
-    so sharing a config with the resource that creates that same infra, forces
-    data source fields to be calculated as "known after apply" and hides the
-    values until you run a second `tf apply`. When data source and resource are
-    kept separate, `terraform apply` on the resource first, allows a
-    `terraform plan` on the data source, ran as a second step, to read the data
-    at plan time with full values.
-
----
-
-## Maintaining this document
-
-Living doc — update it when you finish a migration or hit something surprising:
-
-- **Add durable, reusable knowledge only** — recurring decisions, non-obvious
-  mux behaviours, precedents, gotchas. Not one-off task details or anything
-  obvious from the code / git history.
-- **Correct/merge in place; don't append contradictions.** If a rule turns out
-  wrong or narrower/broader than stated, fix it where it lives.
-- **Cite a concrete anchor** (a precedent file, blueprint, verified test
-  behaviour) so the next session can check it rather than trust it blindly.
-- **Keep §2.1 and §2.2 self-contained as both paths grow.** Data sources and
-  resources are both exercised now; when one gains a gotcha, check whether the
-  other needs the mirror note — but don't make one subsection depend on the
-  other.
-- When you rely on a rule, **sanity-check it still holds** (files move, helpers
-  migrate). If it names a file/helper that no longer exists, update the anchor.
+- Keep repository-wide facts here and task-specific procedures in their skill.
+- Record durable decisions and non-obvious failure modes, not a diary of one
+  implementation.
+- Replace an outdated rule where it lives instead of adding a contradictory
+  exception later in the file.
+- Prefer guidance that explains non-obvious reasoning and helps future
+  contributors choose the right approach. Do not repeat implementation details
+  that are clear from the relevant code.
+- Recheck commands, paths, and precedents whenever you rely on them. Documentation
+  should be corrected in the same change that proves it stale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,35 @@ green".
 
 ---
 
+## Branching & PRs
+
+**Default: branch from — and open PRs against — the latest release branch, not
+`main`.** Release branches are named `release/<x.y.z>` (e.g. `release/2.19.0`).
+Only release branches get merged into `main`, with very few exceptions.
+
+Why: each release is assembled as a stable, predictable set of features. Nothing
+half-baked reaches `main` ahead of a release, and what's on the release branch is
+exactly what ships.
+
+- **Find the latest release branch; never assume one.** `git fetch` then
+  `git branch -r --list 'origin/release/*'` and take the highest version — don't
+  reuse a release branch name you saw in an earlier session or in this document,
+  it goes stale every release. If which one is current is ambiguous (two open, or
+  the newest looks already-released), ask rather than guess: a wrong base makes
+  the whole diff wrong.
+- **Work that won't be in the next release may be based on `main`** — but it's
+  parked, not done. Once the next release branch opens, put it in the right place:
+  rebase onto that newer release branch and merge there.
+- **Stacked work bases on its parent branch**, which is itself based on the
+  release branch — see the stacked-migrations bullet in the playbook (§0).
+- Anchor: `.github/workflows/terraform_provider_pr.yml` runs the PR checks for
+  PRs targeting `main`, `develop`, and `release/*`. Note that
+  `RELEASE_PROCESS.md` step 1 ("open a PR to `main`") describes the
+  release-branch → `main` PR — it is not licence for a feature branch to target
+  `main`.
+
+---
+
 ## Migration playbook (SDKv2 → Plugin Framework)
 
 The provider is migrated one data source / resource at a time. Most rules below
@@ -55,10 +84,12 @@ the few kind-specific bullets are tagged _(data sources)_ / _(resources)_.
   improvement, **stop and confirm with the user** before deviating — don't
   silently "fix" it, and don't silently carry a known bug forward.
 - **Migrations are often stacked.** A task may depend on helpers/files added on
-  an earlier migration branch that are **not on `main`** (e.g.
-  `provider/pro/flatten.go`). Verify prerequisites exist on your base
+  an earlier migration branch that **haven't landed on the release branch** yet
+  (e.g. `provider/pro/flatten.go`). Verify prerequisites exist on your base
   before writing code (`git show HEAD:<path>`). If stacked, the **PR base should
-  be the parent migration branch**, not `main`, so the diff stays scoped.
+  be the parent migration branch** — not the release branch, not `main` — so the
+  diff stays scoped. Unstacked work follows the default in
+  [Branching & PRs](#branching--prs).
 
 ### 1. Schema type translation (non-negotiable mux v5 rules)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,344 @@
+# Agent guide — terraform-provider-rediscloud
+
+> **Status: living guide.** Working notes for agents on this repo — general dev
+> workflow plus task-specific playbooks. It lives in the repo; improve it as you
+> learn more (see [Maintaining this document](#maintaining-this-document)),
+> ideally in the same PR as the work that taught you the thing.
+
+---
+
+## Project basics
+
+`terraform-provider-rediscloud` is a Terraform provider written in Go. It is
+mid-migration from the legacy `terraform-plugin-sdk/v2` to
+`terraform-plugin-framework`, with both running side by side behind a
+**protocol-v5 mux** — so most changes must "keep existing acceptance tests
+green".
+
+- **Build / format:** `make build` (compiles into `bin/` and writes
+  `bin/developer_overrides.tfrc` for local runs) · `make fmtcheck` (goimports
+  `-local github.com/RedisLabs/...`) · `go build ./...` · `go vet ./...`.
+- **Test:** `go test ./...` for unit tests; `make testacc` (`TF_ACC=1`, real API
+  creds — can't run without a live account) for acceptance tests. Current test
+  patterns live in the migration playbook (§7–§8).
+- **Run locally:** after `make build`, `export
+  TF_CLI_CONFIG_FILE=$PWD/bin/developer_overrides.tfrc` so Terraform uses your
+  built provider; put scratch configs in `playground/` (it's gitignored).
+- **Key directories:** `provider/` (all provider code — one package per
+  resource/data source), `docs/` (**published to the Terraform Registry** — no
+  internal notes here), `playground/` (gitignored manual harnesses), `scripts/`,
+  `bin/`.
+- **Sandbox:** `make build`, `go build`/`vet`/`test`, and
+  terraform-with-dev-overrides often need the sandbox disabled; the first time
+  you hit it, confirm the user's per-session preference.
+
+---
+
+## Migration playbook (SDKv2 → Plugin Framework)
+
+The provider is migrated one data source / resource at a time. Most rules below
+fall out of the protocol-v5 mux and out of "keep existing acceptance tests
+green".
+
+**Reading guide:** §2 is split by kind and each subsection is self-contained —
+read only the one you're migrating. Everything else applies to **both** kinds;
+the few kind-specific bullets are tagged _(data sources)_ / _(resources)_.
+
+### 0. Before you start
+
+- **The old SDKv2 source is the baseline spec — but not bug-free.** Tickets are
+  templated and vague; the behavioural spec is the existing SDKv2 code, so
+  replicate what it did by default. Treat it as fallible, though: some quirks
+  are genuine bugs, and the migration is a fair time to fix or improve things
+  **as long as the change is non-breaking** (schema and observable behaviour
+  stay backwards-compatible; see §4). When you spot a likely bug or a worthwhile
+  improvement, **stop and confirm with the user** before deviating — don't
+  silently "fix" it, and don't silently carry a known bug forward.
+- **Migrations are often stacked.** A task may depend on helpers/files added on
+  an earlier migration branch that are **not on `main`** (e.g.
+  `provider/pro/flatten.go`). Verify prerequisites exist on your base
+  before writing code (`git show HEAD:<path>`). If stacked, the **PR base should
+  be the parent migration branch**, not `main`, so the diff stays scoped.
+
+### 1. Schema type translation (non-negotiable mux v5 rules)
+
+- **Nested structures are BLOCKS, never nested attributes.**
+  `TypeList`/`TypeSet` \+ `Elem: &schema.Resource{}` becomes
+  `schema.ListNestedBlock` / `schema.SetNestedBlock` — **not** the
+  `*NestedAttribute` variants. Nested attributes require protocol v6 and will
+  **panic at runtime** under the v5 mux. `TypeSet` → `SetNestedBlock`;
+  `TypeList` → `ListNestedBlock`. See the comment in
+  `provider/regions/datasource_regions.go`.
+- **Primitive collections are ATTRIBUTES.** `TypeList`/`TypeSet` +
+  `Elem: &schema.Schema{}` (list/set of primitives, e.g. strings) →
+  `schema.ListAttribute`/`SetAttribute` with `ElementType`; `TypeMap` →
+  `schema.MapAttribute`. Only list/set **of objects** are blocks.
+
+### 2. Package & file layout
+
+Each migrated data source / resource gets its own package dir, unless it belongs
+to an existing grouping (e.g. `provider/activeactive`, `provider/pro`). After
+migrating, delete the old SDKv2 implementation.
+
+#### 2.1 Data sources
+
+Blueprint: `provider/essentialsplan` (`rediscloud_essentials_plan`) — read it
+with its PR/commit history. Three files:
+
+- `datasource_<x>.go` — interface asserts (`var _ datasource.DataSource = ...`,
+  `...WithConfigure`), `New<X>DataSource`, `Metadata`, `Configure`, `Schema`.
+- `datasource_<x>_model.go` — the `tfsdk`-tagged model struct.
+- `datasource_<x>_read.go` — `Read` + any flatten helpers.
+
+#### 2.2 Resources
+
+Blueprint: `provider/cloudaccount` (`rediscloud_cloud_account`) — read it with
+its PR/commit history. Three files:
+
+- `resource_<x>.go` — interface asserts (`resource.Resource`,
+  `...WithConfigure`, `...WithImportState`), `New<X>Resource`, `Metadata`,
+  `Configure`, `Schema`.
+- `resource_<x>_model.go` — the `tfsdk`-tagged model struct.
+- `resource_<x>_crud.go` — `Create`/`Read`/`Update`/`Delete`/`ImportState` +
+  wait helpers.
+
+**Resource CRUD gotchas** (not obvious from the framework docs):
+
+- **Create/Update can't delegate to Read** the way SDKv2 did
+  (`return ...Read(...)`) — the framework request/response signatures differ.
+  Factor a `read<X>IntoModel(...) (notFound bool)` helper and call it from all
+  three; on not-found, `resp.State.RemoveResource(ctx)` (the framework's
+  `d.SetId("")`).
+- **Fields the API never returns must be left UNTOUCHED by that helper** (e.g.
+  secret key, console user/pass, sign-in URL). Assigning
+  `StringPointerValue(nil)` silently wipes them to null — SDKv2 just never
+  `d.Set` them, preserving the config/state value. Tests skip them via
+  `ImportStateVerifyIgnore`.
+- **State-change waiters stay on SDKv2.** A framework resource still imports
+  `terraform-plugin-sdk/v2/helper/retry` (`retry.StateChangeConf` /
+  `WaitForStateContext`) — there's no framework-native poller, so this is
+  expected, not a leftover to "fix".
+- **A resource that polls for a ready state must not orphan the remote object on
+  poll failure.** When Create (or Update) provisions the object then waits for
+  it to become active/ready, a timed-out or failed wait must still write the
+  object to state before returning the error — persist the `id` and the last
+  observed status via `resp.State.Set` — otherwise the created object leaks
+  (untracked, unrecoverable, and the next apply makes a duplicate). SDKv2 got
+  this for free (`d.SetId()` before the wait is persisted even on error); the
+  framework does not, so do it explicitly. Have the poll helper _return_ the
+  last observed status so you can record it without a second read (fall back to
+  a null status if the first poll never landed). Precedent:
+  `provider/cloudaccount` resource `Create`.
+- **Delete is not idempotent, by design.** Redis TF resources assume their infra
+  is managed **only** by Terraform, so `Delete` propagates the API error rather
+  than swallowing a NotFound. If the object was removed out-of-band,
+  `terraform destroy` **fails** — that's expected, not a bug to "fix" (don't add
+  NotFound-tolerance to `Delete`). Contrast the first gotcha: `Read` _does_
+  treat NotFound as "gone" and drops the resource from state; `Delete` does not.
+
+### 3. Registration
+
+- Add the constructor to `provider/framework_provider.go` (`DataSources()` /
+  `Resources()`) and import the package.
+- Remove the old entry from `provider/sdk_provider.go`, leaving a marker:
+  `// Note: <public_name> is served by the Plugin Framework provider`.
+- `Metadata` TypeName = `req.ProviderTypeName + "_<suffix>"`. **Watch
+  public-name vs file-name mismatches**: `rediscloud_subscription` is the
+  pro/flexible subscription but its package/type is "pro" — suffix is
+  `_subscription`, not `_pro_subscription`.
+- **The Framework has no implicit `id`.** SDKv2 had a mandatory implicit `id`;
+  the Framework treats `id` as an ordinary attribute — nothing in the framework,
+  the mux, or `terraform-plugin-testing` requires one. So whether to add an `id`
+  depends on _why_ it would exist:
+  - _Migrating from SDKv2:_ **add** an explicit `Computed` `id` `StringAttribute`
+    (e.g. `strconv.Itoa(subId)`). The SDKv2 version always exposed an `id`, so
+    keeping it is backward compatibility — existing configs/state/tests reference
+    `.id`. This is the only reason the rule reads "always add an id" for migrations.
+  - _Brand-new (no SDKv2 predecessor):_ add an `id` **only if it's functionally
+    meaningful** (e.g. it's the object's real identifier and is useful to
+    reference downstream); **skip it otherwise**. There's no compatibility
+    constraint, so don't invent a placeholder id just to have one — an absent
+    attribute is more honest than a sentinel that implies meaning it lacks.
+  - Precedent: the net-new plural `rediscloud_subscriptions` data source
+    (`provider/pro`) **omits** a top-level `id` — a list has no meaningful single
+    identifier, and each element already carries its own `id`. Contrast the older
+    SDKv2 aggregate data sources (`rediscloud_database_modules`,
+    `rediscloud_subscription_peerings`), which set `id = "ALL"` as a sentinel
+    purely because SDKv2 _required_ a non-empty id.
+
+### 4. Schema & docs fidelity
+
+- Preserve the schema **exactly**: attribute names, types,
+  computed/optional/required, block nesting — otherwise acceptance tests break.
+  Diff against the old schema; note per-field differences between siblings (e.g.
+  pro-sub `name` is `Computed`+`Optional`, AA `name` is `Required`).
+- Replace placeholder descriptions (`"Self-explanatory"`) with short, meaningful
+  ones in the files you touch. Keep the schema description, the sibling
+  resource/data source, and the `docs/` markdown consistently worded.
+- Only touch `docs/` markdown if the schema actually changes — a faithful
+  migration keeps it identical (exception: placeholder cleanup, when asked).
+
+### 5. Value mapping (scalars)
+
+- **null-for-nil** (see blueprint): `StringPointerValue` / `Float64PointerValue`
+  / `BoolPointerValue` (nil → null); ints →
+  `Int64Value(int64(redis.IntValue(...)))` (0 for nil).
+- Fields the old code always stringifies (e.g. an int id) →
+  `types.StringValue(strconv.Itoa(redis.IntValue(...)))` (always present, never
+  null).
+- Match SDKv2 special-case defaults, e.g. `public_endpoint_access` defaults to
+  `true` when the API returns nil.
+- **Empty-string vs null — testing gotcha.** `terraform-plugin-testing` treats
+  an **absent** attribute as equal to `""`. A framework `types.StringNull()`
+  renders as _absent_ in the test flatmap, satisfying **both**
+  `TestCheckResourceAttr(k, "")` **and** `TestCheckNoResourceAttr(k)`. So
+  null-for-nil is safe even when a test asserts `== ""`; you rarely need
+  `StringValue("")`.
+- **Prefer `rediscloud-go-api` constants over hardcoded literals.** Wherever the
+  SDK exposes a value you'd otherwise hardcode — status strings, provider/enum
+  values, etc. — reference the constant (`cloud_accounts.StatusActive`,
+  `cloud_accounts.StatusDeleted`, `cloud_accounts.ProviderValues()`, …) rather
+  than a magic string. It's a non-breaking readability/robustness win — the value
+  tracks the SDK — that fits the migration, so make the swap when you spot one.
+  Precedent: the status constants in `provider/cloudaccount`'s wait helpers and
+  the `provider_type` `OneOf(cloud_accounts.ProviderValues()...)` validator.
+
+### 6. Helpers
+
+Two concerns: building framework values from API data (6.1), and reusing or
+retiring the shared helper set (6.2).
+
+#### 6.1 Flatten helpers (collections)
+
+- Build nested collections with attr-type maps + `types.ObjectValue` +
+  `types.ListValue`/`SetValue`; primitive collections via `types.ListValueFrom`
+  / `MapValueFrom`. This is the `provider/pro` style (`FlattenMaintenance`,
+  `FlattenPricing`).
+- Alternative **typed-struct** style: `tfsdk`-tagged nested structs +
+  `types.ObjectValueFrom` / `ListValueFrom` (the `provider/regions` style).
+  Cleaner and type-checked, but mixes idioms if the file also uses the
+  hand-rolled style.
+- **Model fields stay `types.List` / `types.Set`.** The framework has no generic
+  typed list value and the shared `pro.Flatten*` helpers return `types.List`,
+  so receiving fields must match. Do **not** convert model fields to `[]struct`:
+  you lose null/unknown fidelity, can't assign shared-helper output, and diverge
+  from precedent.
+- A flatten's behavioural spec is the **old SDKv2 flatten** — replicate its
+  quirks (e.g. the pro cloud-details `isResource=false` path leaves region-level
+  `networking_vpc_id` unset and always returns a non-nil `resource_tags` map).
+- **Deterministic ordering.** The API can return nondeterministically-ordered
+  lists (e.g. pricing) → sort by a composite key inside the flatten to kill a
+  perpetual plan diff. Shared helpers already do this — inherit it, don't change
+  it.
+
+#### 6.2 Shared helpers & old-helper cleanup
+
+- Shared subscription helpers live in the `provider/pro` package —
+  `FilterSubscriptions` (in `datasource_rediscloud_pro_subscription.go`),
+  `FlattenMaintenance` / `FlattenPricing` (in `flatten.go`), and the
+  `CMK_ENABLED_STRING` constant. Reuse; don't duplicate.
+- Filter-helper naming stays `filter<Singular>` (`pro.FilterSubscriptions` +
+  `filterSubscription` predicate) — consistent with ~14 other data sources.
+- **Grep the WHOLE provider for remaining callers before deleting any old
+  helper.** SDKv2 code often still needs the map-based `Flatten*` helpers and
+  constants (e.g. `CMK_ENABLED_STRING`); only remove what's now unused. Grep on
+  the **correct (stacked) base** — a prior migration may already have removed
+  callers.
+- If a duplicated helper's only remaining caller is another SDKv2 file that can
+  use the migrated equivalent (identical signature), **repoint it and delete the
+  duplicate** rather than leaving a near-empty file. (We repointed the SDKv2
+  AA-regions data source to the shared `pro.FilterSubscriptions` and deleted the
+  duplicate helper.)
+- **Leave a removal note on SDKv2-only helpers.** A helper kept alive only
+  because SDKv2 code still calls it is migration debt — mark it in place so a
+  later session deletes it instead of guessing, e.g.
+  `// SDKv2-only: remove once the remaining callers (X, Y) are migrated to the framework.`
+  Use a plain comment, not a godoc `// Deprecated:` marker (which would flag
+  every caller in linters). When the grep above shows no SDKv2 callers remain,
+  delete the helper and its note.
+
+### 7. Tests
+
+- Keep tests schema-compatible so they pass unchanged.
+- **Unit-test the pure helpers you introduce/migrate.** Standalone helpers
+  (filters, `Flatten*`, sort keys) get table-driven tests in
+  `package <pkg>_test` with testify — decoupled from TF/mux, no acceptance
+  creds. This is the cheap regression net the migration otherwise lacks (e.g. it
+  pins the pricing deterministic sort). Exercise unexported helpers through
+  their exported callers. Example: `provider/pro/flatten_test.go`.
+- **Acceptance tests** need real API creds and can't run locally; the
+  `terraform-plugin-testing` framework runs them only when `TF_ACC=1` (set by
+  `make testacc`). There is no `EXECUTE_TESTS` or `testing.Short()` gate.
+- **Prechecks go through the `envchecks` package.** Set
+  `PreCheck: envchecks.ComposePreChecks(t, envchecks.RedisCloudCheck, <more>...)`
+  — it runs every check and fails **once** with the full list of missing env
+  vars (the old per-package `BasicPreCheck` and the `utils.AccRequiresEnvVar`
+  **skip** are gone; there's no skip-vs-fail split any more — everything fails).
+  Ready-made checks: `RedisCloudCheck` (URL + access/secret key),
+  `AWSProviderCheck`, `GCPProviderCheck`, or `RequireEnvVars(t, ...)` for ad-hoc
+  vars. When a test needs a var's **value**, use a value+check pair so the same
+  var is read _and_ gated — `name, check := envchecks.AWSBYOCValueAndCheck()`
+  (also `ValueAndCheck(key)`, `GCPProjectValueAndCheck`,
+  `AwsPeeringValueAndCheck`) — and pass `check` into `ComposePreChecks`.
+- **Unchanged wiring:**
+  `ProtoV5ProviderFactories: testhelpers.ProtoV5ProviderFactories()`; get an API
+  client for `CheckDestroy` / sweepers via `client.GetTestClient()`; name
+  resources with `utils.RandomWithPrefix()` (honours `TEST_RESOURCE_PREFIX`).
+- **A `testdata/*.tf` file maps to a config _form_, not a scenario.** Scenarios
+  that share structure and differ only in values reuse **one** parameterised
+  file via per-step `ConfigVariables`. Add a separate `.tf` only when the
+  _structure_ differs (e.g. a GCP cloud account taking different arguments than
+  AWS) — don't fork just to hardcode different values.
+- _(Data sources)_ Relocate a data-source test only if it's a **standalone**
+  test file → move it into the package as `package <pkg>_test`. If the
+  assertions are **embedded** in a combined resource+datasource test, leave them
+  (AA precedent). The essentialsplan blueprint relocated its standalone test.
+
+### 8. Verify
+
+- `go build ./...` · `go vet ./...` · `make fmtcheck` (goimports
+  `-local github.com/RedisLabs/...`).
+- Run unit tests for the package + `provider/utils`.
+- A pre-existing acceptance test that hard-fails on a missing env var is
+  probably **environmental and not your regression** — confirm it fails
+  identically on the base.
+- Prepare testing .tf files for the user to perform manual testing
+  - drive the freshly-built provider from `playground/` (gitignored; split into
+    `datasource/` and `resource/` if needed)
+  - **The shared test env is wiped daily**. This applies both to resources and
+    data sources, but has more impact on data sources, because usually have no
+    object to read. In that case first `apply` a resource in
+    `playground/resource/` to create one, then point the data-source config in
+    `playground/datasource/` at it and `plan`.
+  - **Setup:** `make build`, then export
+    `TF_CLI_CONFIG_FILE=$PWD/bin/developer_overrides.tfrc` and
+    `REDISCLOUD_ACCESS_KEY` / `REDISCLOUD_SECRET_KEY` (+ any vars the resource
+    needs); dev-overrides let you skip `terraform init`.
+  - _(Data sources)_ - Keep the data-source `.tf` in its own dir, separate from
+    any resource `.tf`.\*\* A data source relies on infra that already exists,
+    so sharing a config with the resource that creates that same infra, forces
+    data source fields to be calculated as "known after apply" and hides the
+    values until you run a second `tf apply`. When data source and resource are
+    kept separate, `terraform apply` on the resource first, allows a
+    `terraform plan` on the data source, ran as a second step, to read the data
+    at plan time with full values.
+
+---
+
+## Maintaining this document
+
+Living doc — update it when you finish a migration or hit something surprising:
+
+- **Add durable, reusable knowledge only** — recurring decisions, non-obvious
+  mux behaviours, precedents, gotchas. Not one-off task details or anything
+  obvious from the code / git history.
+- **Correct/merge in place; don't append contradictions.** If a rule turns out
+  wrong or narrower/broader than stated, fix it where it lives.
+- **Cite a concrete anchor** (a precedent file, blueprint, verified test
+  behaviour) so the next session can check it rather than trust it blindly.
+- **Keep §2.1 and §2.2 self-contained as both paths grow.** Data sources and
+  resources are both exercised now; when one gains a gotcha, check whether the
+  other needs the mirror note — but don't make one subsection depend on the
+  other.
+- When you rely on a rule, **sanity-check it still holds** (files move, helpers
+  migrate). If it names a file/helper that no longer exists, update the anchor.


### PR DESCRIPTION
This PR replaces [#941](https://github.com/RedisLabs/terraform-provider-rediscloud/pull/941), which GitHub automatically closed when its `release/2.19.0` base branch was deleted.

Introduce AGENTS.md

- Documents general things about the project
- Add a SDKv2 => Framework migration skill - this is the main dish

**Disclaimer:** This is still a Draft as the agents.md/skills are actively updated with the latest know-hows from the ongoing migrations of the Cloud Account resource, AA and Pro subscription data sources. The current assertion is that this PR will be merged after those PRs are merged. So it's expected that many of the refs here are for things that have not yet landed on the base branch.

Validation after rebasing onto `main`:

- Agent Skill validation passed
- `nix develop --command make ci`
