### PR TITLE
chore: Use user configured timeout, instead of hardcoded one

### DIFF
--- a/provider/activeactive/helpers.go
+++ b/provider/activeactive/helpers.go
@@ -295,12 +295,12 @@ func flattenBackupPlan(backup *databases.Backup, stateStorageType string) (types
 }
 
 // waitForDatabaseToBeDeleted waits for the database to be deleted using retry.StateChangeConf.
-func waitForDatabaseToBeDeleted(ctx context.Context, subId, dbId int, api *client.ApiClient) error {
+func waitForDatabaseToBeDeleted(ctx context.Context, subId, dbId int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:        30 * time.Second,
 		Pending:      []string{"pending"},
 		Target:       []string{"deleted"},
-		Timeout:      10 * time.Minute,
+		Timeout:      timeout,
 		PollInterval: 30 * time.Second,
 
 		Refresh: func() (result interface{}, state string, err error) {

--- a/provider/activeactive/resource_active_active_database.go
+++ b/provider/activeactive/resource_active_active_database.go
@@ -677,7 +677,7 @@ func (r *activeActiveDatabaseResource) Create(ctx context.Context, req resource.
 	defer cancel()
 
 	// Call the CRUD implementation
-	r.createDatabase(ctx, &plan, &resp.Diagnostics)
+	r.createDatabase(ctx, &plan, &resp.Diagnostics, createTimeout)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -705,7 +705,7 @@ func (r *activeActiveDatabaseResource) Read(ctx context.Context, req resource.Re
 	defer cancel()
 
 	// Call the CRUD implementation
-	removed := r.readDatabase(ctx, &state, &resp.Diagnostics)
+	removed := r.readDatabase(ctx, &state, &resp.Diagnostics, readTimeout)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -749,13 +749,13 @@ func (r *activeActiveDatabaseResource) Update(ctx context.Context, req resource.
 	defer cancel()
 
 	// Call the CRUD implementation
-	r.updateDatabase(ctx, &plan, &state, &resp.Diagnostics)
+	r.updateDatabase(ctx, &plan, &state, &resp.Diagnostics, updateTimeout)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Read back the state to get computed values
-	r.readDatabase(ctx, &plan, &resp.Diagnostics)
+	r.readDatabase(ctx, &plan, &resp.Diagnostics, updateTimeout)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -783,7 +783,7 @@ func (r *activeActiveDatabaseResource) Delete(ctx context.Context, req resource.
 	defer cancel()
 
 	// Call the CRUD implementation
-	r.deleteDatabase(ctx, &state, &resp.Diagnostics)
+	r.deleteDatabase(ctx, &state, &resp.Diagnostics, deleteTimeout)
 }
 
 // getAlertAttrTypes returns the attribute types for alert objects.

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"time"
 
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
@@ -16,7 +17,7 @@ import (
 )
 
 // createDatabase implements the Create operation for the active-active database resource.
-func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) {
+func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics, timeout time.Duration) {
 	subId := int(plan.SubscriptionID.ValueInt64())
 
 	// Acquire subscription mutex
@@ -120,7 +121,7 @@ func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan 
 	}
 
 	// Wait for subscription to be active before creating database
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		diagnostics.AddError("Subscription not active", err.Error())
 		return
@@ -139,14 +140,14 @@ func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan 
 	plan.DbID = types.Int64Value(int64(dbId))
 
 	// Wait for database to be active
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		diagnostics.AddError("Database failed to become active", err.Error())
 		return
 	}
 
 	// Wait for subscription to be active
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		diagnostics.AddError("Subscription failed to become active", err.Error())
 		return
@@ -157,18 +158,18 @@ func (r *activeActiveDatabaseResource) createDatabase(ctx context.Context, plan 
 
 	// Some attributes on a database are not accessible by the create API.
 	// Run the update function to apply any additional changes.
-	r.updateDatabase(ctx, plan, nil, diagnostics)
+	r.updateDatabase(ctx, plan, nil, diagnostics, timeout)
 	if diagnostics.HasError() {
 		return
 	}
 
 	// Read back the state to get computed values
-	r.readDatabase(ctx, plan, diagnostics)
+	r.readDatabase(ctx, plan, diagnostics, timeout)
 }
 
 // readDatabase implements the Read operation for the active-active database resource.
 // Returns true if the resource was removed (not found).
-func (r *activeActiveDatabaseResource) readDatabase(ctx context.Context, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) bool {
+func (r *activeActiveDatabaseResource) readDatabase(ctx context.Context, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics, timeout time.Duration) bool {
 	subId, dbId, err := parseResourceId(state.ID.ValueString())
 	if err != nil {
 		diagnostics.AddError("Invalid resource ID", err.Error())
@@ -233,7 +234,7 @@ func (r *activeActiveDatabaseResource) readDatabase(ctx context.Context, state *
 		globalSourceIPs = currentSourceIPs
 	} else {
 		// No custom value - compute default based on subscription's public_endpoint_access
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client, timeout); err != nil {
 			diagnostics.AddError("Failed to wait for subscription", err.Error())
 			return false
 		}
@@ -364,7 +365,7 @@ func ensureNoUnknownFields(state *ActiveActiveDatabaseModel) {
 }
 
 // updateDatabase implements the Update operation for the active-active database resource.
-func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) {
+func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan *ActiveActiveDatabaseModel, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics, timeout time.Duration) {
 	subId, dbId, err := parseResourceId(plan.ID.ValueString())
 	if err != nil {
 		diagnostics.AddError("Invalid resource ID", err.Error())
@@ -384,13 +385,13 @@ func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan 
 		}
 
 		// Wait for database to be active
-		if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client); err != nil {
+		if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client, timeout); err != nil {
 			diagnostics.AddError("Database failed to become active after update", err.Error())
 			return
 		}
 
 		// Wait for subscription to be active
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client, timeout); err != nil {
 			diagnostics.AddError("Subscription failed to become active after update", err.Error())
 			return
 		}
@@ -523,13 +524,13 @@ func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan 
 	}
 
 	// Wait for database to be active
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client, timeout); err != nil {
 		diagnostics.AddError("Database failed to become active after update", err.Error())
 		return
 	}
 
 	// Wait for subscription to be active
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, r.client, timeout); err != nil {
 		diagnostics.AddError("Subscription failed to become active after update", err.Error())
 		return
 	}
@@ -559,7 +560,7 @@ func (r *activeActiveDatabaseResource) updateDatabase(ctx context.Context, plan 
 }
 
 // deleteDatabase implements the Delete operation for the active-active database resource.
-func (r *activeActiveDatabaseResource) deleteDatabase(ctx context.Context, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics) {
+func (r *activeActiveDatabaseResource) deleteDatabase(ctx context.Context, state *ActiveActiveDatabaseModel, diagnostics *diag.Diagnostics, timeout time.Duration) {
 	subId, dbId, err := parseResourceId(state.ID.ValueString())
 	if err != nil {
 		diagnostics.AddError("Invalid resource ID", err.Error())
@@ -571,7 +572,7 @@ func (r *activeActiveDatabaseResource) deleteDatabase(ctx context.Context, state
 	defer utils.SubscriptionMutex.Unlock(subId)
 
 	// Wait for database to be active before deletion
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, r.client, timeout); err != nil {
 		diagnostics.AddError("Database not active", err.Error())
 		return
 	}

--- a/provider/activeactive/resource_active_active_database_crud.go
+++ b/provider/activeactive/resource_active_active_database_crud.go
@@ -584,7 +584,7 @@ func (r *activeActiveDatabaseResource) deleteDatabase(ctx context.Context, state
 	}
 
 	// Wait for deletion to complete
-	if err := waitForDatabaseToBeDeleted(ctx, subId, dbId, r.client); err != nil {
+	if err := waitForDatabaseToBeDeleted(ctx, subId, dbId, r.client, timeout); err != nil {
 		diagnostics.AddError("Database deletion failed", err.Error())
 		return
 	}

--- a/provider/datasource_rediscloud_active_active_transit_gateway.go
+++ b/provider/datasource_rediscloud_active_active_transit_gateway.go
@@ -153,7 +153,7 @@ func dataSourceActiveActiveTransitGatewayRead(ctx context.Context, d *schema.Res
 		}
 	} else {
 		// No waiting - use existing behaviour that waits for resource to be available
-		tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api)
+		tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api, utils.TransitGatewayProvisioningTimeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/provider/datasource_rediscloud_active_active_transit_gateway.go
+++ b/provider/datasource_rediscloud_active_active_transit_gateway.go
@@ -153,7 +153,7 @@ func dataSourceActiveActiveTransitGatewayRead(ctx context.Context, d *schema.Res
 		}
 	} else {
 		// No waiting - use existing behaviour that waits for resource to be available
-		tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api, utils.TransitGatewayProvisioningTimeout)
+		tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/provider/privatelink/resource_rediscloud_active_active_private_link.go
+++ b/provider/privatelink/resource_rediscloud_active_active_private_link.go
@@ -182,7 +182,7 @@ func resourceRedisCloudActiveActivePrivateLinkCreate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 
-	err = waitForActiveActivePrivateLinkToBeActive(ctx, api, subId, regionId)
+	err = waitForActiveActivePrivateLinkToBeActive(ctx, api, subId, regionId, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/provider/privatelink/resource_rediscloud_active_active_private_link.go
+++ b/provider/privatelink/resource_rediscloud_active_active_private_link.go
@@ -200,7 +200,7 @@ func resourceRedisCloudActiveActivePrivateLinkCreate(ctx context.Context, d *sch
 	//	return diag.FromErr(err)
 	//}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -360,7 +360,7 @@ func resourceRedisCloudActiveActivePrivateLinkDelete(ctx context.Context, d *sch
 
 	d.SetId("")
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/privatelink/resource_rediscloud_private_link.go
+++ b/provider/privatelink/resource_rediscloud_private_link.go
@@ -191,7 +191,7 @@ func resourceRedisCloudPrivateLinkCreate(ctx context.Context, d *schema.Resource
 	//	return diag.FromErr(err)
 	//}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -332,7 +332,7 @@ func resourceRedisCloudPrivateLinkDelete(ctx context.Context, d *schema.Resource
 
 	d.SetId("")
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/privatelink/resource_rediscloud_private_link.go
+++ b/provider/privatelink/resource_rediscloud_private_link.go
@@ -173,7 +173,7 @@ func resourceRedisCloudPrivateLinkCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(strconv.Itoa(subId))
 
-	err = waitForPrivateLinkToBeActive(ctx, api, subId)
+	err = waitForPrivateLinkToBeActive(ctx, api, subId, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/provider/privatelink/utils.go
+++ b/provider/privatelink/utils.go
@@ -14,15 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
-	"github.com/RedisLabs/terraform-provider-rediscloud/provider/utils"
 )
 
-func waitForPrivateLinkToBeActive(ctx context.Context, client *client.ApiClient, subscriptionId int) error {
+func waitForPrivateLinkToBeActive(ctx context.Context, client *client.ApiClient, subscriptionId int, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending: []string{
 			pl.PrivateLinkStatusInitializing},
 		Target:       []string{pl.PrivateLinkStatusActive},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
@@ -48,12 +47,12 @@ func waitForPrivateLinkToBeActive(ctx context.Context, client *client.ApiClient,
 	return nil
 }
 
-func waitForActiveActivePrivateLinkToBeActive(ctx context.Context, client *client.ApiClient, subscriptionId int, regionId int) error {
+func waitForActiveActivePrivateLinkToBeActive(ctx context.Context, client *client.ApiClient, subscriptionId int, regionId int, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending: []string{
 			pl.PrivateLinkStatusInitializing},
 		Target:       []string{pl.PrivateLinkStatusActive},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {

--- a/provider/pro/resource_rediscloud_pro_database.go
+++ b/provider/pro/resource_rediscloud_pro_database.go
@@ -409,6 +409,7 @@ func ResourceRedisCloudProDatabase() *schema.Resource {
 
 func resourceRedisCloudProDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subId := *utils.GetInt(d, "subscription_id")
 	utils.SubscriptionMutex.Lock(subId)
@@ -513,7 +514,7 @@ func resourceRedisCloudProDatabaseCreate(ctx context.Context, d *schema.Resource
 	createDatabase.AutoMinorVersionUpgrade = redis.Bool(d.Get("auto_minor_version_upgrade").(bool))
 
 	// Confirm sub is ready to accept a db request
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -527,11 +528,11 @@ func resourceRedisCloudProDatabaseCreate(ctx context.Context, d *schema.Resource
 	d.SetId(utils.BuildResourceId(subId, dbId))
 
 	// Confirm db + sub active status
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -539,11 +540,15 @@ func resourceRedisCloudProDatabaseCreate(ctx context.Context, d *schema.Resource
 	// Some attributes on a database are not accessible by the subscription creation API.
 	// Run the subscription update function to apply any additional changes to the databases, such as password, enableDefaultUser and so on.
 	utils.SubscriptionMutex.Unlock(subId)
-	updateDiags := resourceRedisCloudProDatabaseUpdate(ctx, d, meta)
+	updateDiags := resourceRedisCloudProDatabaseUpdateWithTimeout(ctx, d, meta, timeout)
 	return append(diags, updateDiags...)
 }
 
 func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudProDatabaseReadWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutRead))
+}
+
+func resourceRedisCloudProDatabaseReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	var diags diag.Diagnostics
@@ -723,7 +728,7 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 	} else if len(sourceIPs) == 0 || isDefaultSourceIPs(sourceIPsPtrs) {
 		// No custom value - ensure defaults match current public_endpoint_access setting
 		// Wait for subscription to be fully active to ensure we have the latest state
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 		subscription, err := api.Client.Subscription.Get(ctx, subId)
@@ -787,6 +792,7 @@ func resourceRedisCloudProDatabaseRead(ctx context.Context, d *schema.ResourceDa
 func resourceRedisCloudProDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 
 	var diags diag.Diagnostics
 	subId := d.Get("subscription_id").(int)
@@ -800,10 +806,10 @@ func resourceRedisCloudProDatabaseDelete(ctx context.Context, d *schema.Resource
 	defer utils.SubscriptionMutex.Unlock(subId)
 
 	// Confirm sub + db are ready to accept a db request
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -811,7 +817,7 @@ func resourceRedisCloudProDatabaseDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -819,6 +825,10 @@ func resourceRedisCloudProDatabaseDelete(ctx context.Context, d *schema.Resource
 }
 
 func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudProDatabaseUpdateWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+}
+
+func resourceRedisCloudProDatabaseUpdateWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 	var diags diag.Diagnostics
 
@@ -977,11 +987,11 @@ func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.Resource
 	}
 
 	// Confirm sub + db are ready to accept a db request
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -995,7 +1005,7 @@ func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.Resource
 		// only upgrade when a known version goes to another known version
 		//TODO(TF3.0) once redis_version goes write-only-by-convention (Computed dropped, not written from Read), drop the actualRedisVersion guard — DSF already makes it unreachable in normal operation. Kept today as belt-and-suspenders against DSF regressions.
 		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion != newVersion.(string) {
-			if upgradeDiags, unlocked := upgradeRedisVersion(ctx, api, subId, dbId, newVersion.(string)); upgradeDiags != nil {
+			if upgradeDiags, unlocked := upgradeRedisVersion(ctx, api, subId, dbId, newVersion.(string), timeout); upgradeDiags != nil {
 				if !unlocked {
 					utils.SubscriptionMutex.Unlock(subId)
 				}
@@ -1012,11 +1022,11 @@ func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.Resource
 	}
 
 	// Confirm db + sub active status
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -1027,11 +1037,11 @@ func resourceRedisCloudProDatabaseUpdate(ctx context.Context, d *schema.Resource
 	}
 
 	utils.SubscriptionMutex.Unlock(subId)
-	readDiags := resourceRedisCloudProDatabaseRead(ctx, d, meta)
+	readDiags := resourceRedisCloudProDatabaseReadWithTimeout(ctx, d, meta, timeout)
 	return append(diags, readDiags...)
 }
 
-func upgradeRedisVersion(ctx context.Context, api *client.ApiClient, subId int, dbId int, newVersion string) (diag.Diagnostics, bool) {
+func upgradeRedisVersion(ctx context.Context, api *client.ApiClient, subId int, dbId int, newVersion string, timeout time.Duration) (diag.Diagnostics, bool) {
 	log.Printf("[INFO] Requesting Redis version change to %s...", newVersion)
 
 	upgrade := databases.UpgradeRedisVersion{
@@ -1045,12 +1055,12 @@ func upgradeRedisVersion(ctx context.Context, api *client.ApiClient, subId int, 
 
 	log.Printf("[INFO] Redis version change request to %s accepted by API", newVersion)
 
-	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := utils.WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return diag.FromErr(err), true
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return diag.FromErr(err), true
 	}

--- a/provider/pro/resource_rediscloud_pro_subscription.go
+++ b/provider/pro/resource_rediscloud_pro_subscription.go
@@ -573,6 +573,7 @@ func getSubscription(ctx context.Context, diff *schema.ResourceDiff, meta interf
 
 func resourceRedisCloudProSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	// Create CloudProviders
 	providers, err := buildCreateCloudProviders(d.Get("cloud_provider"))
@@ -642,14 +643,14 @@ func resourceRedisCloudProSubscriptionCreate(ctx context.Context, d *schema.Reso
 	}
 
 	// Confirm Subscription Active status
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout)
 
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
 
 	// Delete databases created by the subscription creation plan
-	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api); cleanupDiags != nil {
+	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api, timeout); cleanupDiags != nil {
 		return append(diags, cleanupDiags...)
 	}
 	if m, ok := d.GetOk("maintenance_windows"); ok {
@@ -683,7 +684,7 @@ func resourceRedisCloudProSubscriptionCreate(ctx context.Context, d *schema.Reso
 
 	// Some attributes on a database are not accessible by the subscription creation API.
 	// Run the subscription update function to apply any additional changes to the databases, such as password and so on.
-	return append(diags, resourceRedisCloudProSubscriptionUpdate(ctx, d, meta)...)
+	return append(diags, resourceRedisCloudProSubscriptionUpdateWithTimeout(ctx, d, meta, timeout)...)
 }
 
 func resourceRedisCloudProSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -802,6 +803,10 @@ func resourceRedisCloudProSubscriptionRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceRedisCloudProSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudProSubscriptionUpdateWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+}
+
+func resourceRedisCloudProSubscriptionUpdateWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	subId, err := strconv.Atoi(d.Id())
@@ -822,7 +827,7 @@ func resourceRedisCloudProSubscriptionUpdate(ctx context.Context, d *schema.Reso
 	// CMK flow
 	if *subscription.Status == subscriptions.SubscriptionStatusEncryptionKeyPending && cmkEnabled {
 		wasCmkPending = true
-		diags := resourceRedisCloudProSubscriptionUpdateCmk(ctx, d, api, subId)
+		diags := resourceRedisCloudProSubscriptionUpdateCmk(ctx, d, api, subId, timeout)
 
 		if diags != nil {
 			return diags
@@ -869,7 +874,7 @@ func resourceRedisCloudProSubscriptionUpdate(ctx context.Context, d *schema.Reso
 			return diag.FromErr(err)
 		}
 
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -891,7 +896,7 @@ func resourceRedisCloudProSubscriptionUpdate(ctx context.Context, d *schema.Reso
 		}
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -936,7 +941,7 @@ func resourceRedisCloudProSubscriptionUpdate(ctx context.Context, d *schema.Reso
 	return resourceRedisCloudProSubscriptionRead(ctx, d, meta)
 }
 
-func resourceRedisCloudProSubscriptionUpdateCmk(ctx context.Context, d *schema.ResourceData, api *client.ApiClient, subId int) diag.Diagnostics {
+func resourceRedisCloudProSubscriptionUpdateCmk(ctx context.Context, d *schema.ResourceData, api *client.ApiClient, subId int, timeout time.Duration) diag.Diagnostics {
 
 	cmkResourcesRaw, exists := d.GetOk("customer_managed_key")
 	if !exists {
@@ -960,12 +965,12 @@ func resourceRedisCloudProSubscriptionUpdateCmk(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	// After CMK activation, delete databases that were not cleaned up during Create
-	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api); cleanupDiags != nil {
+	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api, timeout); cleanupDiags != nil {
 		return cleanupDiags
 	}
 
@@ -990,6 +995,7 @@ func buildProCmks(cmkResources []interface{}) []subscriptions.CustomerManagedKey
 func resourceRedisCloudProSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 
 	var diags diag.Diagnostics
 
@@ -1017,14 +1023,14 @@ func resourceRedisCloudProSubscriptionDelete(ctx context.Context, d *schema.Reso
 
 	if *subscription.Status != subscriptions.SubscriptionStatusEncryptionKeyPending {
 		// Wait for the subscription to be active before deleting it.
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 
 		// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
 		// This additional wait ensures that the databases are deleted before the subscription is deleted.
 		time.Sleep(30 * time.Second) //lintignore:R018
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/provider/pro/resource_rediscloud_pro_subscription.go
+++ b/provider/pro/resource_rediscloud_pro_subscription.go
@@ -903,7 +903,7 @@ func resourceRedisCloudProSubscriptionUpdateWithTimeout(ctx context.Context, d *
 	// Verify public_endpoint_access has propagated if it was changed
 	if d.HasChange("public_endpoint_access") {
 		expected := d.Get("public_endpoint_access").(bool)
-		if err := utils.WaitForSubscriptionPublicEndpointAccess(ctx, subId, api, expected); err != nil {
+		if err := utils.WaitForSubscriptionPublicEndpointAccess(ctx, subId, api, expected, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/provider/pro/resource_rediscloud_pro_subscription.go
+++ b/provider/pro/resource_rediscloud_pro_subscription.go
@@ -635,7 +635,7 @@ func resourceRedisCloudProSubscriptionCreate(ctx context.Context, d *schema.Reso
 
 	// If in a CMK flow, verify the pending state
 	if cmkEnabled {
-		err = utils.WaitForSubscriptionToBeEncryptionKeyPending(ctx, subId, api)
+		err = utils.WaitForSubscriptionToBeEncryptionKeyPending(ctx, subId, api, timeout)
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -1015,7 +1015,7 @@ func resourceRedisCloudProSubscriptionDelete(ctx context.Context, d *schema.Reso
 	// If already deleting (e.g. auto-deleted empty CMK subscription), wait for completion.
 	if *subscription.Status == subscriptions.SubscriptionStatusDeleting {
 		d.SetId("")
-		if err := WaitForSubscriptionToBeDeleted(ctx, subId, api); err != nil {
+		if err := WaitForSubscriptionToBeDeleted(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 		return diags
@@ -1043,7 +1043,7 @@ func resourceRedisCloudProSubscriptionDelete(ctx context.Context, d *schema.Reso
 
 	d.SetId("")
 
-	err = WaitForSubscriptionToBeDeleted(ctx, subId, api)
+	err = WaitForSubscriptionToBeDeleted(ctx, subId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1266,11 +1266,11 @@ func createDatabase(dbName string, idx *int, modules []*subscriptions.CreateModu
 	return dbs
 }
 
-func WaitForSubscriptionToBeDeleted(ctx context.Context, id int, api *client.ApiClient) error {
+func WaitForSubscriptionToBeDeleted(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending:      []string{subscriptions.SubscriptionStatusDeleting},
 		Target:       []string{"deleted"}, // TODO: update this with deleted field in SDK
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/resource_rediscloud_acl_role.go
+++ b/provider/resource_rediscloud_acl_role.go
@@ -92,6 +92,7 @@ func resourceRedisCloudAclRole() *schema.Resource {
 
 func resourceRedisCloudAclRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	name := d.Get("name").(string)
 	associateWithRules := extractRules(d)
@@ -109,7 +110,7 @@ func resourceRedisCloudAclRoleCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(strconv.Itoa(id))
 
-	err = waitForAclRoleToBeActive(ctx, id, api)
+	err = waitForAclRoleToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -119,7 +120,7 @@ func resourceRedisCloudAclRoleCreate(ctx context.Context, d *schema.ResourceData
 	// TODO Ultimately this is an API problem
 	time.Sleep(15 * time.Second) //lintignore:R018
 
-	err = waitForAclRoleToBeActive(ctx, id, api)
+	err = waitForAclRoleToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -157,6 +158,7 @@ func resourceRedisCloudAclRoleRead(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRedisCloudAclRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -176,7 +178,7 @@ func resourceRedisCloudAclRoleUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		err = waitForAclRoleToBeActive(ctx, id, api)
+		err = waitForAclRoleToBeActive(ctx, id, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -186,7 +188,7 @@ func resourceRedisCloudAclRoleUpdate(ctx context.Context, d *schema.ResourceData
 		// TODO Ultimately this is an API problem
 		time.Sleep(15 * time.Second) //lintignore:R018
 
-		err = waitForAclRoleToBeActive(ctx, id, api)
+		err = waitForAclRoleToBeActive(ctx, id, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -197,6 +199,7 @@ func resourceRedisCloudAclRoleUpdate(ctx context.Context, d *schema.ResourceData
 
 func resourceRedisCloudAclRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 	var diags diag.Diagnostics
 
 	id, err := strconv.Atoi(d.Id())
@@ -207,7 +210,7 @@ func resourceRedisCloudAclRoleDelete(ctx context.Context, d *schema.ResourceData
 	// Sometimes ACL Users and Roles flip between Active and Pending a few times after creation/update.
 	// This delay gives the API a chance to settle
 	// TODO Ultimately this is an API problem
-	err = waitForAclRoleToBeActive(ctx, id, api)
+	err = waitForAclRoleToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,7 +224,7 @@ func resourceRedisCloudAclRoleDelete(ctx context.Context, d *schema.ResourceData
 	d.SetId("")
 
 	// Wait until it's really disappeared
-	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		role, err := api.Client.Roles.Get(ctx, id)
 
 		if err != nil {
@@ -317,12 +320,12 @@ func flattenDatabases(databases []*roles.GetDatabaseInRuleInRoleResponse) []map[
 	return tfs
 }
 
-func waitForAclRoleToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
+func waitForAclRoleToBeActive(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:   5 * time.Second,
 		Pending: []string{roles.StatusPending},
 		Target:  []string{roles.StatusActive},
-		Timeout: 5 * time.Minute,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for role %d to be active", id)

--- a/provider/resource_rediscloud_acl_rule.go
+++ b/provider/resource_rediscloud_acl_rule.go
@@ -53,6 +53,7 @@ func resourceRedisCloudAclRule() *schema.Resource {
 
 func resourceRedisCloudAclRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	name := d.Get("name").(string)
 	rule := d.Get("rule").(string)
@@ -69,7 +70,7 @@ func resourceRedisCloudAclRuleCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(strconv.Itoa(id))
 
-	err = waitForAclRuleToBeActive(ctx, id, api)
+	err = waitForAclRuleToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -108,6 +109,7 @@ func resourceRedisCloudAclRuleRead(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRedisCloudAclRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -130,7 +132,7 @@ func resourceRedisCloudAclRuleUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		err = waitForAclRuleToBeActive(ctx, id, api)
+		err = waitForAclRuleToBeActive(ctx, id, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -141,6 +143,7 @@ func resourceRedisCloudAclRuleUpdate(ctx context.Context, d *schema.ResourceData
 
 func resourceRedisCloudAclRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 	var diags diag.Diagnostics
 
 	id, err := strconv.Atoi(d.Id())
@@ -157,7 +160,7 @@ func resourceRedisCloudAclRuleDelete(ctx context.Context, d *schema.ResourceData
 	d.SetId("")
 
 	// Wait until it's really disappeared
-	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		rule, err := api.Client.RedisRules.Get(ctx, id)
 
 		if err != nil {
@@ -183,12 +186,12 @@ func resourceRedisCloudAclRuleDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func waitForAclRuleToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
+func waitForAclRuleToBeActive(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:   5 * time.Second,
 		Pending: []string{redis_rules.StatusPending},
 		Target:  []string{redis_rules.StatusActive},
-		Timeout: 5 * time.Minute,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for rule %d to be active", id)

--- a/provider/resource_rediscloud_acl_user.go
+++ b/provider/resource_rediscloud_acl_user.go
@@ -61,6 +61,7 @@ func resourceRedisCloudAclUser() *schema.Resource {
 
 func resourceRedisCloudAclUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	name := d.Get("name").(string)
 	role := d.Get("role").(string)
@@ -77,7 +78,7 @@ func resourceRedisCloudAclUserCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	err = waitForAclUserToBeActive(ctx, id, api)
+	err = waitForAclUserToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -87,7 +88,7 @@ func resourceRedisCloudAclUserCreate(ctx context.Context, d *schema.ResourceData
 	// TODO Ultimately this is an API problem
 	time.Sleep(15 * time.Second) //lintignore:R018
 
-	err = waitForAclUserToBeActive(ctx, id, api)
+	err = waitForAclUserToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -128,6 +129,7 @@ func resourceRedisCloudAclUserRead(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRedisCloudAclUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -147,7 +149,7 @@ func resourceRedisCloudAclUserUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		err = waitForAclUserToBeActive(ctx, id, api)
+		err = waitForAclUserToBeActive(ctx, id, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -157,7 +159,7 @@ func resourceRedisCloudAclUserUpdate(ctx context.Context, d *schema.ResourceData
 		// TODO Ultimately this is an API problem
 		time.Sleep(15 * time.Second) //lintignore:R018
 
-		err = waitForAclUserToBeActive(ctx, id, api)
+		err = waitForAclUserToBeActive(ctx, id, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -168,6 +170,7 @@ func resourceRedisCloudAclUserUpdate(ctx context.Context, d *schema.ResourceData
 
 func resourceRedisCloudAclUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 	var diags diag.Diagnostics
 
 	id, err := strconv.Atoi(d.Id())
@@ -178,7 +181,7 @@ func resourceRedisCloudAclUserDelete(ctx context.Context, d *schema.ResourceData
 	// Sometimes ACL Users and Roles flip between Active and Pending a few times after creation/update.
 	// This delay gives the API a chance to settle
 	// TODO Ultimately this is an API problem
-	err = waitForAclUserToBeActive(ctx, id, api)
+	err = waitForAclUserToBeActive(ctx, id, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -192,7 +195,7 @@ func resourceRedisCloudAclUserDelete(ctx context.Context, d *schema.ResourceData
 	d.SetId("")
 
 	// Wait until it's really disappeared
-	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		user, err := api.Client.Users.Get(ctx, id)
 
 		if err != nil {
@@ -218,12 +221,12 @@ func resourceRedisCloudAclUserDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func waitForAclUserToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
+func waitForAclUserToBeActive(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:   5 * time.Second,
 		Pending: []string{users.StatusPending},
 		Target:  []string{users.StatusActive},
-		Timeout: 5 * time.Minute,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for user %d to be active", id)

--- a/provider/resource_rediscloud_active_active_private_service_connect.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect.go
@@ -83,7 +83,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectCreate(ctx context.Conte
 		return diag.FromErr(err)
 	}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -155,7 +155,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectDelete(ctx context.Conte
 
 	d.SetId("")
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_private_service_connect.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect.go
@@ -78,7 +78,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectCreate(ctx context.Conte
 
 	err = waitForPrivateServiceConnectServiceToBeActive(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceActiveActiveStatus(ctx, subscriptionId, regionId, api)
-	})
+	}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_private_service_connect.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect.go
@@ -59,6 +59,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnect() *schema.Resource {
 
 func resourceRedisCloudActiveActivePrivateServiceConnectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -78,12 +79,12 @@ func resourceRedisCloudActiveActivePrivateServiceConnectCreate(ctx context.Conte
 
 	err = waitForPrivateServiceConnectServiceToBeActive(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceActiveActiveStatus(ctx, subscriptionId, regionId, api)
-	}, d.Timeout(schema.TimeoutCreate))
+	}, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_private_service_connect_endpoint.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect_endpoint.go
@@ -287,7 +287,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointDelete(ctx conte
 	// to happen, but we can't check the GCP resources from this provider
 	err = waitForPrivateServiceConnectServiceEndpointDisappear(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceActiveActiveEndpointDisappear(ctx, resId.subscriptionId, resId.regionId, resId.pscServiceId, resId.endpointId, api)
-	})
+	}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_private_service_connect_endpoint.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect_endpoint.go
@@ -148,7 +148,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointCreate(ctx conte
 
 	d.SetId(buildPrivateServiceConnectActiveActiveEndpointId(subscriptionId, regionId, pscServiceId, endpointId))
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_private_service_connect_endpoint_accepter.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect_endpoint_accepter.go
@@ -70,6 +70,16 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepter() *sche
 }
 
 func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutCreate)
+	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
 
@@ -119,7 +129,7 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterCreate(c
 	}
 
 	if redis.StringValue(endpoint.Status) == psc.EndpointStatusInitialized || redis.StringValue(endpoint.Status) == psc.EndpointStatusProcessing {
-		err = waitForPrivateServiceConnectServiceEndpointToBePending(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBePending(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -135,12 +145,12 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterCreate(c
 	}
 
 	if action == psc.EndpointActionAccept {
-		err = waitForPrivateServiceConnectServiceEndpointToBeActive(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBeActive(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	} else {
-		err = waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -250,10 +260,6 @@ func ToPscEndpointActiveActiveAccepterId(id string) (*PrivateServiceConnectActiv
 		PscServiceId:   pscId,
 		EndpointId:     endpointId,
 	}, nil
-}
-
-func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterCreate(ctx, d, meta)
 }
 
 func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_private_service_connect_endpoint_accepter.go
+++ b/provider/resource_rediscloud_active_active_private_service_connect_endpoint_accepter.go
@@ -70,13 +70,11 @@ func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepter() *sche
 }
 
 func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutCreate)
-	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 }
 
 func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 }
 
 func resourceRedisCloudActiveActivePrivateServiceConnectEndpointAccepterApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -428,7 +428,7 @@ func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *sc
 
 	// If in a CMK flow, verify the pending state
 	if cmkEnabled {
-		err = utils.WaitForSubscriptionToBeEncryptionKeyPending(ctx, subId, api)
+		err = utils.WaitForSubscriptionToBeEncryptionKeyPending(ctx, subId, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -797,7 +797,7 @@ func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *sc
 	// If already deleting (e.g. auto-deleted empty CMK subscription), wait for completion.
 	if *subscription.Status == subscriptions.SubscriptionStatusDeleting {
 		d.SetId("")
-		if err := pro.WaitForSubscriptionToBeDeleted(ctx, subId, api); err != nil {
+		if err := pro.WaitForSubscriptionToBeDeleted(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 		return diags
@@ -825,7 +825,7 @@ func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *sc
 
 	d.SetId("")
 
-	err = pro.WaitForSubscriptionToBeDeleted(ctx, subId, api)
+	err = pro.WaitForSubscriptionToBeDeleted(ctx, subId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -377,6 +377,7 @@ func resourceRedisCloudActiveActiveSubscription() *schema.Resource {
 func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	//TODO fix mapping of empty objects to remove non-empty plan on refresh
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	plan := d.Get("creation_plan").([]interface{})
 
@@ -431,17 +432,17 @@ func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *sc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		return resourceRedisCloudActiveActiveSubscriptionRead(ctx, d, meta)
+		return resourceRedisCloudActiveActiveSubscriptionReadWithTimeout(ctx, d, meta, timeout)
 	}
 
 	// Confirm Subscription Active status
-	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Delete databases created by the subscription creation plan
-	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api); cleanupDiags != nil {
+	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api, timeout); cleanupDiags != nil {
 		return cleanupDiags
 	}
 
@@ -474,10 +475,14 @@ func resourceRedisCloudActiveActiveSubscriptionCreate(ctx context.Context, d *sc
 		}
 	}
 
-	return resourceRedisCloudActiveActiveSubscriptionRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveSubscriptionReadWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudActiveActiveSubscriptionReadWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutRead))
+}
+
+func resourceRedisCloudActiveActiveSubscriptionReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	var diags diag.Diagnostics
@@ -499,7 +504,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 
 	// Skip active wait when in CMK pending state
 	if *subscription.Status != subscriptions.SubscriptionStatusEncryptionKeyPending {
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -609,6 +614,7 @@ func resourceRedisCloudActiveActiveSubscriptionRead(ctx context.Context, d *sche
 
 func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	subId, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -628,7 +634,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 	// CMK flow
 	if *subscription.Status == subscriptions.SubscriptionStatusEncryptionKeyPending && cmkEnabled {
 		wasCmkPending = true
-		diags := resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx, d, api, subId)
+		diags := resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx, d, api, subId, timeout)
 
 		if diags != nil {
 			return diags
@@ -661,7 +667,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -682,12 +688,12 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -729,10 +735,10 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	return resourceRedisCloudActiveActiveSubscriptionRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveSubscriptionReadWithTimeout(ctx, d, meta, timeout)
 }
 
-func resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx context.Context, d *schema.ResourceData, api *client.ApiClient, subId int) diag.Diagnostics {
+func resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx context.Context, d *schema.ResourceData, api *client.ApiClient, subId int, timeout time.Duration) diag.Diagnostics {
 
 	cmkResourcesRaw, exists := d.GetOk("customer_managed_key")
 	if !exists {
@@ -756,12 +762,12 @@ func resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx context.Context, d 
 		return diag.FromErr(err)
 	}
 
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	// After CMK activation, delete databases that were not cleaned up during Create
-	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api); cleanupDiags != nil {
+	if cleanupDiags := utils.DeleteSubscriptionDatabases(ctx, subId, api, timeout); cleanupDiags != nil {
 		return cleanupDiags
 	}
 
@@ -771,6 +777,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdateCmk(ctx context.Context, d 
 func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 
 	var diags diag.Diagnostics
 
@@ -798,14 +805,14 @@ func resourceRedisCloudActiveActiveSubscriptionDelete(ctx context.Context, d *sc
 
 	if *subscription.Status != subscriptions.SubscriptionStatusEncryptionKeyPending {
 		// Wait for the subscription to be active before deleting it.
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 
 		// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
 		// This additional wait ensures that the databases are deleted before the subscription is deleted.
 		time.Sleep(30 * time.Second) //lintignore:R018
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/provider/resource_rediscloud_active_active_subscription.go
+++ b/provider/resource_rediscloud_active_active_subscription.go
@@ -700,7 +700,7 @@ func resourceRedisCloudActiveActiveSubscriptionUpdate(ctx context.Context, d *sc
 	// Verify public_endpoint_access has propagated if it was changed
 	if d.HasChange("public_endpoint_access") {
 		expected := d.Get("public_endpoint_access").(bool)
-		if err := utils.WaitForSubscriptionPublicEndpointAccess(ctx, subId, api, expected); err != nil {
+		if err := utils.WaitForSubscriptionPublicEndpointAccess(ctx, subId, api, expected, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/provider/resource_rediscloud_active_active_subscription_peering.go
+++ b/provider/resource_rediscloud_active_active_subscription_peering.go
@@ -153,6 +153,7 @@ func resourceRedisCloudActiveActiveSubscriptionPeering() *schema.Resource {
 
 func resourceRedisCloudSubscriptionActiveActivePeeringCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -232,7 +233,7 @@ func resourceRedisCloudSubscriptionActiveActivePeeringCreate(ctx context.Context
 
 	d.SetId(utils.BuildResourceId(subId, peering))
 
-	err = waitForActiveActivePeeringToBeInitiated(ctx, subId, peering, api)
+	err = waitForActiveActivePeeringToBeInitiated(ctx, subId, peering, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -389,7 +390,7 @@ func findActiveActiveVpcPeering(id int, regions []*subscriptions.ActiveActiveVpc
 	return nil, nil
 }
 
-func waitForActiveActivePeeringToBeInitiated(ctx context.Context, subId, id int, api *client.ApiClient) error {
+func waitForActiveActivePeeringToBeInitiated(ctx context.Context, subId, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay: 30 * time.Second,
 		Pending: []string{
@@ -400,7 +401,7 @@ func waitForActiveActivePeeringToBeInitiated(ctx context.Context, subId, id int,
 			subscriptions.VPCPeeringStatusInactive,
 			subscriptions.VPCPeeringStatusPendingAcceptance,
 		},
-		Timeout:      10 * time.Minute,
+		Timeout:      timeout,
 		PollInterval: 30 * time.Second,
 
 		Refresh: func() (result interface{}, state string, err error) {

--- a/provider/resource_rediscloud_active_active_subscription_regions.go
+++ b/provider/resource_rediscloud_active_active_subscription_regions.go
@@ -137,10 +137,16 @@ func resourceRedisCloudActiveActiveRegionCreate(ctx context.Context, d *schema.R
 	}
 	d.SetId(strconv.Itoa(subId))
 
-	return resourceRedisCloudActiveActiveRegionUpdate(ctx, d, meta)
+	timeout := d.Timeout(schema.TimeoutCreate)
+	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActiveRegionApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	subId, err := strconv.Atoi(d.Id())
@@ -196,7 +202,7 @@ func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.R
 	}
 
 	if len(regionsToCreate) > 0 {
-		err := regionsCreate(ctx, subId, regionsToCreate, api)
+		err := regionsCreate(ctx, subId, regionsToCreate, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -209,18 +215,18 @@ func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.R
 			regionIds = append(regionIds, r.Region)
 		}
 
-		err := regionsDelete(ctx, subId, regionIds, api)
+		err := regionsDelete(ctx, subId, regionIds, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		err = regionsCreate(ctx, subId, regionsToRecreate, api)
+		err = regionsCreate(ctx, subId, regionsToRecreate, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if len(regionsToUpdateDatabases) > 0 {
-		err = regionsUpdateDatabases(ctx, subId, api, regionsToUpdateDatabases, existingRegionMap)
+		err = regionsUpdateDatabases(ctx, subId, api, regionsToUpdateDatabases, existingRegionMap, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -235,7 +241,7 @@ func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.R
 		for _, r := range regionsToDelete {
 			regionIds = append(regionIds, r.Region)
 		}
-		err := regionsDelete(ctx, subId, regionIds, api)
+		err := regionsDelete(ctx, subId, regionIds, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -319,7 +325,7 @@ func resourceRedisCloudActiveActiveRegionDelete(ctx context.Context, d *schema.R
 	return resourceRedisCloudActiveActiveRegionRead(ctx, d, meta)
 }
 
-func regionsCreate(ctx context.Context, subId int, regionsToCreate []*RequestedRegion, api *client.ApiClient) error {
+func regionsCreate(ctx context.Context, subId int, regionsToCreate []*RequestedRegion, api *client.ApiClient, timeout time.Duration) error {
 	// If no new regions were defined return
 	if len(regionsToCreate) == 0 {
 		return nil
@@ -358,14 +364,14 @@ func regionsCreate(ctx context.Context, subId int, regionsToCreate []*RequestedR
 		}
 
 		// Wait for the subscription to be active before deleting it.
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return err
 		}
 
 		// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
 		// This additional wait ensures that the databases are deleted before the subscription is deleted.
 		time.Sleep(30 * time.Second) //lintignore:R018
-		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+		if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 			return err
 		}
 	}
@@ -373,7 +379,7 @@ func regionsCreate(ctx context.Context, subId int, regionsToCreate []*RequestedR
 	return nil
 }
 
-func regionsUpdateDatabases(ctx context.Context, subId int, api *client.ApiClient, regionsToUpdateDatabases []*RequestedRegion, existingRegionMap map[string]*regions.Region) error {
+func regionsUpdateDatabases(ctx context.Context, subId int, api *client.ApiClient, regionsToUpdateDatabases []*RequestedRegion, existingRegionMap map[string]*regions.Region, timeout time.Duration) error {
 	databaseUpdates := make(map[int][]*databases.LocalRegionProperties)
 	for _, desiredRegion := range regionsToUpdateDatabases {
 		// Collect existing databases to a map <dbId, db>
@@ -412,14 +418,14 @@ func regionsUpdateDatabases(ctx context.Context, subId int, api *client.ApiClien
 			}
 
 			// Wait for the subscription to be active before deleting it.
-			if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+			if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 				return err
 			}
 
 			// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
 			// This additional wait ensures that the databases are deleted before the subscription is deleted.
 			time.Sleep(30 * time.Second) //lintignore:R018
-			if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+			if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 				return err
 			}
 		}
@@ -428,7 +434,7 @@ func regionsUpdateDatabases(ctx context.Context, subId int, api *client.ApiClien
 	return nil
 }
 
-func regionsDelete(ctx context.Context, subId int, regionsToDelete []*string, api *client.ApiClient) error {
+func regionsDelete(ctx context.Context, subId int, regionsToDelete []*string, api *client.ApiClient, timeout time.Duration) error {
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
@@ -446,14 +452,14 @@ func regionsDelete(ctx context.Context, subId int, regionsToDelete []*string, ap
 	}
 
 	// Wait for the subscription to be active before deleting it.
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return err
 	}
 
 	// There is a timing issue where the subscription is marked as active before the creation-plan databases are deleted.
 	// This additional wait ensures that the databases are deleted before the subscription is deleted.
 	time.Sleep(30 * time.Second) //lintignore:R018
-	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := utils.WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return err
 	}
 

--- a/provider/resource_rediscloud_active_active_subscription_regions.go
+++ b/provider/resource_rediscloud_active_active_subscription_regions.go
@@ -137,13 +137,11 @@ func resourceRedisCloudActiveActiveRegionCreate(ctx context.Context, d *schema.R
 	}
 	d.SetId(strconv.Itoa(subId))
 
-	timeout := d.Timeout(schema.TimeoutCreate)
-	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 }
 
 func resourceRedisCloudActiveActiveRegionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActiveRegionApply(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 }
 
 func resourceRedisCloudActiveActiveRegionApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_transit_gateway_attachment.go
+++ b/provider/resource_rediscloud_active_active_transit_gateway_attachment.go
@@ -91,6 +91,7 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachment() *schema.Resource {
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -116,17 +117,22 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachmentCreate(ctx context.Co
 	}
 
 	// Wait for attachment to become available
-	_, err = utils.WaitForActiveActiveTransitGatewayAttachmentToBeAvailable(ctx, subscriptionId, regionId, tgwId, api)
+	_, err = utils.WaitForActiveActiveTransitGatewayAttachmentToBeAvailable(ctx, subscriptionId, regionId, tgwId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	d.SetId(transitgateway.BuildActiveActiveTransitGatewayAttachmentId(subscriptionId, regionId, tgwId))
 
-	return resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutRead)
+	return resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
 
@@ -146,7 +152,7 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx context.Cont
 	}
 
 	// Wait for Transit Gateway resource to become available (handles subscription provisioning delays)
-	tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api)
+	tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -193,6 +199,7 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx context.Cont
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	subId, regionId, tgwId, err := transitgateway.ParseActiveActiveTransitGatewayAttachmentId(d.Id())
 	if err != nil {
@@ -209,7 +216,7 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachmentUpdate(ctx context.Co
 		return diag.FromErr(err)
 	}
 
-	return resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_transit_gateway_attachment.go
+++ b/provider/resource_rediscloud_active_active_transit_gateway_attachment.go
@@ -128,8 +128,7 @@ func resourceRedisCloudActiveActiveTransitGatewayAttachmentCreate(ctx context.Co
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutRead)
-	return resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutRead))
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayAttachmentReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_transit_gateway_route.go
+++ b/provider/resource_rediscloud_active_active_transit_gateway_route.go
@@ -68,6 +68,7 @@ func resourceRedisCloudActiveActiveTransitGatewayRoute() *schema.Resource {
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -88,10 +89,15 @@ func resourceRedisCloudActiveActiveTransitGatewayRouteCreate(ctx context.Context
 
 	d.SetId(transitgateway.BuildActiveActiveTransitGatewayAttachmentId(subId, regionId, tgwId))
 
-	return resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutRead)
+	return resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
 
@@ -111,7 +117,7 @@ func resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx context.Context, 
 	}
 
 	// Wait for Transit Gateway resource to become available (handles subscription provisioning delays)
-	tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api)
+	tgwTask, err := utils.WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx, subId, regionId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -142,6 +148,7 @@ func resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx context.Context, 
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -160,7 +167,7 @@ func resourceRedisCloudActiveActiveTransitGatewayRouteUpdate(ctx context.Context
 		return diag.FromErr(err)
 	}
 
-	return resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx, d, meta)
+	return resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/resource_rediscloud_active_active_transit_gateway_route.go
+++ b/provider/resource_rediscloud_active_active_transit_gateway_route.go
@@ -93,8 +93,7 @@ func resourceRedisCloudActiveActiveTransitGatewayRouteCreate(ctx context.Context
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutRead)
-	return resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx, d, meta, timeout)
+	return resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutRead))
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayRouteReadWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {

--- a/provider/resource_rediscloud_essentials_database.go
+++ b/provider/resource_rediscloud_essentials_database.go
@@ -315,6 +315,7 @@ func resourceRedisCloudEssentialsDatabase() *schema.Resource {
 
 func resourceRedisCloudEssentialsDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subId := d.Get("subscription_id").(int)
 
@@ -436,7 +437,7 @@ func resourceRedisCloudEssentialsDatabaseCreate(ctx context.Context, d *schema.R
 	d.SetId(utils.BuildResourceId(subId, databaseId))
 
 	// Confirm Subscription Active status
-	err = waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api)
+	err = waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api, timeout)
 	if err != nil {
 		utils.SubscriptionMutex.Unlock(subId)
 		return diag.FromErr(err)
@@ -446,7 +447,7 @@ func resourceRedisCloudEssentialsDatabaseCreate(ctx context.Context, d *schema.R
 	// Run the subscription update function to apply any additional changes to the databases (enableDefaultUser)
 	// Others are omitted here _because_ the update will take care of them, such as tags
 	utils.SubscriptionMutex.Unlock(subId)
-	return resourceRedisCloudEssentialsDatabaseUpdate(ctx, d, meta)
+	return resourceRedisCloudEssentialsDatabaseUpdateWithTimeout(ctx, d, meta, timeout)
 }
 
 func resourceRedisCloudEssentialsDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -620,6 +621,10 @@ func resourceRedisCloudEssentialsDatabaseRead(ctx context.Context, d *schema.Res
 }
 
 func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceRedisCloudEssentialsDatabaseUpdateWithTimeout(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+}
+
+func resourceRedisCloudEssentialsDatabaseUpdateWithTimeout(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	_, databaseId, err := pro.ToDatabaseId(d.Id())
@@ -639,7 +644,7 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 		// Only perform upgrade if both versions are non-empty (prevents unnecessary upgrades on creation)
 		//TODO(TF3.0) once redis_version goes write-only-by-convention (Computed dropped, not written from Read), drop the actualRedisVersion guard — DSF already makes it unreachable in normal operation. Kept today as belt-and-suspenders against DSF regressions.
 		if originalVersion.(string) != "" && newVersion.(string) != "" && actualRedisVersion.(string) != newVersion.(string) {
-			if upgradeDiags := upgradeRedisVersionEssentials(ctx, api, subId, databaseId, newVersion.(string)); upgradeDiags != nil {
+			if upgradeDiags := upgradeRedisVersionEssentials(ctx, api, subId, databaseId, newVersion.(string), timeout); upgradeDiags != nil {
 				return upgradeDiags
 			}
 		}
@@ -738,11 +743,11 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 
-	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api); err != nil {
+	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -757,6 +762,7 @@ func resourceRedisCloudEssentialsDatabaseUpdate(ctx context.Context, d *schema.R
 func resourceRedisCloudEssentialsDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 
 	var diags diag.Diagnostics
 	subId := d.Get("subscription_id").(int)
@@ -769,7 +775,7 @@ func resourceRedisCloudEssentialsDatabaseDelete(ctx context.Context, d *schema.R
 	utils.SubscriptionMutex.Lock(subId)
 	defer utils.SubscriptionMutex.Unlock(subId)
 
-	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api); err != nil {
+	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, databaseId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -780,7 +786,7 @@ func resourceRedisCloudEssentialsDatabaseDelete(ctx context.Context, d *schema.R
 	return diags
 }
 
-func upgradeRedisVersionEssentials(ctx context.Context, api *client.ApiClient, subId int, dbId int, newVersion string) diag.Diagnostics {
+func upgradeRedisVersionEssentials(ctx context.Context, api *client.ApiClient, subId int, dbId int, newVersion string, timeout time.Duration) diag.Diagnostics {
 	log.Printf("[INFO] Requesting Redis version change to %s...", newVersion)
 
 	upgrade := fixedDatabases.UpgradeRedisVersion{
@@ -794,19 +800,19 @@ func upgradeRedisVersionEssentials(ctx context.Context, api *client.ApiClient, s
 	log.Printf("[INFO] Redis version change request to %s accepted by API", newVersion)
 
 	// Wait for database to be active
-	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+	if err := waitForEssentialsDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Wait for subscription to be active
-	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func waitForEssentialsDatabaseToBeActive(ctx context.Context, subId, id int, api *client.ApiClient) error {
+func waitForEssentialsDatabaseToBeActive(ctx context.Context, subId, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay: 30 * time.Second,
 		Pending: []string{
@@ -822,7 +828,7 @@ func waitForEssentialsDatabaseToBeActive(ctx context.Context, subId, id int, api
 			databases.StatusDynamicEndpointsCreationPending,
 		},
 		Target:       []string{databases.StatusActive},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		PollInterval: 30 * time.Second,
 
 		Refresh: func() (result interface{}, state string, err error) {

--- a/provider/resource_rediscloud_essentials_subscription.go
+++ b/provider/resource_rediscloud_essentials_subscription.go
@@ -116,7 +116,7 @@ func resourceRedisCloudEssentialsSubscriptionCreate(ctx context.Context, d *sche
 	d.SetId(strconv.Itoa(subId))
 
 	// Confirm Subscription Active status
-	err = waitForEssentialsSubscriptionToBeActive(ctx, subId, api)
+	err = waitForEssentialsSubscriptionToBeActive(ctx, subId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -207,6 +207,7 @@ func resourceRedisCloudEssentialsSubscriptionUpdate(ctx context.Context, d *sche
 func resourceRedisCloudEssentialsSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutDelete)
 
 	subId, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -217,7 +218,7 @@ func resourceRedisCloudEssentialsSubscriptionDelete(ctx context.Context, d *sche
 	defer utils.SubscriptionMutex.Unlock(subId)
 
 	// Wait for the subscription to be active before deleting it.
-	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := waitForEssentialsSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -229,7 +230,7 @@ func resourceRedisCloudEssentialsSubscriptionDelete(ctx context.Context, d *sche
 
 	d.SetId("")
 
-	err = waitForEssentialsSubscriptionToBeDeleted(ctx, subId, api)
+	err = waitForEssentialsSubscriptionToBeDeleted(ctx, subId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -237,12 +238,12 @@ func resourceRedisCloudEssentialsSubscriptionDelete(ctx context.Context, d *sche
 	return diags
 }
 
-func waitForEssentialsSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
+func waitForEssentialsSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:   10 * time.Second,
 		Pending: []string{subscriptions.SubscriptionStatusPending},
 		Target:  []string{subscriptions.SubscriptionStatusActive},
-		Timeout: utils.SafetyTimeout,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for fixed subscription %d to be active", id)
@@ -262,12 +263,12 @@ func waitForEssentialsSubscriptionToBeActive(ctx context.Context, id int, api *c
 	return nil
 }
 
-func waitForEssentialsSubscriptionToBeDeleted(ctx context.Context, id int, api *client.ApiClient) error {
+func waitForEssentialsSubscriptionToBeDeleted(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay:   10 * time.Second,
 		Pending: []string{subscriptions.SubscriptionStatusDeleting},
 		Target:  []string{"deleted"},
-		Timeout: utils.SafetyTimeout,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for fixed subscription %d to be deleted", id)

--- a/provider/resource_rediscloud_private_service_connect.go
+++ b/provider/resource_rediscloud_private_service_connect.go
@@ -71,7 +71,7 @@ func resourceRedisCloudPrivateServiceConnectCreate(ctx context.Context, d *schem
 
 	err = waitForPrivateServiceConnectServiceToBeActive(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceStatus(ctx, subscriptionId, api)
-	})
+	}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -191,14 +191,14 @@ func refreshPrivateServiceConnectServiceStatus(ctx context.Context, subscription
 	return redis.StringValue(pscService.Status), redis.StringValue(pscService.Status), nil
 }
 
-func waitForPrivateServiceConnectServiceToBeActive(ctx context.Context, refreshFunc func() (result interface{}, state string, err error)) error {
+func waitForPrivateServiceConnectServiceToBeActive(ctx context.Context, refreshFunc func() (result interface{}, state string, err error), timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending: []string{
 			psc.ServiceStatusCreateQueued,
 			psc.ServiceStatusInitialized,
 			psc.ServiceStatusCreatePending},
 		Target:       []string{psc.ServiceStatusActive},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/resource_rediscloud_private_service_connect.go
+++ b/provider/resource_rediscloud_private_service_connect.go
@@ -76,7 +76,7 @@ func resourceRedisCloudPrivateServiceConnectCreate(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -141,7 +141,7 @@ func resourceRedisCloudPrivateServiceConnectDelete(ctx context.Context, d *schem
 
 	d.SetId("")
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_private_service_connect.go
+++ b/provider/resource_rediscloud_private_service_connect.go
@@ -54,6 +54,7 @@ func resourceRedisCloudPrivateServiceConnect() *schema.Resource {
 
 func resourceRedisCloudPrivateServiceConnectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -71,12 +72,12 @@ func resourceRedisCloudPrivateServiceConnectCreate(ctx context.Context, d *schem
 
 	err = waitForPrivateServiceConnectServiceToBeActive(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceStatus(ctx, subscriptionId, api)
-	}, d.Timeout(schema.TimeoutCreate))
+	}, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_private_service_connect_endpoint.go
+++ b/provider/resource_rediscloud_private_service_connect_endpoint.go
@@ -274,7 +274,7 @@ func resourceRedisCloudPrivateServiceConnectEndpointDelete(ctx context.Context, 
 	// to happen, but we can't check the GCP resources from this provider
 	err = waitForPrivateServiceConnectServiceEndpointDisappear(ctx, func() (result interface{}, state string, err error) {
 		return refreshPrivateServiceConnectServiceEndpointDisappear(ctx, resId.subscriptionId, resId.pscServiceId, resId.endpointId, api)
-	})
+	}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -374,7 +374,7 @@ func flattenPrivateServiceConnectEndpointServiceAttachments(serviceAttachments [
 	return rl
 }
 
-func waitForPrivateServiceConnectServiceEndpointDisappear(ctx context.Context, refreshFunc func() (result interface{}, state string, err error)) error {
+func waitForPrivateServiceConnectServiceEndpointDisappear(ctx context.Context, refreshFunc func() (result interface{}, state string, err error), timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending: []string{
 			psc.EndpointStatusProcessing,
@@ -387,7 +387,7 @@ func waitForPrivateServiceConnectServiceEndpointDisappear(ctx context.Context, r
 			psc.EndpointStatusFailed,
 		},
 		Target:       []string{placeholderStatusDisappear},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/resource_rediscloud_private_service_connect_endpoint.go
+++ b/provider/resource_rediscloud_private_service_connect_endpoint.go
@@ -140,7 +140,7 @@ func resourceRedisCloudPrivateServiceConnectEndpointCreate(ctx context.Context, 
 
 	d.SetId(buildPrivateServiceConnectEndpointId(subscriptionId, pscServiceId, endpointId))
 
-	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+	err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_rediscloud_private_service_connect_endpoint_accepter.go
+++ b/provider/resource_rediscloud_private_service_connect_endpoint_accepter.go
@@ -65,6 +65,16 @@ func resourceRedisCloudPrivateServiceConnectEndpointAccepter() *schema.Resource 
 }
 
 func resourceRedisCloudPrivateServiceConnectEndpointAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutCreate)
+	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudPrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	var diags diag.Diagnostics
 	api := meta.(*client.ApiClient)
 
@@ -113,7 +123,7 @@ func resourceRedisCloudPrivateServiceConnectEndpointAccepterCreate(ctx context.C
 	}
 
 	if redis.StringValue(endpoint.Status) == psc.EndpointStatusInitialized || redis.StringValue(endpoint.Status) == psc.EndpointStatusProcessing {
-		err = waitForPrivateServiceConnectServiceEndpointToBePending(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBePending(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -129,12 +139,12 @@ func resourceRedisCloudPrivateServiceConnectEndpointAccepterCreate(ctx context.C
 	}
 
 	if action == psc.EndpointActionAccept {
-		err = waitForPrivateServiceConnectServiceEndpointToBeActive(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBeActive(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	} else {
-		err = waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx, refreshFunc)
+		err = waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx, refreshFunc, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -233,10 +243,6 @@ func ToPscEndpointAccepterId(id string) (*PrivateServiceConnectEndpointAccepterI
 	}, nil
 }
 
-func resourceRedisCloudPrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceRedisCloudPrivateServiceConnectEndpointAccepterCreate(ctx, d, meta)
-}
-
 func resourceRedisCloudPrivateServiceConnectEndpointAccepterDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	d.SetId("")
@@ -261,39 +267,39 @@ func refreshPrivateServiceConnectServiceEndpointStatus(ctx context.Context, subs
 	return redis.StringValue(endpoint.Status), redis.StringValue(endpoint.Status), nil
 }
 
-func waitForPrivateServiceConnectServiceEndpointToBePending(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error)) error {
+func waitForPrivateServiceConnectServiceEndpointToBePending(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error), timeout time.Duration) error {
 	targetStatus := psc.EndpointStatusPending
 	return waitForPrivateServiceConnectServiceEndpointToBeInStatus(ctx, func() (result interface{}, state string, err error) {
 		return refreshFunc(targetStatus)
 	}, targetStatus, []string{
 		psc.EndpointStatusInitialized,
-		psc.EndpointStatusProcessing})
+		psc.EndpointStatusProcessing}, timeout)
 }
 
-func waitForPrivateServiceConnectServiceEndpointToBeActive(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error)) error {
+func waitForPrivateServiceConnectServiceEndpointToBeActive(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error), timeout time.Duration) error {
 	targetStatus := psc.EndpointStatusActive
 	return waitForPrivateServiceConnectServiceEndpointToBeInStatus(ctx, func() (result interface{}, state string, err error) {
 		return refreshFunc(targetStatus)
 	}, targetStatus, []string{
 		psc.EndpointStatusPending,
-		psc.EndpointStatusAcceptPending})
+		psc.EndpointStatusAcceptPending}, timeout)
 }
 
-func waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error)) error {
+func waitForPrivateServiceConnectServiceEndpointToBeRejected(ctx context.Context, refreshFunc func(targetStatus string) (result interface{}, state string, err error), timeout time.Duration) error {
 	targetStatus := psc.EndpointStatusRejected
 	return waitForPrivateServiceConnectServiceEndpointToBeInStatus(ctx, func() (result interface{}, state string, err error) {
 		return refreshFunc(targetStatus)
 	}, targetStatus, []string{
 		psc.EndpointStatusPending,
-		psc.EndpointStatusRejectPending})
+		psc.EndpointStatusRejectPending}, timeout)
 }
 
 func waitForPrivateServiceConnectServiceEndpointToBeInStatus(ctx context.Context,
-	refreshFunc func() (result interface{}, state string, err error), status string, pendingStatus []string) error {
+	refreshFunc func() (result interface{}, state string, err error), status string, pendingStatus []string, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending:      pendingStatus,
 		Target:       []string{status},
-		Timeout:      utils.SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/resource_rediscloud_private_service_connect_endpoint_accepter.go
+++ b/provider/resource_rediscloud_private_service_connect_endpoint_accepter.go
@@ -65,13 +65,11 @@ func resourceRedisCloudPrivateServiceConnectEndpointAccepter() *schema.Resource 
 }
 
 func resourceRedisCloudPrivateServiceConnectEndpointAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutCreate)
-	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 }
 
 func resourceRedisCloudPrivateServiceConnectEndpointAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, timeout)
+	return resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 }
 
 func resourceRedisCloudPrivateServiceConnectEndpointAccepterApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {

--- a/provider/resource_rediscloud_subscription_peering.go
+++ b/provider/resource_rediscloud_subscription_peering.go
@@ -148,6 +148,7 @@ func resourceRedisCloudSubscriptionPeering() *schema.Resource {
 
 func resourceRedisCloudSubscriptionPeeringCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	if err != nil {
@@ -215,7 +216,7 @@ func resourceRedisCloudSubscriptionPeeringCreate(ctx context.Context, d *schema.
 
 	d.SetId(utils.BuildResourceId(subId, peering))
 
-	err = waitForPeeringToBeInitiated(ctx, subId, peering, api)
+	err = waitForPeeringToBeInitiated(ctx, subId, peering, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -382,7 +383,7 @@ func findVpcPeering(id int, peerings []*subscriptions.VPCPeering) *subscriptions
 	return nil
 }
 
-func waitForPeeringToBeInitiated(ctx context.Context, subId, id int, api *client.ApiClient) error {
+func waitForPeeringToBeInitiated(ctx context.Context, subId, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Delay: 10 * time.Second,
 		Pending: []string{
@@ -393,7 +394,7 @@ func waitForPeeringToBeInitiated(ctx context.Context, subId, id int, api *client
 			subscriptions.VPCPeeringStatusInactive,
 			subscriptions.VPCPeeringStatusPendingAcceptance,
 		},
-		Timeout: 10 * time.Minute,
+		Timeout: timeout,
 
 		Refresh: func() (result interface{}, state string, err error) {
 			log.Printf("[DEBUG] Waiting for vpc peering %d to be initiated", id)

--- a/provider/resource_rediscloud_transit_gateway_attachment.go
+++ b/provider/resource_rediscloud_transit_gateway_attachment.go
@@ -86,6 +86,7 @@ func resourceRedisCloudTransitGatewayAttachment() *schema.Resource {
 
 func resourceRedisCloudTransitGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
+	timeout := d.Timeout(schema.TimeoutCreate)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
 	tgwId := d.Get("tgw_id").(int)
@@ -105,7 +106,7 @@ func resourceRedisCloudTransitGatewayAttachmentCreate(ctx context.Context, d *sc
 	}
 
 	// Wait for attachment to become available
-	_, err = utils.WaitForTransitGatewayAttachmentToBeAvailable(ctx, subscriptionId, tgwId, api)
+	_, err = utils.WaitForTransitGatewayAttachmentToBeAvailable(ctx, subscriptionId, tgwId, api, timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/transitgateway/resource_rediscloud_active_active_transit_gateway_invitation_acceptor.go
+++ b/provider/transitgateway/resource_rediscloud_active_active_transit_gateway_invitation_acceptor.go
@@ -91,6 +91,17 @@ func ResourceRedisCloudActiveActiveTransitGatewayInvitationAcceptor() *schema.Re
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutCreate)
+	return resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorApply(ctx, d, meta, timeout)
+}
+
+// Update reapplies the configured action to correct drift.
+func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	return resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
@@ -135,7 +146,7 @@ func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorCreate(ctx co
 		}
 
 		// Wait for subscription to be active
-		err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+		err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -203,11 +214,6 @@ func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorRead(ctx cont
 	}
 
 	return diags
-}
-
-func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Update = re-apply the action (drift correction)
-	return resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorCreate(ctx, d, meta)
 }
 
 func resourceRedisCloudActiveActiveTransitGatewayInvitationAcceptorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/transitgateway/resource_rediscloud_transit_gateway_invitation_acceptor.go
+++ b/provider/transitgateway/resource_rediscloud_transit_gateway_invitation_acceptor.go
@@ -86,6 +86,17 @@ func ResourceRedisCloudTransitGatewayInvitationAcceptor() *schema.Resource {
 }
 
 func resourceRedisCloudTransitGatewayInvitationAcceptorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutCreate)
+	return resourceRedisCloudTransitGatewayInvitationAcceptorApply(ctx, d, meta, timeout)
+}
+
+// Update reapplies the configured action to correct drift.
+func resourceRedisCloudTransitGatewayInvitationAcceptorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	return resourceRedisCloudTransitGatewayInvitationAcceptorApply(ctx, d, meta, timeout)
+}
+
+func resourceRedisCloudTransitGatewayInvitationAcceptorApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) diag.Diagnostics {
 	api := meta.(*client.ApiClient)
 
 	subscriptionId, err := strconv.Atoi(d.Get("subscription_id").(string))
@@ -129,7 +140,7 @@ func resourceRedisCloudTransitGatewayInvitationAcceptorCreate(ctx context.Contex
 		}
 
 		// Wait for subscription to be active
-		err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api)
+		err = utils.WaitForSubscriptionToBeActive(ctx, subscriptionId, api, timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -194,11 +205,6 @@ func resourceRedisCloudTransitGatewayInvitationAcceptorRead(ctx context.Context,
 	}
 
 	return diags
-}
-
-func resourceRedisCloudTransitGatewayInvitationAcceptorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Update = re-apply the action (drift correction)
-	return resourceRedisCloudTransitGatewayInvitationAcceptorCreate(ctx, d, meta)
 }
 
 func resourceRedisCloudTransitGatewayInvitationAcceptorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/utils/cleanup.go
+++ b/provider/utils/cleanup.go
@@ -15,11 +15,11 @@ import (
 // least one database in the subscription creation plan, but Terraform manages databases as separate
 // resources. This function is called during Create and UpdateCmk to clean up those creation-plan
 // placeholder databases before Terraform creates user-configured ones.
-func DeleteSubscriptionDatabases(ctx context.Context, subId int, api *client.ApiClient) diag.Diagnostics {
+func DeleteSubscriptionDatabases(ctx context.Context, subId int, api *client.ApiClient, timeout time.Duration) diag.Diagnostics {
 	// There is a timing issue where the subscription is marked as active before the creation-plan
 	// databases are visible via the List API. This sleep works around it.
 	time.Sleep(30 * time.Second) //lintignore:R018
-	if err := WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -33,7 +33,7 @@ func DeleteSubscriptionDatabases(ctx context.Context, subId int, api *client.Api
 		dbId := *dbList.Value().ID
 
 		log.Printf("[DEBUG] Waiting for database %d in subscription %d to be active before deletion", dbId, subId)
-		if err := WaitForDatabaseToBeActive(ctx, subId, dbId, api); err != nil {
+		if err := WaitForDatabaseToBeActive(ctx, subId, dbId, api, timeout); err != nil {
 			return diag.FromErr(fmt.Errorf("failed waiting for database %d to be active: %w", dbId, err))
 		}
 
@@ -46,7 +46,7 @@ func DeleteSubscriptionDatabases(ctx context.Context, subId int, api *client.Api
 		return diag.FromErr(fmt.Errorf("failed to list databases in subscription %d: %w", subId, dbList.Err()))
 	}
 
-	if err := WaitForSubscriptionToBeActive(ctx, subId, api); err != nil {
+	if err := WaitForSubscriptionToBeActive(ctx, subId, api, timeout); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/provider/utils/get_set.go
+++ b/provider/utils/get_set.go
@@ -7,14 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// This timeout is an absolute maximum used in some of the waitForStatus operations concerning creation and updating
-// Subscriptions and Databases. Reads and Deletions have their own, stricter timeouts because they consistently behave
-// well. The Terraform operation-level timeout should kick in way before we hit this and kill the task.
-// Unfortunately there's no "time-remaining-before-timeout" utility, or we could use that in the wait blocks.
-const SafetyTimeout = 6 * time.Hour
-
-// TransitGatewayProvisioningTimeout is used when waiting for Transit Gateway resources to become available during
-// subscription provisioning. This is shorter than SafetyTimeout as tests typically complete within 45 minutes.
+// TransitGatewayProvisioningTimeout limits waits for Transit Gateway resources during subscription provisioning.
+// The limit keeps these waits within the 45-minute duration in which acceptance tests typically finish.
 const TransitGatewayProvisioningTimeout = 40 * time.Minute
 
 // GetString safely retrieves a string value from schema.ResourceData.

--- a/provider/utils/get_set.go
+++ b/provider/utils/get_set.go
@@ -1,15 +1,9 @@
 package utils
 
 import (
-	"time"
-
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// TransitGatewayProvisioningTimeout limits waits for Transit Gateway resources during subscription provisioning.
-// The limit keeps these waits within the 45-minute duration in which acceptance tests typically finish.
-const TransitGatewayProvisioningTimeout = 40 * time.Minute
 
 // GetString safely retrieves a string value from schema.ResourceData.
 func GetString(d *schema.ResourceData, key string) *string {

--- a/provider/utils/wait.go
+++ b/provider/utils/wait.go
@@ -304,11 +304,11 @@ func WaitForActiveActiveTransitGatewayAttachmentToBeAvailable(
 	return tgw, nil
 }
 
-func WaitForSubscriptionToBeEncryptionKeyPending(ctx context.Context, id int, api *client.ApiClient) error {
+func WaitForSubscriptionToBeEncryptionKeyPending(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending:      []string{subscriptions.SubscriptionStatusPending},
 		Target:       []string{subscriptions.SubscriptionStatusEncryptionKeyPending, subscriptions.SubscriptionStatusActive},
-		Timeout:      SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/utils/wait.go
+++ b/provider/utils/wait.go
@@ -16,11 +16,11 @@ import (
 	"github.com/RedisLabs/terraform-provider-rediscloud/provider/client"
 )
 
-func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiClient) error {
+func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending:      []string{subscriptions.SubscriptionStatusPending},
 		Target:       []string{subscriptions.SubscriptionStatusActive},
-		Timeout:      SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 
@@ -75,8 +75,7 @@ func WaitForSubscriptionPublicEndpointAccess(ctx context.Context, id int, api *c
 	return nil
 }
 
-// TODO: use configurable timeout, instead of SafetyTimeout
-func WaitForDatabaseToBeActive(ctx context.Context, subId, id int, api *client.ApiClient) error {
+func WaitForDatabaseToBeActive(ctx context.Context, subId, id int, api *client.ApiClient, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending: []string{
 			databases.StatusDraft,
@@ -94,7 +93,7 @@ func WaitForDatabaseToBeActive(ctx context.Context, subId, id int, api *client.A
 			// TODO replace with api model string in next release
 		},
 		Target:       []string{databases.StatusActive},
-		Timeout:      SafetyTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 

--- a/provider/utils/wait.go
+++ b/provider/utils/wait.go
@@ -44,11 +44,11 @@ func WaitForSubscriptionToBeActive(ctx context.Context, id int, api *client.ApiC
 
 // WaitForSubscriptionPublicEndpointAccess waits for the subscription's public_endpoint_access
 // property to match the expected value. This handles API eventual consistency after updates.
-func WaitForSubscriptionPublicEndpointAccess(ctx context.Context, id int, api *client.ApiClient, expected bool) error {
+func WaitForSubscriptionPublicEndpointAccess(ctx context.Context, id int, api *client.ApiClient, expected bool, timeout time.Duration) error {
 	wait := &retry.StateChangeConf{
 		Pending:      []string{"waiting"},
 		Target:       []string{"matched"},
-		Timeout:      30 * time.Second,
+		Timeout:      timeout,
 		Delay:        2 * time.Second,
 		PollInterval: 5 * time.Second,
 
@@ -117,11 +117,11 @@ func WaitForDatabaseToBeActive(ctx context.Context, subId, id int, api *client.A
 
 // WaitForActiveActiveTransitGatewayResourceToBeAvailable waits for Active-Active Transit Gateway API resources
 // to become available. This handles the case where Response.Resource is nil during initial subscription provisioning.
-func WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx context.Context, subId int, regionId int, api *client.ApiClient) (*attachments.GetAttachmentsTask, error) {
+func WaitForActiveActiveTransitGatewayResourceToBeAvailable(ctx context.Context, subId int, regionId int, api *client.ApiClient, timeout time.Duration) (*attachments.GetAttachmentsTask, error) {
 	wait := &retry.StateChangeConf{
 		Pending:      []string{"provisioning"},
 		Target:       []string{"available"},
-		Timeout:      TransitGatewayProvisioningTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 
@@ -187,11 +187,12 @@ func WaitForTransitGatewayAttachmentToBeAvailable(
 	subId int,
 	tgwId int,
 	api *client.ApiClient,
+	timeout time.Duration,
 ) (*attachments.TransitGatewayAttachment, error) {
 	wait := &retry.StateChangeConf{
 		Pending:      transitGatewayAttachmentPendingStates,
 		Target:       []string{TransitGatewayAttachmentStatusAvailable},
-		Timeout:      TransitGatewayProvisioningTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 
@@ -250,11 +251,12 @@ func WaitForActiveActiveTransitGatewayAttachmentToBeAvailable(
 	regionId int,
 	tgwId int,
 	api *client.ApiClient,
+	timeout time.Duration,
 ) (*attachments.TransitGatewayAttachment, error) {
 	wait := &retry.StateChangeConf{
 		Pending:      transitGatewayAttachmentPendingStates,
 		Target:       []string{TransitGatewayAttachmentStatusAvailable},
-		Timeout:      TransitGatewayProvisioningTimeout,
+		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 30 * time.Second,
 


### PR DESCRIPTION
The current change is functionally pointless, kind of, since the calling operation timeout will always fire first. I.e. The `Create` or `Update`'s `ctx, cancel := context.WithTimeout(ctx, createTimeout)`. The main goal is not to use the hardcoded SafetyTimeout, so at least that is achieved.