### PR TITLE
fix: Fix Active-Active Database constant drift

### DIFF
--- a/provider/activeactive/active_active_database_resource_test.go
+++ b/provider/activeactive/active_active_database_resource_test.go
@@ -1,0 +1,278 @@
+package activeactive_test
+
+// This file exercises the real redis_version / redis_version_actual plan modifiers
+// (activeactive.RedisVersion / RedisVersionActual) end-to-end through Terraform's plan/apply
+// pipeline, WITHOUT provisioning any real infrastructure.
+//
+// It defines a minimal "test_active_active_subscription_database" resource that wires those exact
+// modifiers onto two attributes and backs its CRUD with an in-memory "running version" (the api
+// stub). The generic throwaway provider that serves it lives in testhelpers.FrameworkProviderFactories.
+// resource.UnitTest drives real Terraform against it, so the modifiers run as Terraform would run
+// them — catching plan idempotency and plan/apply consistency behaviour that direct
+// PlanModifyString calls cannot.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/activeactive"
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/testhelpers"
+)
+
+const defaultRedisVersion = "8.0"
+
+type api struct {
+	redisVersion string
+}
+
+type activeActiveDatabaseResource struct{ api *api }
+
+var _ tfresource.Resource = &activeActiveDatabaseResource{}
+
+type activeActiveDatabaseModel struct {
+	ID                 types.String `tfsdk:"id"`
+	RedisVersion       types.String `tfsdk:"redis_version"`
+	RedisVersionActual types.String `tfsdk:"redis_version_actual"`
+}
+
+func newActiveActiveDatabaseResource(api *api) func() tfresource.Resource {
+	return func() tfresource.Resource { return &activeActiveDatabaseResource{api: api} }
+}
+
+func (r *activeActiveDatabaseResource) Metadata(_ context.Context, req tfresource.MetadataRequest, resp *tfresource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_active_active_subscription_database"
+}
+
+func (r *activeActiveDatabaseResource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *tfresource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"redis_version": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					activeactive.RedisVersion(),
+				},
+			},
+			"redis_version_actual": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					activeactive.RedisVersionActual(),
+				},
+			},
+		},
+	}
+}
+
+// Keep in sync: ./resource_active_active_database_crud.go (createDatabase)
+func (r *activeActiveDatabaseResource) Create(ctx context.Context, req tfresource.CreateRequest, resp *tfresource.CreateResponse) {
+	var plan activeActiveDatabaseModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Mirror the real create API: when redis_version is omitted, the database is created at a
+	// server-chosen default version rather than failing.
+	requested := defaultRedisVersion
+	if !plan.RedisVersion.IsNull() && plan.RedisVersion.ValueString() != "" {
+		requested = plan.RedisVersion.ValueString()
+	}
+
+	r.api.redisVersion = requested // created at the requested (or default) version
+
+	plan.ID = types.StringValue(acctest.RandomWithPrefix("aa-db"))
+	plan.RedisVersion = types.StringValue(requested)
+	plan.RedisVersionActual = types.StringValue(r.api.redisVersion)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Keep in sync: ./resource_active_active_database_crud.go (readDatabase)
+func (r *activeActiveDatabaseResource) Read(ctx context.Context, req tfresource.ReadRequest, resp *tfresource.ReadResponse) {
+	var state activeActiveDatabaseModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.RedisVersion.IsNull() || state.RedisVersion.ValueString() == "" {
+		state.RedisVersion = types.StringValue(r.api.redisVersion)
+	}
+	state.RedisVersionActual = types.StringValue(r.api.redisVersion)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Keep in sync: ./resource_active_active_database_crud.go (updateDatabase, readDatabase)
+func (r *activeActiveDatabaseResource) Update(ctx context.Context, req tfresource.UpdateRequest, resp *tfresource.UpdateResponse) {
+	var plan activeActiveDatabaseModel
+	state := &activeActiveDatabaseModel{}
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Mirror updateDatabase's upgrade guard: only issue a version upgrade when the requested
+	// redis_version differs from both the prior requested value AND the running version. Together
+	// with the redis_version plan modifier (which keeps the prior value when the request is already
+	// satisfied) this is what prevents an in-place downgrade after a background auto minor upgrade.
+	if !plan.RedisVersion.IsNull() && state != nil && !state.RedisVersion.IsNull() && plan.RedisVersion.ValueString() != state.RedisVersion.ValueString() && plan.RedisVersion.ValueString() != state.RedisVersionActual.ValueString() { //nolint:govet // state != nil kept to mirror production's updateDatabase guard verbatim
+		r.api.redisVersion = plan.RedisVersion.ValueString() // UpgradeRedisVersion(target)
+	}
+
+	// Mirror readDatabase: heal an empty redis_version from the running version, then always reflect
+	// the running version in redis_version_actual. On a genuine upgrade the redis_version_actual
+	// modifier left this unknown, so writing the new running version resolves it; otherwise it
+	// re-writes the unchanged running version.
+	if plan.RedisVersion.IsNull() || plan.RedisVersion.ValueString() == "" {
+		plan.RedisVersion = types.StringValue(r.api.redisVersion)
+	}
+	plan.RedisVersionActual = types.StringValue(r.api.redisVersion)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *activeActiveDatabaseResource) Delete(_ context.Context, _ tfresource.DeleteRequest, _ *tfresource.DeleteResponse) {
+}
+
+func newAADatabaseConfigNoVersion() string {
+	return `resource "test_active_active_subscription_database" "aa_db" {
+}`
+}
+
+func newAADatabaseConfig(redisVersion string) string {
+	return fmt.Sprintf(`resource "test_active_active_subscription_database" "aa_db" {
+  redis_version = %q
+}`, redisVersion)
+}
+
+func TestUnitActiveActiveDatabaseVersion_DefaultsWhenOmitted(t *testing.T) {
+	api := &api{}
+
+	resourceName := "test_active_active_subscription_database.aa_db"
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testhelpers.FrameworkProviderFactories(newActiveActiveDatabaseResource(api)),
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfigNoVersion(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.0"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.0"),
+				),
+			},
+			{
+				Config: newAADatabaseConfigNoVersion(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+func TestUnitActiveActiveDatabaseVersion_SatisfiedRequestIsNoOp(t *testing.T) {
+	api := &api{}
+
+	resourceName := "test_active_active_subscription_database.aa_db"
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testhelpers.FrameworkProviderFactories(newActiveActiveDatabaseResource(api)),
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig("8.4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.4"),
+				),
+			},
+			{
+				Config: newAADatabaseConfig("8.2"), // lower than running 8.4 -> satisfied
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.4"),
+				),
+			},
+		},
+	})
+}
+
+// A genuine upgrade recomputes the running version without a plan/apply inconsistency (which
+// would otherwise surface as "Provider produced inconsistent result after apply").
+func TestUnitActiveActiveDatabaseVersion_GenuineUpgrade(t *testing.T) {
+	api := &api{}
+
+	resourceName := "test_active_active_subscription_database.aa_db"
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testhelpers.FrameworkProviderFactories(newActiveActiveDatabaseResource(api)),
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig("8.2"),
+				Check:  resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.2"),
+			},
+			{
+				Config: newAADatabaseConfig("8.4"), // higher than running 8.2 -> genuine upgrade
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.4"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.4"),
+				),
+			},
+		},
+	})
+}
+
+// A background auto-upgrade moves the running version past the requested one; a subsequent config
+// change to a still-lower version must be a no-op (never an in-place downgrade).
+func TestUnitActiveActiveDatabaseVersion_BackgroundUpgradeThenLowerRequestIsNoOp(t *testing.T) {
+	api := &api{}
+
+	resourceName := "test_active_active_subscription_database.aa_db"
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testhelpers.FrameworkProviderFactories(newActiveActiveDatabaseResource(api)),
+		Steps: []resource.TestStep{
+			{
+				Config: newAADatabaseConfig("8.2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.2"),
+				),
+			},
+			{
+				PreConfig: func() {
+					api.redisVersion = "8.6" // simulate background auto minor upgrade
+				},
+				Config: newAADatabaseConfig("8.4"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(resourceName, "redis_version_actual", "8.6"),
+				),
+			},
+		},
+	})
+}

--- a/provider/activeactive/rediscloud_active_active_database_test.go
+++ b/provider/activeactive/rediscloud_active_active_database_test.go
@@ -215,7 +215,9 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceName, "external_endpoint_for_oss_cluster_api", "true"),
 				),
 			},
-			// Simulate auto_minor_version_upgrade having gone through
+			// Requesting a lower redis_version than the running one (as happens after a background
+			// auto minor upgrade) is already satisfied, so it is a no-op: redis_version keeps the
+			// running value (8.4) and no in-place downgrade is attempted.
 			{
 				ConfigFile: config.StaticFile("./testdata/database_crudi_update.tf"),
 				ConfigVariables: config.Variables{
@@ -225,7 +227,7 @@ func TestAccResourceRedisCloudActiveActiveDatabase_CRUDI(t *testing.T) {
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(databaseResourceName, "name", databaseNameUpdated),
-					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.2"),
+					resource.TestCheckResourceAttr(databaseResourceName, "redis_version", "8.4"),
 					resource.TestCheckResourceAttr(databaseResourceName, "redis_version_actual", "8.4"),
 					resource.TestCheckResourceAttr(databaseResourceName, "dataset_size_in_gb", "1"),
 					resource.TestCheckResourceAttr(databaseResourceName, "support_oss_cluster_api", "true"),

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )
 
 var (
@@ -129,6 +130,107 @@ func (m emptyStringToNullModifier) PlanModifyString(_ context.Context, req planm
 // in agreement and avoid "planned set element does not correlate" errors on parent set blocks.
 func EmptyStringToNull() planmodifier.String {
 	return emptyStringToNullModifier{}
+}
+
+// redisVersionModifier ports the Pro database's SuppressIfRedisVersionSatisfied DiffSuppressFunc to
+// the framework. If the running version (redis_version_actual) already satisfies the requested
+// redis_version — same major and actual >= requested — the requested change is treated as a no-op
+// (keep the prior value), so no update is planned. This implements "the requested version is a
+// floor" and, in particular, avoids attempting an in-place downgrade when a background auto minor
+// upgrade has moved the actual version past the requested one. It also subsumes UseStateForUnknown
+// (keeps the prior value when redis_version is not explicitly requested).
+type redisVersionModifier struct{}
+
+var _ planmodifier.String = redisVersionModifier{}
+
+func (m redisVersionModifier) Description(_ context.Context) string {
+	return "Keeps the prior requested version when the running version already satisfies it (same major, actual >= requested)."
+}
+
+func (m redisVersionModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m redisVersionModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Nothing to preserve on create.
+	if req.StateValue.IsNull() {
+		return
+	}
+	// No explicit request: keep the prior value (UseStateForUnknown behaviour) so a computed
+	// unknown plan value doesn't churn.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+	// If the running version already satisfies the request, suppress the change (keep the prior
+	// value); otherwise leave the configured value in place — a genuine upgrade.
+	var actual types.String
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("redis_version_actual"), &actual)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !actual.IsNull() && !actual.IsUnknown() &&
+		utils.RedisVersionSatisfied(req.ConfigValue.ValueString(), actual.ValueString()) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+// RedisVersion returns the plan modifier for the requested redis_version attribute.
+func RedisVersion() planmodifier.String {
+	return redisVersionModifier{}
+}
+
+// redisVersionActualModifier keeps the prior redis_version_actual value in the plan unless a genuine
+// upgrade is requested (the running version does not satisfy the requested redis_version), in which
+// case it lets the value be recomputed. This gives the framework resource the same behaviour SDKv2
+// provides for free on the Pro database (stable on non-version in-place updates, refreshed on
+// upgrade). A plain Computed field would show a spurious "known after apply" diff on every update;
+// UseStateForUnknown would instead pin the value and cause "Provider produced inconsistent result
+// after apply" when an upgrade legitimately changes the running version.
+type redisVersionActualModifier struct{}
+
+var _ planmodifier.String = redisVersionActualModifier{}
+
+func (m redisVersionActualModifier) Description(_ context.Context) string {
+	return "Uses the prior state value unless a genuine redis_version upgrade is requested, in which case redis_version_actual is recomputed."
+}
+
+func (m redisVersionActualModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m redisVersionActualModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Same guards as UseStateForUnknown: nothing to do on create, when the value is already known
+	// (e.g. destroy leaves a null plan value), or with an unknown config value.
+	if req.StateValue.IsNull() {
+		return
+	}
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// req.StateValue is the running version. If the requested redis_version is NOT satisfied by it
+	// (a genuine upgrade will occur), leave the value unknown so apply can set the new running
+	// version without a plan/apply inconsistency. Otherwise keep the prior value (no churn).
+	var configVersion types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("redis_version"), &configVersion)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !configVersion.IsNull() && !configVersion.IsUnknown() &&
+		!utils.RedisVersionSatisfied(configVersion.ValueString(), req.StateValue.ValueString()) {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}
+
+// RedisVersionActual returns the plan modifier for the computed redis_version_actual attribute.
+func RedisVersionActual() planmodifier.String {
+	return redisVersionActualModifier{}
 }
 
 // Schema defines the schema for the resource.
@@ -237,12 +339,15 @@ func (r *activeActiveDatabaseResource) Schema(ctx context.Context, _ resource.Sc
 				//TODO(TF3.0) drop Computed and stop writing redis_version from Read — makes the field write-only-by-convention (no plugin-framework migration), so state only ever holds what the user wrote in config and auto-upgrades can't drift state. DSF stays to heal state poisoned by older provider versions.
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					RedisVersion(),
 				},
 			},
 			"redis_version_actual": schema.StringAttribute{
 				Description: "The actual Redis database version",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					RedisVersionActual(),
+				},
 			},
 			"support_oss_cluster_api": schema.BoolAttribute{
 				Description: "Support Redis open-source (OSS) Cluster API",

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -16,6 +16,7 @@ import (
 )
 
 // createDatabase implements the Create operation for the active-active database resource.
+// Keep in sync: ./active_active_database_resource_test.go
 func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) {
 	subId := int(plan.SubscriptionID.ValueInt64())
 
@@ -168,6 +169,7 @@ func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan 
 
 // readDatabase implements the Read operation for the active-active database resource.
 // Returns true if the resource was removed (not found).
+// Keep in sync: ./active_active_database_resource_test.go
 func (r *activeActiveDatabaseResource) readDatabase(ctx context.Context, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) bool {
 	subId, dbId, err := parseResourceId(state.ID.ValueString())
 	if err != nil {
@@ -364,6 +366,7 @@ func ensureNoUnknownFields(state *ActiveActiveDatabaseModel) {
 }
 
 // updateDatabase implements the Update operation for the active-active database resource.
+// Keep in sync: ./active_active_database_resource_test.go
 func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) {
 	subId, dbId, err := parseResourceId(plan.ID.ValueString())
 	if err != nil {

--- a/provider/activeactive/resource_active_active_database_test.go
+++ b/provider/activeactive/resource_active_active_database_test.go
@@ -1,0 +1,50 @@
+package activeactive_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedisLabs/terraform-provider-rediscloud/provider/activeactive"
+)
+
+func hasModifier(t *testing.T, resp resource.SchemaResponse, attr string, want planmodifier.String) {
+	t.Helper()
+
+	a, ok := resp.Schema.Attributes[attr]
+	if !assert.True(t, ok, "attribute %q missing", attr) {
+		return
+	}
+
+	sa, ok := a.(schema.StringAttribute)
+	if !assert.True(t, ok, "attribute %q is not a StringAttribute", attr) {
+		return
+	}
+
+	found := false
+	for _, m := range sa.PlanModifiers {
+		if reflect.TypeOf(m) == reflect.TypeOf(want) {
+			found = true
+		}
+	}
+	if !assert.True(t, found, "attribute %q missing expected plan modifier %T", attr, want) {
+		return
+	}
+}
+
+// Wiring: prove the REAL Active-Active database resource attaches these modifiers to the version
+// attributes (the behaviour tests above run on a test resource, not this wiring).
+func TestUnitRedisVersionModifiersWired(t *testing.T) {
+	var resp resource.SchemaResponse
+	activeactive.NewActiveActiveDatabaseResource().Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	assert.False(t, resp.Diagnostics.HasError())
+
+	hasModifier(t, resp, "redis_version", stringplanmodifier.UseStateForUnknown())
+	hasModifier(t, resp, "redis_version_actual", stringplanmodifier.UseStateForUnknown())
+}

--- a/provider/activeactive/resource_active_active_database_test.go
+++ b/provider/activeactive/resource_active_active_database_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/activeactive"
@@ -45,6 +44,6 @@ func TestUnitRedisVersionModifiersWired(t *testing.T) {
 	activeactive.NewActiveActiveDatabaseResource().Schema(context.Background(), resource.SchemaRequest{}, &resp)
 	assert.False(t, resp.Diagnostics.HasError())
 
-	hasModifier(t, resp, "redis_version", stringplanmodifier.UseStateForUnknown())
-	hasModifier(t, resp, "redis_version_actual", stringplanmodifier.UseStateForUnknown())
+	hasModifier(t, resp, "redis_version", activeactive.RedisVersion())
+	hasModifier(t, resp, "redis_version_actual", activeactive.RedisVersionActual())
 }

--- a/provider/testhelpers/framework_test_provider.go
+++ b/provider/testhelpers/framework_test_provider.go
@@ -1,0 +1,52 @@
+package testhelpers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+// FrameworkTestProviderTypeName is the provider type name for the throwaway plugin-framework
+// provider built by FrameworkProviderFactories. Resources it serves therefore use type names
+// like "test_<suffix>" (set in their Metadata via req.ProviderTypeName).
+const FrameworkTestProviderTypeName = "test"
+
+type frameworkTestProvider struct {
+	resources []func() resource.Resource
+}
+
+var _ provider.Provider = &frameworkTestProvider{}
+
+func (p *frameworkTestProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = FrameworkTestProviderTypeName
+}
+
+func (p *frameworkTestProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{}
+}
+
+func (p *frameworkTestProvider) Configure(_ context.Context, _ provider.ConfigureRequest, _ *provider.ConfigureResponse) {
+}
+
+func (p *frameworkTestProvider) Resources(_ context.Context) []func() resource.Resource {
+	return p.resources
+}
+
+func (p *frameworkTestProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+// FrameworkProviderFactories builds a ProtoV5ProviderFactories map serving a throwaway
+// plugin-framework provider (type name "test") that exposes only the given resources. Use it to
+// unit-test resource/schema behaviour — e.g. plan modifiers — via resource.UnitTest, with no real
+// provider wiring or backend. A fresh map is returned each call to avoid cross-test mutation.
+func FrameworkProviderFactories(resources ...func() resource.Resource) map[string]func() (tfprotov5.ProviderServer, error) {
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		FrameworkTestProviderTypeName: providerserver.NewProtocol5WithError(&frameworkTestProvider{resources: resources}),
+	}
+}

--- a/provider/utils/redis_version.go
+++ b/provider/utils/redis_version.go
@@ -28,11 +28,22 @@ func SuppressIfRedisVersionSatisfied(_, _, newVal string, d *schema.ResourceData
 	if !ok {
 		return false
 	}
-	requested, err := version.NewVersion(newVal)
+	return RedisVersionSatisfied(newVal, actualRaw.(string))
+}
+
+// RedisVersionSatisfied reports whether a database already running actualVersion
+// satisfies a request for requestedVersion: same major version, with the running
+// version greater than or equal to the requested one. This treats "already at or
+// above the requested version" (e.g. after a background auto minor upgrade) as a
+// no-op rather than a change — and in particular avoids attempting an unsupported
+// in-place downgrade. Returns false if either version is unparseable or the majors
+// differ.
+func RedisVersionSatisfied(requestedVersion, actualVersion string) bool {
+	requested, err := version.NewVersion(requestedVersion)
 	if err != nil {
 		return false
 	}
-	actual, err := version.NewVersion(actualRaw.(string))
+	actual, err := version.NewVersion(actualVersion)
 	if err != nil {
 		return false
 	}

--- a/provider/utils/redis_version_test.go
+++ b/provider/utils/redis_version_test.go
@@ -46,3 +46,31 @@ func TestSuppressIfRedisVersionSatisfied(t *testing.T) {
 		})
 	}
 }
+
+func TestRedisVersionSatisfied(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		actual    string
+		satisfied bool
+	}{
+		{name: "running version ahead within major (bg auto-upgrade past request)", requested: "8.2", actual: "8.6", satisfied: true},
+		{name: "running version behind (genuine upgrade needed)", requested: "8.4", actual: "8.2", satisfied: false},
+		{name: "running version equals request", requested: "8.4", actual: "8.4", satisfied: true},
+		{name: "unchanged version (e.g. non-version update)", requested: "7.4", actual: "7.4", satisfied: true},
+		{name: "patch-level actual ahead satisfies", requested: "7.4", actual: "7.4.2", satisfied: true},
+		{name: "higher requested minor not satisfied", requested: "8.10", actual: "8.2", satisfied: false},
+		{name: "lower requested minor satisfied", requested: "8.2", actual: "8.10", satisfied: true},
+		{name: "cross-major upgrade not satisfied", requested: "9.0", actual: "8.6", satisfied: false},
+		{name: "cross-major downgrade not satisfied", requested: "7.0", actual: "8.6", satisfied: false},
+		{name: "unparseable requested not satisfied", requested: "not-a-version", actual: "8.6", satisfied: false},
+		{name: "unparseable actual not satisfied", requested: "8.4", actual: "not-a-version", satisfied: false},
+		{name: "empty requested not satisfied", requested: "", actual: "8.6", satisfied: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.satisfied, utils.RedisVersionSatisfied(tc.requested, tc.actual))
+		})
+	}
+}


### PR DESCRIPTION
This PR replaces [#971](https://github.com/RedisLabs/terraform-provider-rediscloud/pull/971), which GitHub automatically closed when its `release/2.19.0` base branch was deleted.

Besides the actual fix, this creates infrastructure to run Terraform unit tests without provisioning any external infrastructure while still exercising Terraform plan and apply operations.

It requires some copy and paste, but this gives us a mock backend and lets us exercise different plan, state, and configuration scenarios locally. Given that adding modifiers is not a daily activity, this is a useful way to catch unusual errors early.

The test setup also lets us add regression coverage so the issues are not reintroduced.

A safeguard is included in case the modifiers are dropped from the resource schema.

## Verification

- `nix develop --command make ci`
