### PR TITLE
chore: remove goreleaser toggle to remove changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,5 +51,3 @@ signs:
 release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  disable: true


### PR DESCRIPTION
allows the generated release notes passed via `--release-notes=...` to be used for the release